### PR TITLE
14 [Explore] Profile Training Performance Bottlenecks

### DIFF
--- a/configs/combined_mermaid_coralnet.yaml
+++ b/configs/combined_mermaid_coralnet.yaml
@@ -1,0 +1,26 @@
+run_name: "combined_base"
+
+logger:
+  uri: "segmentation"
+  experiment_name: "mermaid_combined"
+  log_epochs: 5
+
+data:
+  batch_size: 8
+  class_subset: [
+    "Turf algae",
+    "Sand",
+    "Crustose coralline algae",
+    "Macroalgae",
+    "Bare substrate",
+    "Acropora",
+    "Montipora",
+    "Pocillopora",
+    "Rubble",
+    "Soft coral",
+    "Porites",
+    "Hard coral",
+    "Millepora",
+  ]
+  padding: 7
+  concept_mapping_flag: False

--- a/mermaidseg/datasets/concepts.py
+++ b/mermaidseg/datasets/concepts.py
@@ -43,13 +43,15 @@ def initialize_benthic_hierarchy(
         attribute names (str) or None.
     """
 
-    response = requests.get(hierarchy_json_url)
+    response = requests.get(hierarchy_json_url, timeout=30)
+    response.raise_for_status()
     data = response.json()
     benthic_attributes = data["results"]
 
     # Keep fetching next pages while there is a 'next' URL
     while data["next"]:
-        response = requests.get(data["next"])
+        response = requests.get(data["next"], timeout=30)
+        response.raise_for_status()
         data = response.json()
         benthic_attributes.extend(data["results"])
 

--- a/mermaidseg/datasets/dataset.py
+++ b/mermaidseg/datasets/dataset.py
@@ -8,6 +8,7 @@ Classes:
     BaseCoralDataset - A base PyTorch Dataset for loading annotated coral reef images.
     MermaidDataset - A PyTorch Dataset for loading annotated coral reef images from MERMAID sources.
     CoralNetDataset - A PyTorch Dataset for loading annotated coral reef images from CoralNet sources.
+    CombinedCoralDataset - Combines multiple BaseCoralDataset instances with a shared label space.
 """
 
 import logging
@@ -27,7 +28,7 @@ from mermaidseg.datasets.concepts import (
     initialize_benthic_concepts,
     initialize_benthic_hierarchy,
 )
-from mermaidseg.datasets.utils import create_annotation_mask, get_image_s3
+from mermaidseg.datasets.utils import _joint_collate, create_annotation_mask, get_image_s3
 
 logger = logging.getLogger(__name__)
 
@@ -460,6 +461,52 @@ class CoralNetDataset(BaseCoralDataset):
             label["provider_id"]: label["benthic_attribute_name"] for label in labelset
         }
         return label_mapping
+
+
+class CombinedCoralDataset:
+    """
+    Wraps multiple BaseCoralDataset instances into a single dataset with a unified label space.
+
+    All constituent datasets must share an identical label2id mapping (i.e. constructed with the
+    same class_subset). Indexing and length are delegated to ConcatDataset. The _datasets
+    attribute is recognised by Logger.log_datasets for per-source MLflow logging.
+    """
+
+    def __init__(self, datasets: list):
+        if not datasets:
+            raise ValueError("datasets must be non-empty.")
+
+        def _root(ds):
+            """Unwrap Subset wrappers to reach the underlying BaseCoralDataset."""
+            while hasattr(ds, "dataset"):
+                ds = ds.dataset
+            return ds
+
+        roots = [_root(ds) for ds in datasets]
+        ref_label2id = roots[0].label2id
+        for root in roots[1:]:
+            if root.label2id != ref_label2id:
+                raise ValueError(
+                    f"All datasets must share the same label2id mapping. "
+                    f"Got {ref_label2id!r} vs {root.label2id!r}."
+                )
+
+        self._datasets = datasets
+        self._concat = torch.utils.data.ConcatDataset(datasets)
+
+        self.label2id = ref_label2id
+        self.id2label = {0: "background", **roots[0].id2label}
+        self.num_classes = roots[0].num_classes
+        self.class_subset = roots[0].class_subset
+
+    def __len__(self) -> int:
+        return len(self._concat)
+
+    def __getitem__(self, idx: int):
+        return self._concat[idx]
+
+    def collate_fn(self, batch):
+        return _joint_collate(batch)
 
 
 class CoralscapesDataset(Dataset[tuple[torch.Tensor | NDArray[Any], Any]]):

--- a/mermaidseg/datasets/dataset.py
+++ b/mermaidseg/datasets/dataset.py
@@ -10,6 +10,7 @@ Classes:
     CoralNetDataset - A PyTorch Dataset for loading annotated coral reef images from CoralNet sources.
 """
 
+import logging
 from typing import Any
 
 import albumentations as A
@@ -27,6 +28,20 @@ from mermaidseg.datasets.concepts import (
     initialize_benthic_hierarchy,
 )
 from mermaidseg.datasets.utils import create_annotation_mask, get_image_s3
+
+logger = logging.getLogger(__name__)
+
+
+def worker_init_fn(worker_id: int) -> None:
+    """Configure logging in DataLoader worker processes.
+
+    Pass this as ``worker_init_fn`` to DataLoader when ``num_workers > 0``
+    so that warnings emitted in worker subprocesses are visible.
+    """
+    logging.basicConfig(
+        level=logging.WARNING,
+        format=f"[worker-{worker_id}] %(levelname)s %(name)s: %(message)s",
+    )
 
 
 class BaseCoralDataset(Dataset[tuple[torch.Tensor | NDArray[Any], Any]]):
@@ -160,7 +175,15 @@ class BaseCoralDataset(Dataset[tuple[torch.Tensor | NDArray[Any], Any]]):
         row_kwargs = self.df_images.loc[idx].to_dict()
         try:
             image = self.read_image(**row_kwargs)
-        except Exception:
+        except Exception as e:
+            source_info = {k: v for k, v in row_kwargs.items() if k != "image_id"}
+            logger.warning(
+                "Skipping image_id=%s (source=%s): %s: %s",
+                image_id,
+                source_info,
+                type(e).__name__,
+                e,
+            )
             return None, None
         annotations = self.df_annotations.loc[
             self.df_annotations["image_id"] == image_id,
@@ -195,10 +218,22 @@ class BaseCoralDataset(Dataset[tuple[torch.Tensor | NDArray[Any], Any]]):
             masks: Tensor or ndarray batch of masks
         """
         # Filter out entries where image or mask is None
+        batch_size = len(batch)
         filtered = [(img, msk) for img, msk in batch if img is not None and msk is not None]
+        n_skipped = batch_size - len(filtered)
+        if n_skipped > 0:
+            logger.warning(
+                "collate_fn: skipped %d/%d items in batch due to load errors",
+                n_skipped,
+                batch_size,
+            )
 
         # Handle empty batch
         if len(filtered) == 0:
+            logger.warning(
+                "collate_fn: entire batch of %d items was empty, returning empty tensors",
+                batch_size,
+            )
             return torch.tensor([]), torch.tensor([])
 
         images, masks = zip(*filtered, strict=False)
@@ -411,12 +446,14 @@ class CoralNetDataset(BaseCoralDataset):
         """
         Initialize CoralNet to MERMAID label mapping from provider API.
         """
-        response = requests.get(mapping_endpoint)
+        response = requests.get(mapping_endpoint, timeout=30)
+        response.raise_for_status()
         data = response.json()
         labelset = data["results"]
 
         while data["next"]:
-            response = requests.get(data["next"])
+            response = requests.get(data["next"], timeout=30)
+            response.raise_for_status()
             data = response.json()
             labelset.extend(data["results"])
         label_mapping = {
@@ -603,13 +640,27 @@ class CoralscapesDataset(Dataset[tuple[torch.Tensor | NDArray[Any], Any]]):
         return len(self.dataset)
 
     def __getitem__(self, idx: int) -> tuple[torch.Tensor | NDArray[Any], Any]:
-        image, mask = np.array(self.dataset[idx]["image"]), self.dataset[idx]["label"]
-        mask = np.vectorize(self.labelmapping.get)(mask)
+        try:
+            image = np.array(self.dataset[idx]["image"])
+            mask = self.dataset[idx]["label"]
+            mask = np.vectorize(self.labelmapping.get)(mask)
+        except Exception as e:
+            logger.warning("CoralscapesDataset: skipping idx=%d: %s: %s", idx, type(e).__name__, e)
+            return None, None
 
         if self.transform:
-            transformed = self.transform(image=image, mask=mask)
-            image = transformed["image"].transpose(2, 0, 1)
-            mask = transformed["mask"]
+            try:
+                transformed = self.transform(image=image, mask=mask)
+                image = transformed["image"].transpose(2, 0, 1)
+                mask = transformed["mask"]
+            except Exception as e:
+                logger.warning(
+                    "CoralscapesDataset: transform failed for idx=%d: %s: %s",
+                    idx,
+                    type(e).__name__,
+                    e,
+                )
+                return None, None
 
         return image, mask
 
@@ -638,20 +689,31 @@ class CoralscapesDataset(Dataset[tuple[torch.Tensor | NDArray[Any], Any]]):
 
     def collate_fn(self, batch):
         """
-        Collate function for MermaidDataset and CoralNetDataset.
+        Collate function for CoralscapesDataset.
         Args:
-            batch: List of tuples (image, mask, annotations)
+            batch: List of tuples (image, mask)
         Returns:
             images: Tensor or ndarray batch of images
             masks: Tensor or ndarray batch of masks
-            annotations: List of annotation DataFrames
         """
+        batch_size = len(batch)
+        filtered = [(img, msk) for img, msk in batch if img is not None and msk is not None]
+        n_skipped = batch_size - len(filtered)
+        if n_skipped > 0:
+            logger.warning(
+                "CoralscapesDataset.collate_fn: skipped %d/%d items in batch due to load errors",
+                n_skipped,
+                batch_size,
+            )
 
-        images, masks = zip(*batch, strict=False)
+        if len(filtered) == 0:
+            logger.warning(
+                "CoralscapesDataset.collate_fn: entire batch of %d items was empty, returning empty tensors",
+                batch_size,
+            )
+            return torch.tensor([]), torch.tensor([])
 
-        # Handle empty batch
-        if len(images) == 0:
-            return torch.tensor([]), torch.tensor([]), []
+        images, masks = zip(*filtered, strict=False)
 
         # Convert to tensors if they aren't already
         if isinstance(images[0], torch.Tensor):

--- a/mermaidseg/datasets/utils.py
+++ b/mermaidseg/datasets/utils.py
@@ -11,14 +11,22 @@ Functions:
 """
 
 import io
+import logging
 
 import boto3
 import numpy as np
 import pandas as pd
 import torch
-from PIL import Image
+from botocore.exceptions import ClientError
+from PIL import Image, UnidentifiedImageError
 from torch.utils.data import Dataset, default_collate
 from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
+
+
+class DataLoadError(Exception):
+    """Raised when an image cannot be loaded from S3 or decoded."""
 
 
 def get_image_s3(
@@ -41,10 +49,22 @@ def get_image_s3(
     if thumbnail:
         key = key.replace(".png", "_thumbnail.png")
 
-    response = s3.get_object(Bucket=bucket, Key=key)
-    image_data = response["Body"].read()
+    try:
+        response = s3.get_object(Bucket=bucket, Key=key)
+        image_data = response["Body"].read()
+    except ClientError as e:
+        error_code = e.response["Error"]["Code"]
+        logger.warning(
+            "S3 error loading image (bucket=%s, key=%s): %s %s", bucket, key, error_code, e
+        )
+        raise DataLoadError(f"S3 ClientError for s3://{bucket}/{key}: {error_code}") from e
 
-    image = Image.open(io.BytesIO(image_data))
+    try:
+        image = Image.open(io.BytesIO(image_data))
+    except (UnidentifiedImageError, OSError) as e:
+        logger.warning("Corrupted image (bucket=%s, key=%s): %s", bucket, key, e)
+        raise DataLoadError(f"PIL cannot open image at s3://{bucket}/{key}") from e
+
     return image
 
 
@@ -64,18 +84,37 @@ def create_annotation_mask(
         np.ndarray: Annotation mask with integer class IDs.
     """
     ## TODO: Make Padding percentage based so that it is applicable to all class sizes
-    mask = np.zeros(shape[:2])
-    for _, annotation in annotations.iterrows():
-        if annotation["benthic_attribute_name"] is not None:
-            if padding is not None and padding > 0:
-                mask[
-                    annotation["row"] - padding : annotation["row"] + padding,
-                    annotation["col"] - padding : annotation["col"] + padding,
-                ] = label2id[annotation["benthic_attribute_name"]]
-            else:
-                mask[annotation["row"], annotation["col"]] = label2id[
-                    annotation["benthic_attribute_name"]
-                ]
+    mask = np.zeros(shape[:2], dtype=np.int64)
+
+    if annotations.empty:
+        return mask
+
+    valid = annotations[annotations["benthic_attribute_name"].notna()].copy()
+
+    unknown = set(valid["benthic_attribute_name"]) - set(label2id.keys())
+    if unknown:
+        logger.warning(
+            "create_annotation_mask: skipping %d unknown label(s): %s",
+            len(unknown),
+            sorted(unknown),
+        )
+        valid = valid[valid["benthic_attribute_name"].isin(label2id)]
+
+    if valid.empty:
+        return mask
+
+    rows = valid["row"].to_numpy(dtype=np.intp)
+    cols = valid["col"].to_numpy(dtype=np.intp)
+    label_ids = valid["benthic_attribute_name"].map(label2id).to_numpy(dtype=np.int64)
+
+    if padding is not None and padding > 0:
+        h, w = shape[:2]
+        for r, c, lid in zip(rows, cols, label_ids, strict=False):
+            r0, r1 = max(0, r - padding), min(h, r + padding)
+            c0, c1 = max(0, c - padding), min(w, c + padding)
+            mask[r0:r1, c0:c1] = lid
+    else:
+        mask[rows, cols] = label_ids
 
     return mask
 
@@ -140,35 +179,54 @@ def get_coralnet_sources():
         folder = "coralnet-public-images/"
         sub_response = s3.list_objects_v2(Bucket=bucket_name, Prefix=folder, Delimiter="/")
         if "CommonPrefixes" in sub_response:
-            print("Subfolders in coralnet-public-images/:")
+            logger.warning("Subfolders in coralnet-public-images/:")
             folders_new = [prefix["Prefix"] for prefix in sub_response["CommonPrefixes"]]
             folders_new = [folder.replace("coralnet-public-images/", "") for folder in folders_new]
         else:
-            print("No subfolders found in coralnet-public-images/")
+            logger.warning("No subfolders found in coralnet-public-images/")
     else:
-        print("No folders found in the bucket")
+        logger.warning("No folders found in the bucket")
 
     whitelist_sources = []
     for source in tqdm(folders_new):
         if not source.startswith("s"):
-            print(source)
+            logger.warning("Unexpected source folder name (no 's' prefix): %s", source)
 
         file_key = f"coralnet-public-images/{source}annotations.csv"
-
         try:
             s3.head_object(Bucket=bucket_name, Key=file_key)
-        except s3.exceptions.ClientError as e:
-            if e.response["Error"]["Code"] == "404":
-                print(f"File {file_key} not found in bucket")
-                continue
+        except ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            if error_code == "404":
+                logger.warning(
+                    "get_coralnet_sources: annotations.csv not found for source %s", source
+                )
+            else:
+                logger.warning(
+                    "get_coralnet_sources: unexpected S3 error for %s (code=%s): %s",
+                    file_key,
+                    error_code,
+                    e,
+                )
+            continue
 
         file_key = f"coralnet-public-images/{source}image_list.csv"
-
         try:
             s3.head_object(Bucket=bucket_name, Key=file_key)
-        except s3.exceptions.ClientError as e:
-            if e.response["Error"]["Code"] == "404":
-                print(f"File {file_key} not found in bucket")
-                continue
+        except ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            if error_code == "404":
+                logger.warning(
+                    "get_coralnet_sources: image_list.csv not found for source %s", source
+                )
+            else:
+                logger.warning(
+                    "get_coralnet_sources: unexpected S3 error for %s (code=%s): %s",
+                    file_key,
+                    error_code,
+                    e,
+                )
+            continue
+
         whitelist_sources.append(source)
     return whitelist_sources

--- a/mermaidseg/datasets/utils.py
+++ b/mermaidseg/datasets/utils.py
@@ -109,10 +109,15 @@ def create_annotation_mask(
 
     if padding is not None and padding > 0:
         h, w = shape[:2]
-        for r, c, lid in zip(rows, cols, label_ids, strict=False):
-            r0, r1 = max(0, r - padding), min(h, r + padding)
-            c0, c1 = max(0, c - padding), min(w, c + padding)
-            mask[r0:r1, c0:c1] = lid
+        # Vectorized bounds computation
+        r0 = np.maximum(0, rows - padding)
+        r1 = np.minimum(h, rows + padding)
+        c0 = np.maximum(0, cols - padding)
+        c1 = np.minimum(w, cols + padding)
+
+        # Apply padding regions (later annotations overwrite earlier ones)
+        for r0i, r1i, c0i, c1i, lid in zip(r0, r1, c0, c1, label_ids, strict=False):
+            mask[r0i:r1i, c0i:c1i] = lid
     else:
         mask[rows, cols] = label_ids
 

--- a/nbs/Base_Pipeline.ipynb
+++ b/nbs/Base_Pipeline.ipynb
@@ -1,381 +1,346 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "d37e781e",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Load the autoreload extension\n",
-        "%load_ext autoreload\n",
-        "\n",
-        "# Set autoreload mode\n",
-        "%autoreload 2"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "34bd5ec4",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import copy\n",
-        "\n",
-        "import albumentations as A\n",
-        "import mlflow\n",
-        "import torch\n",
-        "from torch.utils.data import DataLoader, random_split\n",
-        "\n",
-        "import mermaidseg.datasets.dataset\n",
-        "from mermaidseg.io import get_parser, setup_config, update_config_with_args\n",
-        "from mermaidseg.logger import Logger\n",
-        "from mermaidseg.model.eval import EvaluatorSemanticSegmentation\n",
-        "from mermaidseg.model.meta import MetaModel\n",
-        "from mermaidseg.model.train import train_model"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "f7eb62aa",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "os.environ[\"TF_ENABLE_ONEDNN_OPTS\"] = \"0\"\n",
-        "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"  # suppress TF warnings\n",
-        "os.environ[\"CUDA_LAUNCH_BLOCKING\"] = \"1\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "f4cfe179",
-      "metadata": {},
-      "source": [
-        "## Set MLFlow App \n",
-        "\n",
-        "* Set in notebook or as envrionment variable\n",
-        "* Verify URI after config setup (before training)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "04b544b3",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "if not os.getenv(\"MLFLOW_TRACKING_URI\"):\n",
-        "    # Replace with your actual SageMaker MLflow App ARN\n",
-        "    os.environ[\"MLFLOW_TRACKING_URI\"] = \"arn:aws:sagemaker:{region}:12345678:mlflow-app/app-ABCDEFG\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "3cb19575",
-      "metadata": {},
-      "source": [
-        "# 1. Setup"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "f4391353",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "device_count = torch.cuda.device_count()\n",
-        "for i in range(device_count):\n",
-        "    print(f\"CUDA Device {i}: {torch.cuda.get_device_name(i)}\")\n",
-        "\n",
-        "device = torch.device(\"cuda\") if torch.cuda.is_available() else torch.device(\"cpu\")\n",
-        "\n",
-        "seed = 42\n",
-        "torch.manual_seed(seed)\n",
-        "torch.cuda.manual_seed(seed)\n",
-        "# torch.backends.cudnn.deterministic = True\n",
-        "# torch.backends.cudnn.benchmark = True"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "43447f2d",
-      "metadata": {},
-      "source": [
-        "## Config"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "3f4e0786",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Start off with a configuration file\n",
-        "cfg = setup_config(\n",
-        "    config_path=\"../configs/linear-dinov3-base.yaml\",\n",
-        "    config_base_path=\"../configs/base_mermaid.yaml\",\n",
-        ")\n",
-        "\n",
-        "\n",
-        "# Update the initial configuration file with command line arguments\n",
-        "# (in the case of a notebook run these can be defined explicitly here)\n",
-        "args_input = \"--run-name=mermaid_base_run_dinov3 --log-epochs=1\"\n",
-        "args_input = args_input.split(\" \")\n",
-        "\n",
-        "parser = get_parser()\n",
-        "args = parser.parse_args(args_input)\n",
-        "\n",
-        "cfg = update_config_with_args(cfg, args)\n",
-        "cfg_logger = copy.deepcopy(cfg)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "b02e7d85",
-      "metadata": {},
-      "source": [
-        "# 2. Data"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "c4144675",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "transforms = {}\n",
-        "for split in cfg.augmentation:\n",
-        "    transforms[split] = A.Compose(\n",
-        "        [\n",
-        "            getattr(A, transform_name)(**transform_params)\n",
-        "            for transform_name, transform_params in cfg.augmentation[split].items()\n",
-        "        ]\n",
-        "    )"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "9c0dad66",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "dataset_name = cfg.data.pop(\"name\", None)\n",
-        "batch_size = cfg.data.pop(\"batch_size\", 8)\n",
-        "whitelist_sources = cfg.data.pop(\"whitelist_sources\", None)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "2a1ac8d9",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "dataset_dict = {}\n",
-        "dataset_dict[\"train\"] = getattr(mermaidseg.datasets.dataset, dataset_name)(\n",
-        "    transform=transforms[split], **cfg.data\n",
-        ")\n",
-        "print(len(dataset_dict[\"train\"]))\n",
-        "\n",
-        "total_size = len(dataset_dict[\"train\"])\n",
-        "train_size = int(0.7 * total_size)\n",
-        "val_size = int(0.15 * total_size)\n",
-        "test_size = total_size - train_size - val_size\n",
-        "train_size, val_size, test_size"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "e1a6aea2",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# total_size = len(dataset)\n",
-        "# train_size = int(0.7 * total_size)\n",
-        "# val_size = int(0.1 * total_size)\n",
-        "# test_size = total_size - train_size - val_size\n",
-        "\n",
-        "generator = torch.Generator().manual_seed(seed)\n",
-        "train_dataset, val_dataset, test_dataset = random_split(\n",
-        "    dataset_dict[\"train\"], [train_size, val_size, test_size], generator=generator\n",
-        ")\n",
-        "\n",
-        "train_loader = DataLoader(\n",
-        "    train_dataset,\n",
-        "    batch_size=batch_size,\n",
-        "    shuffle=True,\n",
-        "    num_workers=4,\n",
-        "    drop_last=True,\n",
-        "    collate_fn=dataset_dict[\"train\"].collate_fn,\n",
-        ")\n",
-        "val_loader = DataLoader(\n",
-        "    val_dataset,\n",
-        "    batch_size=batch_size,\n",
-        "    shuffle=False,\n",
-        "    num_workers=4,\n",
-        "    drop_last=True,\n",
-        "    collate_fn=dataset_dict[\"train\"].collate_fn,\n",
-        ")\n",
-        "test_loader = DataLoader(\n",
-        "    test_dataset,\n",
-        "    batch_size=batch_size,\n",
-        "    shuffle=False,\n",
-        "    num_workers=4,\n",
-        "    drop_last=True,\n",
-        "    collate_fn=dataset_dict[\"train\"].collate_fn,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "570a9668",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "print(f\"Number of training batches: {len(train_loader)}\")\n",
-        "print(f\"Number of validation batches: {len(val_loader)}\")\n",
-        "print(f\"Number of test batches: {len(test_loader)}\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "84882082",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "dataset_dict[\"train\"].num_classes, dataset_dict[\"train\"].num_concepts"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "92dab7e4",
-      "metadata": {},
-      "source": [
-        "# 3. Model"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "f8924b17",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "meta_model = MetaModel(\n",
-        "    run_name=cfg.run_name,\n",
-        "    num_classes=dataset_dict[\"train\"].num_classes,\n",
-        "    device=device,\n",
-        "    model_kwargs=cfg.model,\n",
-        "    training_kwargs=cfg.training,\n",
-        ")\n",
-        "\n",
-        "evaluator = EvaluatorSemanticSegmentation(\n",
-        "    num_classes=dataset_dict[\"train\"].num_classes,\n",
-        "    device=device,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6d4a96de",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "cfg.logger.experiment_name = \"mermaid\"\n",
-        "cfg_logger.logger.experiment_name = \"mermaid\""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "71ebe7bc",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "logger = Logger(\n",
-        "    config=cfg_logger,\n",
-        "    meta_model=meta_model,\n",
-        "    log_epochs=cfg.logger.log_epochs,\n",
-        "    log_checkpoint=2,  # cfg.logger.log_checkpoint\n",
-        "    checkpoint_dir=\".\",\n",
-        "    enable_mlflow=False,\n",
-        "    enable_wandb=True,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "d8b3630c",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "tracking_uri = mlflow.get_tracking_uri()\n",
-        "print(f\"Tracking URI: {tracking_uri}\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "572f0044",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "logger.log_dataset(dataset_dict[\"train\"], context=\"training\")\n",
-        "\n",
-        "if mlflow.active_run():\n",
-        "    mlflow.log_params({\n",
-        "        \"data/total_size\": total_size,\n",
-        "        \"data/train_size\": train_size,\n",
-        "        \"data/val_size\": val_size,\n",
-        "        \"data/test_size\": test_size,\n",
-        "        \"data/seed\": seed,\n",
-        "        \"data/dataset_name\": dataset_name,\n",
-        "    })"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "d2635c29",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "train_model(meta_model, evaluator, train_loader, val_loader, logger=logger)"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": ".venv",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.12"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d37e781e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the autoreload extension\n",
+    "%load_ext autoreload\n",
+    "\n",
+    "# Set autoreload mode\n",
+    "%autoreload 2"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34bd5ec4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import copy\n",
+    "\n",
+    "import albumentations as A\n",
+    "import mlflow\n",
+    "import torch\n",
+    "from torch.utils.data import DataLoader, random_split\n",
+    "\n",
+    "import mermaidseg.datasets.dataset\n",
+    "from mermaidseg.io import get_parser, setup_config, update_config_with_args\n",
+    "from mermaidseg.logger import Logger\n",
+    "from mermaidseg.model.eval import EvaluatorSemanticSegmentation\n",
+    "from mermaidseg.model.meta import MetaModel\n",
+    "from mermaidseg.model.train import train_model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7eb62aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"TF_ENABLE_ONEDNN_OPTS\"] = \"0\"\n",
+    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"  # suppress TF warnings\n",
+    "os.environ[\"CUDA_LAUNCH_BLOCKING\"] = \"1\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4cfe179",
+   "metadata": {},
+   "source": [
+    "## Set MLFlow App \n",
+    "\n",
+    "* Set in notebook or as envrionment variable\n",
+    "* Verify URI after config setup (before training)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04b544b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not os.getenv(\"MLFLOW_TRACKING_URI\"):\n",
+    "    # Replace with your actual SageMaker MLflow App ARN\n",
+    "    os.environ[\"MLFLOW_TRACKING_URI\"] = \"arn:aws:sagemaker:{region}:12345678:mlflow-app/app-ABCDEFG\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3cb19575",
+   "metadata": {},
+   "source": [
+    "# 1. Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4391353",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device_count = torch.cuda.device_count()\n",
+    "for i in range(device_count):\n",
+    "    print(f\"CUDA Device {i}: {torch.cuda.get_device_name(i)}\")\n",
+    "\n",
+    "device = torch.device(\"cuda\") if torch.cuda.is_available() else torch.device(\"cpu\")\n",
+    "\n",
+    "seed = 42\n",
+    "torch.manual_seed(seed)\n",
+    "torch.cuda.manual_seed(seed)\n",
+    "# torch.backends.cudnn.deterministic = True\n",
+    "# torch.backends.cudnn.benchmark = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43447f2d",
+   "metadata": {},
+   "source": [
+    "## Config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f4e0786",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Start off with a configuration file\n",
+    "cfg = setup_config(\n",
+    "    config_path=\"../configs/linear-dinov3-base.yaml\",\n",
+    "    config_base_path=\"../configs/base_mermaid.yaml\",\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# Update the initial configuration file with command line arguments\n",
+    "# (in the case of a notebook run these can be defined explicitly here)\n",
+    "args_input = \"--run-name=mermaid_base_run_dinov3 --log-epochs=1\"\n",
+    "args_input = args_input.split(\" \")\n",
+    "\n",
+    "parser = get_parser()\n",
+    "args = parser.parse_args(args_input)\n",
+    "\n",
+    "cfg = update_config_with_args(cfg, args)\n",
+    "cfg_logger = copy.deepcopy(cfg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b02e7d85",
+   "metadata": {},
+   "source": [
+    "# 2. Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4144675",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transforms = {}\n",
+    "for split in cfg.augmentation:\n",
+    "    transforms[split] = A.Compose(\n",
+    "        [\n",
+    "            getattr(A, transform_name)(**transform_params)\n",
+    "            for transform_name, transform_params in cfg.augmentation[split].items()\n",
+    "        ]\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c0dad66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_name = cfg.data.pop(\"name\", None)\n",
+    "batch_size = cfg.data.pop(\"batch_size\", 8)\n",
+    "whitelist_sources = cfg.data.pop(\"whitelist_sources\", None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a1ac8d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_dict = {}\n",
+    "dataset_dict[\"train\"] = getattr(mermaidseg.datasets.dataset, dataset_name)(\n",
+    "    transform=transforms[split], **cfg.data\n",
+    ")\n",
+    "print(len(dataset_dict[\"train\"]))\n",
+    "\n",
+    "total_size = len(dataset_dict[\"train\"])\n",
+    "train_size = int(0.7 * total_size)\n",
+    "val_size = int(0.15 * total_size)\n",
+    "test_size = total_size - train_size - val_size\n",
+    "train_size, val_size, test_size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1a6aea2",
+   "metadata": {},
+   "outputs": [],
+   "source": "# total_size = len(dataset)\n# train_size = int(0.7 * total_size)\n# val_size = int(0.1 * total_size)\n# test_size = total_size - train_size - val_size\n\ngenerator = torch.Generator().manual_seed(seed)\ntrain_dataset, val_dataset, test_dataset = random_split(\n    dataset_dict[\"train\"], [train_size, val_size, test_size], generator=generator\n)\n\ntrain_loader = DataLoader(\n    train_dataset,\n    batch_size=batch_size,\n    shuffle=True,\n    num_workers=4,\n    pin_memory=True,\n    persistent_workers=True,\n    drop_last=True,\n    collate_fn=dataset_dict[\"train\"].collate_fn,\n    worker_init_fn=mermaidseg.datasets.dataset.worker_init_fn,\n)\nval_loader = DataLoader(\n    val_dataset,\n    batch_size=batch_size,\n    shuffle=False,\n    num_workers=4,\n    pin_memory=True,\n    persistent_workers=True,\n    drop_last=True,\n    collate_fn=dataset_dict[\"train\"].collate_fn,\n    worker_init_fn=mermaidseg.datasets.dataset.worker_init_fn,\n)\ntest_loader = DataLoader(\n    test_dataset,\n    batch_size=batch_size,\n    shuffle=False,\n    num_workers=4,\n    pin_memory=True,\n    persistent_workers=True,\n    drop_last=True,\n    collate_fn=dataset_dict[\"train\"].collate_fn,\n    worker_init_fn=mermaidseg.datasets.dataset.worker_init_fn,\n)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "570a9668",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Number of training batches: {len(train_loader)}\")\n",
+    "print(f\"Number of validation batches: {len(val_loader)}\")\n",
+    "print(f\"Number of test batches: {len(test_loader)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84882082",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_dict[\"train\"].num_classes, dataset_dict[\"train\"].num_concepts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92dab7e4",
+   "metadata": {},
+   "source": [
+    "# 3. Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8924b17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta_model = MetaModel(\n",
+    "    run_name=cfg.run_name,\n",
+    "    num_classes=dataset_dict[\"train\"].num_classes,\n",
+    "    device=device,\n",
+    "    model_kwargs=cfg.model,\n",
+    "    training_kwargs=cfg.training,\n",
+    ")\n",
+    "\n",
+    "evaluator = EvaluatorSemanticSegmentation(\n",
+    "    num_classes=dataset_dict[\"train\"].num_classes,\n",
+    "    device=device,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d4a96de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cfg.logger.experiment_name = \"mermaid\"\n",
+    "cfg_logger.logger.experiment_name = \"mermaid\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71ebe7bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logger = Logger(\n",
+    "    config=cfg_logger,\n",
+    "    meta_model=meta_model,\n",
+    "    log_epochs=cfg.logger.log_epochs,\n",
+    "    log_checkpoint=2,  # cfg.logger.log_checkpoint\n",
+    "    checkpoint_dir=\".\",\n",
+    "    enable_mlflow=False,\n",
+    "    enable_wandb=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8b3630c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tracking_uri = mlflow.get_tracking_uri()\n",
+    "print(f\"Tracking URI: {tracking_uri}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "572f0044",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logger.log_dataset(dataset_dict[\"train\"], context=\"training\")\n",
+    "\n",
+    "if mlflow.active_run():\n",
+    "    mlflow.log_params({\n",
+    "        \"data/total_size\": total_size,\n",
+    "        \"data/train_size\": train_size,\n",
+    "        \"data/val_size\": val_size,\n",
+    "        \"data/test_size\": test_size,\n",
+    "        \"data/seed\": seed,\n",
+    "        \"data/dataset_name\": dataset_name,\n",
+    "    })"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2635c29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_model(meta_model, evaluator, train_loader, val_loader, logger=logger)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/nbs/Combined_Pipeline.ipynb
+++ b/nbs/Combined_Pipeline.ipynb
@@ -1,0 +1,466 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "b605200b",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%load_ext autoreload\n",
+        "%autoreload 2"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "bb8cc2a1",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import copy\n",
+        "\n",
+        "import albumentations as A\n",
+        "import mlflow\n",
+        "import pandas as pd\n",
+        "import torch\n",
+        "from torch.utils.data import DataLoader, random_split\n",
+        "\n",
+        "from mermaidseg.datasets.dataset import CoralNetDataset, CombinedCoralDataset, MermaidDataset\n",
+        "from mermaidseg.io import get_parser, setup_config, update_config_with_args\n",
+        "from mermaidseg.logger import Logger\n",
+        "from mermaidseg.model.eval import EvaluatorSemanticSegmentation\n",
+        "from mermaidseg.model.meta import MetaModel\n",
+        "from mermaidseg.model.train import train_model"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "d6715943",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "\n",
+        "os.environ[\"TF_ENABLE_ONEDNN_OPTS\"] = \"0\"\n",
+        "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"\n",
+        "os.environ[\"CUDA_LAUNCH_BLOCKING\"] = \"1\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "bb781660",
+      "metadata": {},
+      "source": [
+        "## Set MLFlow App\n",
+        "\n",
+        "* Set in notebook or as environment variable\n",
+        "* Verify URI after config setup (before training)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "76da5ad0",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "if not os.getenv(\"MLFLOW_TRACKING_URI\"):\n",
+        "    os.environ[\"MLFLOW_TRACKING_URI\"] = \"arn:aws:sagemaker:{region}:12345678:mlflow-app/app-ABCDEFG\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "dfb42178",
+      "metadata": {},
+      "source": [
+        "# 1. Setup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "6636b425",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "device_count = torch.cuda.device_count()\n",
+        "for i in range(device_count):\n",
+        "    print(f\"CUDA Device {i}: {torch.cuda.get_device_name(i)}\")\n",
+        "\n",
+        "device = torch.device(\"cuda\") if torch.cuda.is_available() else torch.device(\"cpu\")\n",
+        "\n",
+        "seed = 42\n",
+        "torch.manual_seed(seed)\n",
+        "torch.cuda.manual_seed(seed)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "30526672",
+      "metadata": {},
+      "source": [
+        "## Config"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "be08f53e",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "cfg = setup_config(\n",
+        "    config_path=\"../configs/linear-dinov3-base.yaml\",\n",
+        "    config_base_path=\"../configs/combined_mermaid_coralnet.yaml\",\n",
+        ")\n",
+        "\n",
+        "args_input = \"--run-name=combined_base_dinov3 --log-epochs=5\"\n",
+        "args_input = args_input.split(\" \")\n",
+        "\n",
+        "parser = get_parser()\n",
+        "args = parser.parse_args(args_input)\n",
+        "\n",
+        "cfg = update_config_with_args(cfg, args)\n",
+        "cfg_logger = copy.deepcopy(cfg)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "b2ba2a94",
+      "metadata": {},
+      "source": [
+        "# 2. Dataset"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ed956f5c",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "transforms = {}\n",
+        "for split in cfg.augmentation:\n",
+        "    transforms[split] = A.Compose(\n",
+        "        [\n",
+        "            getattr(A, transform_name)(**transform_params)\n",
+        "            for transform_name, transform_params in cfg.augmentation[split].items()\n",
+        "        ]\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "69a5f4c6",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "batch_size = cfg.data.pop(\"batch_size\", 8)\n",
+        "class_subset = cfg.data.class_subset\n",
+        "padding = cfg.data.padding"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ebe9563b",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "mermaid_full = MermaidDataset(\n",
+        "    transform=transforms[\"train\"],\n",
+        "    class_subset=class_subset,\n",
+        "    padding=padding,\n",
+        ")\n",
+        "\n",
+        "total_size = len(mermaid_full)\n",
+        "train_size = int(0.7 * total_size)\n",
+        "val_size = int(0.15 * total_size)\n",
+        "test_size = total_size - train_size - val_size\n",
+        "\n",
+        "generator = torch.Generator().manual_seed(seed)\n",
+        "mermaid_train, mermaid_val, mermaid_test = random_split(\n",
+        "    mermaid_full, [train_size, val_size, test_size], generator=generator\n",
+        ")\n",
+        "\n",
+        "print(f\"MERMAID splits: train={train_size}, val={val_size}, test={test_size}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "65c58cdc",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def _load_sources(path: str) -> list:\n",
+        "    return pd.read_csv(path, header=0).values.flatten().tolist()\n",
+        "\n",
+        "coralnet_train = CoralNetDataset(\n",
+        "    transform=transforms[\"train\"],\n",
+        "    class_subset=class_subset,\n",
+        "    padding=padding,\n",
+        "    whitelist_sources=_load_sources(\"../configs/run1_train_sources.csv\"),\n",
+        ")\n",
+        "coralnet_val = CoralNetDataset(\n",
+        "    transform=transforms[\"val\"],\n",
+        "    class_subset=class_subset,\n",
+        "    padding=padding,\n",
+        "    whitelist_sources=_load_sources(\"../configs/run1_val_sources.csv\"),\n",
+        ")\n",
+        "coralnet_test = CoralNetDataset(\n",
+        "    transform=transforms[\"test\"],\n",
+        "    class_subset=class_subset,\n",
+        "    padding=padding,\n",
+        "    whitelist_sources=_load_sources(\"../configs/run1_test_sources.csv\"),\n",
+        ")\n",
+        "\n",
+        "print(f\"CoralNet splits: train={len(coralnet_train)}, val={len(coralnet_val)}, test={len(coralnet_test)}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "aa7c078a",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "MERMAID_CAP = 8000\n",
+        "CORALNET_CAP = 8000\n",
+        "\n",
+        "def _subsample(dataset, cap, generator):\n",
+        "    if len(dataset) <= cap:\n",
+        "        return dataset\n",
+        "    return random_split(dataset, [cap, len(dataset) - cap], generator=generator)[0]\n",
+        "\n",
+        "sub_generator = torch.Generator().manual_seed(seed)\n",
+        "\n",
+        "# Subsample MERMAID splits proportionally (preserves ~70/15/15 ratio)\n",
+        "mermaid_cap_train = int(MERMAID_CAP * 0.70)\n",
+        "mermaid_cap_val   = int(MERMAID_CAP * 0.15)\n",
+        "mermaid_cap_test  = MERMAID_CAP - mermaid_cap_train - mermaid_cap_val\n",
+        "mermaid_train = _subsample(mermaid_train, mermaid_cap_train, sub_generator)\n",
+        "mermaid_val   = _subsample(mermaid_val,   mermaid_cap_val,   sub_generator)\n",
+        "mermaid_test  = _subsample(mermaid_test,  mermaid_cap_test,  sub_generator)\n",
+        "\n",
+        "# Subsample CoralNet within source-split datasets proportionally\n",
+        "coralnet_cap_train = int(CORALNET_CAP * 0.70)\n",
+        "coralnet_cap_val   = int(CORALNET_CAP * 0.15)\n",
+        "coralnet_cap_test  = CORALNET_CAP - coralnet_cap_train - coralnet_cap_val\n",
+        "coralnet_train = _subsample(coralnet_train, coralnet_cap_train, sub_generator)\n",
+        "coralnet_val   = _subsample(coralnet_val,   coralnet_cap_val,   sub_generator)\n",
+        "coralnet_test  = _subsample(coralnet_test,  coralnet_cap_test,  sub_generator)\n",
+        "\n",
+        "print(f\"MERMAID  (capped): train={len(mermaid_train)}, val={len(mermaid_val)}, test={len(mermaid_test)}\")\n",
+        "print(f\"CoralNet (capped): train={len(coralnet_train)}, val={len(coralnet_val)}, test={len(coralnet_test)}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "a1475e8d",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "combined_train = CombinedCoralDataset([mermaid_train, coralnet_train])\n",
+        "combined_val = CombinedCoralDataset([mermaid_val, coralnet_val])\n",
+        "combined_test = CombinedCoralDataset([mermaid_test, coralnet_test])\n",
+        "\n",
+        "print(f\"Combined splits: train={len(combined_train)}, val={len(combined_val)}, test={len(combined_test)}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e82af862",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "train_loader = DataLoader(\n",
+        "    combined_train,\n",
+        "    batch_size=batch_size,\n",
+        "    shuffle=True,\n",
+        "    num_workers=1,\n",
+        "    drop_last=True,\n",
+        "    collate_fn=combined_train.collate_fn,\n",
+        ")\n",
+        "val_loader = DataLoader(\n",
+        "    combined_val,\n",
+        "    batch_size=batch_size,\n",
+        "    shuffle=False,\n",
+        "    num_workers=1,\n",
+        "    drop_last=True,\n",
+        "    collate_fn=combined_val.collate_fn,\n",
+        ")\n",
+        "test_loader = DataLoader(\n",
+        "    combined_test,\n",
+        "    batch_size=batch_size,\n",
+        "    shuffle=False,\n",
+        "    num_workers=1,\n",
+        "    drop_last=True,\n",
+        "    collate_fn=combined_test.collate_fn,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "571e8e39",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "print(f\"Number of training batches: {len(train_loader)}\")\n",
+        "print(f\"Number of validation batches: {len(val_loader)}\")\n",
+        "print(f\"Number of test batches: {len(test_loader)}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e3ee3aec",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "combined_train.num_classes"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "c72830d7",
+      "metadata": {},
+      "source": [
+        "# 3. Model"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "d5dfec2e",
+      "metadata": {},
+      "outputs": [
+        {
+          "ename": "",
+          "evalue": "",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[1;31mThe Kernel crashed while executing code in the current cell or a previous cell. \n",
+            "\u001b[1;31mPlease review the code in the cell(s) to identify a possible cause of the failure. \n",
+            "\u001b[1;31mClick <a href='https://aka.ms/vscodeJupyterKernelCrash'>here</a> for more info. \n",
+            "\u001b[1;31mView Jupyter <a href='command:jupyter.viewOutput'>log</a> for further details."
+          ]
+        }
+      ],
+      "source": [
+        "meta_model = MetaModel(\n",
+        "    run_name=cfg.run_name,\n",
+        "    num_classes=combined_train.num_classes,\n",
+        "    device=device,\n",
+        "    model_kwargs=cfg.model,\n",
+        "    training_kwargs=cfg.training,\n",
+        ")\n",
+        "\n",
+        "evaluator = EvaluatorSemanticSegmentation(\n",
+        "    num_classes=combined_train.num_classes,\n",
+        "    device=device,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "472a8c25",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "cfg.logger.experiment_name = \"mermaid_combined\"\n",
+        "cfg_logger.logger.experiment_name = \"mermaid_combined\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "f7c27586",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "logger = Logger(\n",
+        "    config=cfg_logger,\n",
+        "    meta_model=meta_model,\n",
+        "    log_epochs=cfg.logger.log_epochs,\n",
+        "    log_checkpoint=2,\n",
+        "    checkpoint_dir=\".\",\n",
+        "    enable_mlflow=True,\n",
+        "    enable_wandb=False,\n",
+        "    id2label=combined_train.id2label,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "6c07331b",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "tracking_uri = mlflow.get_tracking_uri()\n",
+        "print(f\"Tracking URI: {tracking_uri}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "735948e0",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "logger.log_datasets(combined_train, context=\"training\")\n",
+        "\n",
+        "if mlflow.active_run():\n",
+        "    mlflow.log_params({\n",
+        "        \"data/mermaid_total_size\": total_size,\n",
+        "        \"data/mermaid_train_size\": train_size,\n",
+        "        \"data/mermaid_val_size\": val_size,\n",
+        "        \"data/mermaid_test_size\": test_size,\n",
+        "        \"data/combined_train_size\": len(combined_train),\n",
+        "        \"data/combined_val_size\": len(combined_val),\n",
+        "        \"data/combined_test_size\": len(combined_test),\n",
+        "        \"data/seed\": seed,\n",
+        "    })"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "0ba8e45a",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "train_model(meta_model, evaluator, train_loader, val_loader, logger=logger)"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/nbs/Concept_Bottleneck_Pipeline.ipynb
+++ b/nbs/Concept_Bottleneck_Pipeline.ipynb
@@ -251,32 +251,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "e1a6aea2",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "total_size = len(dataset_dict[\"train\"])\n",
-    "train_size = int(0.7 * total_size)\n",
-    "val_size = int(0.15 * total_size)\n",
-    "test_size = total_size - train_size - val_size\n",
-    "\n",
-    "generator = torch.Generator().manual_seed(42)\n",
-    "train_dataset, val_dataset, test_dataset = random_split(dataset_dict[\"train\"], [train_size, val_size, test_size], generator=generator)\n",
-    "train_dataset = torch.utils.data.Subset(train_dataset, range(5000))\n",
-    "val_dataset = torch.utils.data.Subset(val_dataset, range(1000))\n",
-    "test_dataset = torch.utils.data.Subset(test_dataset, range(1000))\n",
-    "# train_dataset = torch.utils.data.Subset(dataset_dict[\"train\"], range(3000))\n",
-    "# val_dataset = torch.utils.data.Subset(dataset_dict[\"val\"], range(500))\n",
-    "# test_dataset = torch.utils.data.Subset(dataset_dict[\"test\"], range(500))\n",
-    "\n",
-    "train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True, num_workers=2, drop_last=True, collate_fn = dataset_dict[\"train\"].collate_fn)\n",
-    "val_loader = DataLoader(val_dataset, batch_size=batch_size, shuffle=False, num_workers=2, drop_last=True, collate_fn = dataset_dict[\"train\"].collate_fn)\n",
-    "test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False, num_workers=2, drop_last=True, collate_fn = dataset_dict[\"train\"].collate_fn)\n",
-    "# train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True, num_workers=2, drop_last=True, collate_fn = dataset_dict[\"train\"].collate_fn)\n",
-    "# val_loader = DataLoader(val_dataset, batch_size=batch_size, shuffle=False, num_workers=2, drop_last=True, collate_fn = dataset_dict[\"val\"].collate_fn)\n",
-    "# test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False, num_workers=2, drop_last=True, collate_fn = dataset_dict[\"test\"].collate_fn)"
-   ]
+   "source": "total_size = len(dataset_dict[\"train\"])\ntrain_size = int(0.7 * total_size)\nval_size = int(0.15 * total_size)\ntest_size = total_size - train_size - val_size\n\ngenerator = torch.Generator().manual_seed(42)\ntrain_dataset, val_dataset, test_dataset = random_split(dataset_dict[\"train\"], [train_size, val_size, test_size], generator=generator)\ntrain_dataset = torch.utils.data.Subset(train_dataset, range(5000))\nval_dataset = torch.utils.data.Subset(val_dataset, range(1000))\ntest_dataset = torch.utils.data.Subset(test_dataset, range(1000))\n# train_dataset = torch.utils.data.Subset(dataset_dict[\"train\"], range(3000))\n# val_dataset = torch.utils.data.Subset(dataset_dict[\"val\"], range(500))\n# test_dataset = torch.utils.data.Subset(dataset_dict[\"test\"], range(500))\n\ntrain_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True, num_workers=2, pin_memory=True, persistent_workers=True, drop_last=True, collate_fn=dataset_dict[\"train\"].collate_fn, worker_init_fn=mermaidseg.datasets.dataset.worker_init_fn)\nval_loader = DataLoader(val_dataset, batch_size=batch_size, shuffle=False, num_workers=2, pin_memory=True, persistent_workers=True, drop_last=True, collate_fn=dataset_dict[\"train\"].collate_fn, worker_init_fn=mermaidseg.datasets.dataset.worker_init_fn)\ntest_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False, num_workers=2, pin_memory=True, persistent_workers=True, drop_last=True, collate_fn=dataset_dict[\"train\"].collate_fn, worker_init_fn=mermaidseg.datasets.dataset.worker_init_fn)\n# train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True, num_workers=2, drop_last=True, collate_fn = dataset_dict[\"train\"].collate_fn)\n# val_loader = DataLoader(val_dataset, batch_size=batch_size, shuffle=False, num_workers=2, drop_last=True, collate_fn = dataset_dict[\"val\"].collate_fn)\n# test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False, num_workers=2, drop_last=True, collate_fn = dataset_dict[\"test\"].collate_fn)"
   },
   {
    "cell_type": "code",

--- a/nbs/Concept_Bottleneck_Pipeline.ipynb
+++ b/nbs/Concept_Bottleneck_Pipeline.ipynb
@@ -1,601 +1,412 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "d37e781e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Load the autoreload extension\n",
-    "%load_ext autoreload\n",
-    "\n",
-    "# Set autoreload mode\n",
-    "%autoreload 2"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3cb19575",
-   "metadata": {},
-   "source": [
-    "# 1. Setup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "34bd5ec4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import albumentations as A\n",
-    "import mermaidseg.datasets.dataset\n",
-    "import numpy as np\n",
-    "from mermaidseg.io import setup_config, get_parser, update_config_with_args\n",
-    "import copy\n",
-    "import torch\n",
-    "from matplotlib import pyplot as plt"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "69d7931f",
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CUDA Device 0: Tesla T4\n"
-     ]
-    }
-   ],
-   "source": [
-    "device_count = torch.cuda.device_count()\n",
-    "for i in range(device_count):\n",
-    "    print(f\"CUDA Device {i}: {torch.cuda.get_device_name(i)}\")\n",
-    "    \n",
-    "device = torch.device(\"cuda\") if torch.cuda.is_available() else torch.device(\"cpu\")\n",
-    "device\n",
-    "\n",
-    "seed = 42\n",
-    "torch.manual_seed(seed)\n",
-    "torch.cuda.manual_seed(seed)\n",
-    "# torch.backends.cudnn.deterministic = True\n",
-    "# torch.backends.cudnn.benchmark = True"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "ea3f30c2",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-12-18 06:36:37.965271: I tensorflow/core/util/port.cc:153] oneDNN custom operations are on. You may see slightly different numerical results due to floating-point round-off errors from different computation orders. To turn them off, set the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.\n",
-      "2025-12-18 06:36:37.979140: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:477] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered\n",
-      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
-      "E0000 00:00:1766039797.997780  128293 cuda_dnn.cc:8310] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
-      "E0000 00:00:1766039798.003532  128293 cuda_blas.cc:1418] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
-      "2025-12-18 06:36:38.021516: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.\n",
-      "To enable the following instructions: SSE4.1 SSE4.2 AVX AVX2 AVX512F AVX512_VNNI FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
-     ]
-    }
-   ],
-   "source": [
-    "from torch.utils.data import DataLoader, random_split\n",
-    "from mermaidseg.model.meta import MetaModel\n",
-    "from mermaidseg.model.eval import EvaluatorSemanticSegmentation\n",
-    "from mermaidseg.logger import Logger\n",
-    "from mermaidseg.model.train import train_model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "43447f2d",
-   "metadata": {},
-   "source": [
-    "## Config"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "3f4e0786",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Start off with a configuration file\n",
-    "cfg = setup_config(config_path='../configs/linear-dinov3-concept-bottleneck.yaml', config_base_path='../configs/concept_mermaid.yaml')\n",
-    "\n",
-    "# Update the initial configuration file with command line arguments \n",
-    "# (in the case of a notebook run these can be defined explicitly here)\n",
-    "args_input = \"--run-name=dinov3-test-concept-bottleneck-run_2 --batch-size=4 --epochs=5 --log-epochs=1\"\n",
-    "args_input = args_input.split(\" \")\n",
-    "\n",
-    "parser = get_parser()\n",
-    "args = parser.parse_args(args_input)\n",
-    "\n",
-    "cfg = update_config_with_args(cfg, args)\n",
-    "cfg_logger = copy.deepcopy(cfg)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b02e7d85",
-   "metadata": {},
-   "source": [
-    "# 2. Data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "c4144675",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "transforms = {}\n",
-    "for split in cfg.augmentation:\n",
-    "    transforms[split] = A.Compose(\n",
-    "        [\n",
-    "            getattr(A, transform_name)(**transform_params) for transform_name, transform_params\n",
-    "                                                                 in cfg.augmentation[split].items()\n",
-    "        ]\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "9c0dad66",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dataset_name = cfg.data.pop(\"name\", None)\n",
-    "batch_size = cfg.data.pop(\"batch_size\", 4)\n",
-    "whitelist_sources = cfg.data.pop(\"whitelist_sources\", None)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "373143d8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dataset_dict = {}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "4ffe178d-b1a9-4b06-9ef7-318a1c3ac46c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dataset_dict[\"train\"] = getattr(mermaidseg.datasets.dataset, dataset_name)(transform = transforms[split], **cfg.data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "aa72c11c-87ed-4e3f-aa21-e4a472a883e1",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "8180"
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "d37e781e",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Load the autoreload extension\n",
+        "%load_ext autoreload\n",
+        "\n",
+        "# Set autoreload mode\n",
+        "%autoreload 2"
       ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
+    },
+    {
+      "cell_type": "markdown",
+      "id": "3cb19575",
+      "metadata": {},
+      "source": [
+        "# 1. Setup"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "34bd5ec4",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import albumentations as A\n",
+        "import mermaidseg.datasets.dataset\n",
+        "import numpy as np\n",
+        "from mermaidseg.io import setup_config, get_parser, update_config_with_args\n",
+        "import copy\n",
+        "import torch\n",
+        "from matplotlib import pyplot as plt"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "69d7931f",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "device_count = torch.cuda.device_count()\n",
+        "for i in range(device_count):\n",
+        "    print(f\"CUDA Device {i}: {torch.cuda.get_device_name(i)}\")\n",
+        "    \n",
+        "device = torch.device(\"cuda\") if torch.cuda.is_available() else torch.device(\"cpu\")\n",
+        "device\n",
+        "\n",
+        "seed = 42\n",
+        "torch.manual_seed(seed)\n",
+        "torch.cuda.manual_seed(seed)\n",
+        "# torch.backends.cudnn.deterministic = True\n",
+        "# torch.backends.cudnn.benchmark = True"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ea3f30c2",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from torch.utils.data import DataLoader, random_split\n",
+        "from mermaidseg.model.meta import MetaModel\n",
+        "from mermaidseg.model.eval import EvaluatorSemanticSegmentation\n",
+        "from mermaidseg.logger import Logger\n",
+        "from mermaidseg.model.train import train_model"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "43447f2d",
+      "metadata": {},
+      "source": [
+        "## Config"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "3f4e0786",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Start off with a configuration file\n",
+        "cfg = setup_config(config_path='../configs/linear-dinov3-concept-bottleneck.yaml', config_base_path='../configs/concept_mermaid.yaml')\n",
+        "\n",
+        "# Update the initial configuration file with command line arguments \n",
+        "# (in the case of a notebook run these can be defined explicitly here)\n",
+        "args_input = \"--run-name=dinov3-test-concept-bottleneck-run_2 --batch-size=4 --epochs=5 --log-epochs=1\"\n",
+        "args_input = args_input.split(\" \")\n",
+        "\n",
+        "parser = get_parser()\n",
+        "args = parser.parse_args(args_input)\n",
+        "\n",
+        "cfg = update_config_with_args(cfg, args)\n",
+        "cfg_logger = copy.deepcopy(cfg)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "b02e7d85",
+      "metadata": {},
+      "source": [
+        "# 2. Data"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c4144675",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "transforms = {}\n",
+        "for split in cfg.augmentation:\n",
+        "    transforms[split] = A.Compose(\n",
+        "        [\n",
+        "            getattr(A, transform_name)(**transform_params) for transform_name, transform_params\n",
+        "                                                                 in cfg.augmentation[split].items()\n",
+        "        ]\n",
+        "    )"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "9c0dad66",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "dataset_name = cfg.data.pop(\"name\", None)\n",
+        "batch_size = cfg.data.pop(\"batch_size\", 4)\n",
+        "whitelist_sources = cfg.data.pop(\"whitelist_sources\", None)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "373143d8",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "dataset_dict = {}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "4ffe178d-b1a9-4b06-9ef7-318a1c3ac46c",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "dataset_dict[\"train\"] = getattr(mermaidseg.datasets.dataset, dataset_name)(transform = transforms[split], **cfg.data)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "aa72c11c-87ed-4e3f-aa21-e4a472a883e1",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "len(dataset_dict[\"train\"])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "4ed349cf",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# for split in [\"train\", \"val\", \"test\"]:\n",
+        "#     dataset_dict[split] = getattr(mermaidseg.datasets.dataset, dataset_name)(transform = transforms[split], whitelist_sources=whitelist_sources[split], **cfg.data)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cd9cc3b4",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# for split in [\"train\", \"val\", \"test\"]:\n",
+        "#     if split in dataset_dict:\n",
+        "#         print(split, len(dataset_dict[split]), dataset_dict[split].num_classes)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "14508e6c",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# fig, ax = plt.subplots(figsize= (13,6), ncols = 2, nrows = 2)\n",
+        "\n",
+        "# image, mask, annotations = dataset[0]\n",
+        "# print(image.shape, mask.shape)\n",
+        "\n",
+        "# ax[0, 0].imshow(image.transpose(1,2,0))\n",
+        "# ax[0, 1].imshow(np.where(mask>0, mask, np.nan), cmap = \"tab10\", vmin=1, vmax=15)\n",
+        "\n",
+        "# image, mask, annotations = dataset[0]\n",
+        "\n",
+        "# ax[1, 0].imshow(image.transpose(1,2,0))\n",
+        "# ax[1, 1].imshow(np.where(mask>0, mask, np.nan), cmap = \"tab10\", vmin=1, vmax=15)\n",
+        "\n",
+        "# plt.show()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e1a6aea2",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "total_size = len(dataset_dict[\"train\"])\n",
+        "train_size = int(0.7 * total_size)\n",
+        "val_size = int(0.15 * total_size)\n",
+        "test_size = total_size - train_size - val_size\n",
+        "\n",
+        "generator = torch.Generator().manual_seed(42)\n",
+        "train_dataset, val_dataset, test_dataset = random_split(dataset_dict[\"train\"], [train_size, val_size, test_size], generator=generator)\n",
+        "train_dataset = torch.utils.data.Subset(train_dataset, range(5000))\n",
+        "val_dataset = torch.utils.data.Subset(val_dataset, range(1000))\n",
+        "test_dataset = torch.utils.data.Subset(test_dataset, range(1000))\n",
+        "# train_dataset = torch.utils.data.Subset(dataset_dict[\"train\"], range(3000))\n",
+        "# val_dataset = torch.utils.data.Subset(dataset_dict[\"val\"], range(500))\n",
+        "# test_dataset = torch.utils.data.Subset(dataset_dict[\"test\"], range(500))\n",
+        "\n",
+        "train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True, num_workers=2, drop_last=True, persistent_workers=True, pin_memory=True, collate_fn = dataset_dict[\"train\"].collate_fn)\n",
+        "val_loader = DataLoader(val_dataset, batch_size=batch_size, shuffle=False, num_workers=2, drop_last=True, persistent_workers=True, pin_memory=True, collate_fn = dataset_dict[\"train\"].collate_fn)\n",
+        "test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False, num_workers=2, drop_last=True, persistent_workers=True, pin_memory=True, collate_fn = dataset_dict[\"train\"].collate_fn)\n",
+        "# train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True, num_workers=2, drop_last=True, persistent_workers=True, pin_memory=True, collate_fn = dataset_dict[\"train\"].collate_fn)\n",
+        "# val_loader = DataLoader(val_dataset, batch_size=batch_size, shuffle=False, num_workers=2, drop_last=True, persistent_workers=True, pin_memory=True, collate_fn = dataset_dict[\"val\"].collate_fn)\n",
+        "# test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False, num_workers=2, drop_last=True, persistent_workers=True, pin_memory=True, collate_fn = dataset_dict[\"test\"].collate_fn)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "63fec21c",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "print(f\"Number of training batches: {len(train_loader)}\")\n",
+        "print(f\"Number of validation batches: {len(val_loader)}\")\n",
+        "print(f\"Number of test batches: {len(test_loader)}\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "382620c0",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "dataset_dict[\"train\"].num_classes, dataset_dict[\"train\"].num_concepts"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "f353f3a0",
+      "metadata": {},
+      "source": [
+        "# 3. Model"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "b61ff27c",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "meta_model = MetaModel(run_name = cfg.run_name, \n",
+        "                       num_classes = dataset_dict[\"train\"].num_classes,\n",
+        "                       num_concepts = dataset_dict[\"train\"].num_concepts,\n",
+        "                       device = device,\n",
+        "                       model_kwargs = cfg.model,\n",
+        "                       training_mode = cfg.training_mode,\n",
+        "                       training_kwargs = cfg.training,\n",
+        "                       concept_matrix = dataset_dict[\"train\"].benthic_concept_matrix,\n",
+        "                       conceptid2labelid = dataset_dict[\"train\"].conceptid2labelid,)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "0c689a4b",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "evaluator = EvaluatorSemanticSegmentation(num_classes=dataset_dict[\"train\"].num_classes,\n",
+        "                                            device=device,\n",
+        "                                            calculate_concept_metrics=True\n",
+        "                                            )\n",
+        "\n",
+        "# from torchmetrics.classification import F1Score, JaccardIndex\n",
+        "\n",
+        "# metric_dict = {\n",
+        "#             \"f1_class\": F1Score(task=\"multiclass\", average = \"none\", num_classes=3, ignore_index = 0).to(device),\n",
+        "#             \"mean_iou\": JaccardIndex(task=\"multiclass\", num_classes=3, ignore_index = 0).to(device),\n",
+        "#             \"iou\": JaccardIndex(task=\"multiclass\", num_classes=3, ignore_index = 0, average='none').to(device)\n",
+        "#             }\n",
+        "\n",
+        "# evaluator = EvaluatorSemanticSegmentation(num_classes=dataset.num_concepts,\n",
+        "#                                             device=device,\n",
+        "#                                             metric_dict = metric_dict\n",
+        "#                                             )"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "d82e24bf",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "id2label = {0: \"background\", **dataset_dict[\"train\"].id2label}\n",
+        "_id2concept = getattr(dataset_dict[\"train\"], \"id2concept\", None)\n",
+        "id2concept = _id2concept if _id2concept else None"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "dc742a03",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "cfg.logger.experiment_name = \"mermaid\"\n",
+        "cfg_logger.logger.experiment_name = \"mermaid\"\n",
+        "\n",
+        "from mermaidseg.logger import Logger\n",
+        "\n",
+        "logger = Logger(\n",
+        "    config=cfg_logger,\n",
+        "    meta_model=meta_model,\n",
+        "    log_epochs=cfg.logger.log_epochs,\n",
+        "    log_checkpoint=2,\n",
+        "    checkpoint_dir=\".\",\n",
+        "    enable_mlflow=True,\n",
+        "    enable_wandb=False,\n",
+        "    id2label=id2label,\n",
+        "    id2concept=id2concept,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "04c28309",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from mermaidseg.model.train import train_model\n",
+        "train_model(meta_model, evaluator, train_loader, val_loader, logger=logger)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "4b770607-3bbc-4aa2-82ce-6aa20a4f3618",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "final_val_results = evaluator.evaluate_model(dataloader = val_loader, meta_model=meta_model)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "22e56b86-f47c-4663-9879-f3d050cab782",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "final_val_results"
+      ]
     }
-   ],
-   "source": [
-    "len(dataset_dict[\"train\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "4ed349cf",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# for split in [\"train\", \"val\", \"test\"]:\n",
-    "#     dataset_dict[split] = getattr(mermaidseg.datasets.dataset, dataset_name)(transform = transforms[split], whitelist_sources=whitelist_sources[split], **cfg.data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "cd9cc3b4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# for split in [\"train\", \"val\", \"test\"]:\n",
-    "#     if split in dataset_dict:\n",
-    "#         print(split, len(dataset_dict[split]), dataset_dict[split].num_classes)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "14508e6c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# fig, ax = plt.subplots(figsize= (13,6), ncols = 2, nrows = 2)\n",
-    "\n",
-    "# image, mask, annotations = dataset[0]\n",
-    "# print(image.shape, mask.shape)\n",
-    "\n",
-    "# ax[0, 0].imshow(image.transpose(1,2,0))\n",
-    "# ax[0, 1].imshow(np.where(mask>0, mask, np.nan), cmap = \"tab10\", vmin=1, vmax=15)\n",
-    "\n",
-    "# image, mask, annotations = dataset[0]\n",
-    "\n",
-    "# ax[1, 0].imshow(image.transpose(1,2,0))\n",
-    "# ax[1, 1].imshow(np.where(mask>0, mask, np.nan), cmap = \"tab10\", vmin=1, vmax=15)\n",
-    "\n",
-    "# plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e1a6aea2",
-   "metadata": {},
-   "outputs": [],
-   "source": "total_size = len(dataset_dict[\"train\"])\ntrain_size = int(0.7 * total_size)\nval_size = int(0.15 * total_size)\ntest_size = total_size - train_size - val_size\n\ngenerator = torch.Generator().manual_seed(42)\ntrain_dataset, val_dataset, test_dataset = random_split(dataset_dict[\"train\"], [train_size, val_size, test_size], generator=generator)\ntrain_dataset = torch.utils.data.Subset(train_dataset, range(5000))\nval_dataset = torch.utils.data.Subset(val_dataset, range(1000))\ntest_dataset = torch.utils.data.Subset(test_dataset, range(1000))\n# train_dataset = torch.utils.data.Subset(dataset_dict[\"train\"], range(3000))\n# val_dataset = torch.utils.data.Subset(dataset_dict[\"val\"], range(500))\n# test_dataset = torch.utils.data.Subset(dataset_dict[\"test\"], range(500))\n\ntrain_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True, num_workers=2, pin_memory=True, persistent_workers=True, drop_last=True, collate_fn=dataset_dict[\"train\"].collate_fn, worker_init_fn=mermaidseg.datasets.dataset.worker_init_fn)\nval_loader = DataLoader(val_dataset, batch_size=batch_size, shuffle=False, num_workers=2, pin_memory=True, persistent_workers=True, drop_last=True, collate_fn=dataset_dict[\"train\"].collate_fn, worker_init_fn=mermaidseg.datasets.dataset.worker_init_fn)\ntest_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False, num_workers=2, pin_memory=True, persistent_workers=True, drop_last=True, collate_fn=dataset_dict[\"train\"].collate_fn, worker_init_fn=mermaidseg.datasets.dataset.worker_init_fn)\n# train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True, num_workers=2, drop_last=True, collate_fn = dataset_dict[\"train\"].collate_fn)\n# val_loader = DataLoader(val_dataset, batch_size=batch_size, shuffle=False, num_workers=2, drop_last=True, collate_fn = dataset_dict[\"val\"].collate_fn)\n# test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False, num_workers=2, drop_last=True, collate_fn = dataset_dict[\"test\"].collate_fn)"
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "63fec21c",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Number of training batches: 1250\n",
-      "Number of validation batches: 250\n",
-      "Number of test batches: 250\n"
-     ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.12"
     }
-   ],
-   "source": [
-    "print(f\"Number of training batches: {len(train_loader)}\")\n",
-    "print(f\"Number of validation batches: {len(val_loader)}\")\n",
-    "print(f\"Number of test batches: {len(test_loader)}\")"
-   ]
   },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "382620c0",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(16, 20)"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "dataset_dict[\"train\"].num_classes, dataset_dict[\"train\"].num_concepts"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f353f3a0",
-   "metadata": {},
-   "source": [
-    "# 3. Model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "b61ff27c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "meta_model = MetaModel(run_name = cfg.run_name, \n",
-    "                       num_classes = dataset_dict[\"train\"].num_classes,\n",
-    "                       num_concepts = dataset_dict[\"train\"].num_concepts,\n",
-    "                       device = device,\n",
-    "                       model_kwargs = cfg.model,\n",
-    "                       training_mode = cfg.training_mode,\n",
-    "                       training_kwargs = cfg.training,\n",
-    "                       concept_matrix = dataset_dict[\"train\"].benthic_concept_matrix,\n",
-    "                       conceptid2labelid = dataset_dict[\"train\"].conceptid2labelid,)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "0c689a4b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "evaluator = EvaluatorSemanticSegmentation(num_classes=dataset_dict[\"train\"].num_classes,\n",
-    "                                            device=device,\n",
-    "                                            calculate_concept_metrics=True\n",
-    "                                            )\n",
-    "\n",
-    "# from torchmetrics.classification import F1Score, JaccardIndex\n",
-    "\n",
-    "# metric_dict = {\n",
-    "#             \"f1_class\": F1Score(task=\"multiclass\", average = \"none\", num_classes=3, ignore_index = 0).to(device),\n",
-    "#             \"mean_iou\": JaccardIndex(task=\"multiclass\", num_classes=3, ignore_index = 0).to(device),\n",
-    "#             \"iou\": JaccardIndex(task=\"multiclass\", num_classes=3, ignore_index = 0, average='none').to(device)\n",
-    "#             }\n",
-    "\n",
-    "# evaluator = EvaluatorSemanticSegmentation(num_classes=dataset.num_concepts,\n",
-    "#                                             device=device,\n",
-    "#                                             metric_dict = metric_dict\n",
-    "#                                             )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "dc742a03",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[34m\u001b[1mwandb\u001b[0m: Currently logged in as: \u001b[33mviktor-domazetoski\u001b[0m to \u001b[32mhttps://api.wandb.ai\u001b[0m. Use \u001b[1m`wandb login --relogin`\u001b[0m to force relogin\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Tracking run with wandb version 0.23.1"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Run data is saved locally in <code>/home/sagemaker-user/mermaid-segmentation/nbs/wandb/run-20251218_063728-oe6a0nbl</code>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Syncing run <strong><a href='https://wandb.ai/viktor-domazetoski/mermaid/runs/oe6a0nbl' target=\"_blank\">dinov3-test-concept-bottleneck-run_2</a></strong> to <a href='https://wandb.ai/viktor-domazetoski/mermaid' target=\"_blank\">Weights & Biases</a> (<a href='https://wandb.me/developer-guide' target=\"_blank\">docs</a>)<br>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       " View project at <a href='https://wandb.ai/viktor-domazetoski/mermaid' target=\"_blank\">https://wandb.ai/viktor-domazetoski/mermaid</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       " View run at <a href='https://wandb.ai/viktor-domazetoski/mermaid/runs/oe6a0nbl' target=\"_blank\">https://wandb.ai/viktor-domazetoski/mermaid/runs/oe6a0nbl</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "cfg.logger.experiment_name = \"mermaid\"\n",
-    "cfg_logger.logger.experiment_name = \"mermaid\"\n",
-    "\n",
-    "from mermaidseg.logger import Logger\n",
-    "\n",
-    "logger = Logger(\n",
-    "    config = cfg_logger,\n",
-    "    meta_model = meta_model,\n",
-    "    log_epochs = cfg.logger.log_epochs,\n",
-    "    log_checkpoint = 2, #cfg.logger.log_checkpoint\n",
-    "    checkpoint_dir = \".\",\n",
-    "    enable_mlflow = False,\n",
-    "    enable_wandb = True\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "04c28309",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "EPOCH: 0\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 1250/1250 [20:18<00:00,  1.03it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "LOSS train 0.3576062069684267\n",
-      "TRAIN METRICS: {'accuracy': 0.9245154857635498, 'mean_iou': 0.7320473194122314, 'f1_concept': 0.8983958959579468}\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "  0%|          | 0/250 [00:00<?, ?it/s]\u001b[34m\u001b[1mwandb\u001b[0m: \u001b[33mWARNING\u001b[0m Tried to log to step 0 that is less than the current step 4. Steps must be monotonically increasing, so this data will be ignored. See https://wandb.me/define-metric to log data out of order.\n",
-      "100%|██████████| 250/250 [03:26<00:00,  1.21it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "LOSS valid 1.301874003648758\n",
-      "VALID METRICS: {'accuracy': 0.6980696320533752, 'mean_iou': 0.44179531931877136, 'f1_concept': 0.6968477368354797}\n",
-      "EPOCH: 1\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " 44%|████▍     | 547/1250 [08:54<11:27,  1.02it/s]\n"
-     ]
-    },
-    {
-     "ename": "KeyboardInterrupt",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[39], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mmermaidseg\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mmodel\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mtrain\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m train_model\n\u001b[0;32m----> 2\u001b[0m \u001b[43mtrain_model\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmeta_model\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mevaluator\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mtrain_loader\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mval_loader\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mlogger\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mlogger\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/mermaid-segmentation/mermaidseg/model/train.py:82\u001b[0m, in \u001b[0;36mtrain_model\u001b[0;34m(meta_model, evaluator, train_loader, val_loader, test_loader, logger, start_epoch, end_epoch, metric_of_interest)\u001b[0m\n\u001b[1;32m     79\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mEPOCH: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mepoch\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     81\u001b[0m meta_model\u001b[38;5;241m.\u001b[39mmodel\u001b[38;5;241m.\u001b[39mtrain(\u001b[38;5;28;01mTrue\u001b[39;00m)\n\u001b[0;32m---> 82\u001b[0m train_loss, train_metric_results \u001b[38;5;241m=\u001b[39m \u001b[43mmeta_model\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtrain_epoch\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m     83\u001b[0m \u001b[43m    \u001b[49m\u001b[43mtrain_loader\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mevaluator\u001b[49m\n\u001b[1;32m     84\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     85\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mLOSS train \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mtrain_loss\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     86\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mTRAIN METRICS: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mtrain_metric_results\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n",
-      "File \u001b[0;32m~/mermaid-segmentation/mermaidseg/model/meta.py:307\u001b[0m, in \u001b[0;36mMetaModel.train_epoch\u001b[0;34m(self, train_loader, evaluator)\u001b[0m\n\u001b[1;32m    305\u001b[0m _, labels \u001b[38;5;241m=\u001b[39m data\n\u001b[1;32m    306\u001b[0m labels \u001b[38;5;241m=\u001b[39m labels\u001b[38;5;241m.\u001b[39mlong()\u001b[38;5;241m.\u001b[39mto(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdevice)\n\u001b[0;32m--> 307\u001b[0m loss, outputs, concept_outputs \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbatch_predict_loss\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdata\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    309\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(loss, torch\u001b[38;5;241m.\u001b[39mTensor), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mLoss must be a torch.Tensor\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    310\u001b[0m loss\u001b[38;5;241m.\u001b[39mbackward()  \u001b[38;5;66;03m# Double check\u001b[39;00m\n",
-      "File \u001b[0;32m~/mermaid-segmentation/mermaidseg/model/meta.py:255\u001b[0m, in \u001b[0;36mMetaModel.batch_predict_loss\u001b[0;34m(self, batch, target_dim)\u001b[0m\n\u001b[1;32m    253\u001b[0m concept_outputs \u001b[38;5;241m=\u001b[39m segmentation_outputs\u001b[38;5;241m.\u001b[39mhidden_states\n\u001b[1;32m    254\u001b[0m outputs \u001b[38;5;241m=\u001b[39m segmentation_outputs\u001b[38;5;241m.\u001b[39mlogits\n\u001b[0;32m--> 255\u001b[0m concept_labels \u001b[38;5;241m=\u001b[39m \u001b[43mlabels_to_concepts\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlabels\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mconcept_matrix\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    256\u001b[0m loss \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mloss(outputs, labels, concept_outputs, concept_labels)\n\u001b[1;32m    257\u001b[0m concept_outputs \u001b[38;5;241m=\u001b[39m torch\u001b[38;5;241m.\u001b[39msigmoid(concept_outputs)\n",
-      "File \u001b[0;32m~/mermaid-segmentation/mermaidseg/datasets/concepts.py:241\u001b[0m, in \u001b[0;36mlabels_to_concepts\u001b[0;34m(labels, benthic_concept_matrix)\u001b[0m\n\u001b[1;32m    239\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(labels, torch\u001b[38;5;241m.\u001b[39mTensor):\n\u001b[1;32m    240\u001b[0m     device \u001b[38;5;241m=\u001b[39m labels\u001b[38;5;241m.\u001b[39mdevice\n\u001b[0;32m--> 241\u001b[0m     labels_np \u001b[38;5;241m=\u001b[39m \u001b[43mlabels\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdetach\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcpu\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241m.\u001b[39mnumpy()\u001b[38;5;241m.\u001b[39mastype(np\u001b[38;5;241m.\u001b[39mint64)\n\u001b[1;32m    242\u001b[0m     mapped \u001b[38;5;241m=\u001b[39m lookup[labels_np]  \u001b[38;5;66;03m# shape (B, H, W, C)\u001b[39;00m\n\u001b[1;32m    243\u001b[0m     mapped \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39mtranspose(mapped, (\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m3\u001b[39m, \u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m))  \u001b[38;5;66;03m# (B, C, H, W)\u001b[39;00m\n",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
-     ]
-    }
-   ],
-   "source": [
-    "from mermaidseg.model.train import train_model\n",
-    "train_model(meta_model, evaluator, train_loader, val_loader, logger=logger)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 75,
-   "id": "4b770607-3bbc-4aa2-82ce-6aa20a4f3618",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'accuracy': MulticlassAccuracy(), 'mean_iou': MulticlassJaccardIndex()}\n",
-      "{'f1_concept': MulticlassF1Score()}\n",
-      "concept-bottleneck\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 250/250 [03:21<00:00,  1.24it/s]\n"
-     ]
-    }
-   ],
-   "source": [
-    "final_val_results = evaluator.evaluate_model(dataloader = val_loader, meta_model=meta_model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 76,
-   "id": "22e56b86-f47c-4663-9879-f3d050cab782",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'accuracy': 0.700265645980835,\n",
-       " 'mean_iou': 0.4505966901779175,\n",
-       " 'f1_concept': array([0.       , 0.9828919, 0.6998219], dtype=float32)}"
-      ]
-     },
-     "execution_count": 76,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "final_val_results"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.9"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import io
 from typing import Any
-from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
@@ -12,140 +10,17 @@ import pytest
 import torch
 
 from mermaidseg.datasets.dataset import BaseCoralDataset
-from mermaidseg.datasets.utils import DataLoadError, create_annotation_mask, get_image_s3
+from mermaidseg.datasets.utils import create_annotation_mask
 
 
-def _make_annotations(rows, cols, labels):
+def _make_annotations(rows: list, cols: list, labels: list) -> pd.DataFrame:
     """Build a minimal annotations DataFrame."""
     return pd.DataFrame({"row": rows, "col": cols, "benthic_attribute_name": labels})
 
 
-def _valid_png_bytes():
-    """Return raw bytes for a tiny valid 2x2 RGB PNG."""
-    from PIL import Image
-
-    buf = io.BytesIO()
-    img = Image.new("RGB", (2, 2), color=(255, 0, 0))
-    img.save(buf, format="PNG")
-    return buf.getvalue()
-
-
-def _make_s3_response(data: bytes):
-    """Return a mock boto3 get_object response dict."""
-    body = MagicMock()
-    body.read.return_value = data
-    return {"Body": body}
-
-
-def test_create_annotation_mask_basic():
-    annotations = _make_annotations([10, 20, 30], [5, 15, 25], ["Coral", "Sand", "Rubble"])
-    label2id = {"Coral": 1, "Sand": 2, "Rubble": 3}
-    mask = create_annotation_mask(annotations, (50, 50), label2id)
-
-    assert mask[10, 5] == 1
-    assert mask[20, 15] == 2
-    assert mask[30, 25] == 3
-    # All other pixels should be background
-    assert mask[0, 0] == 0
-
-
-def test_create_annotation_mask_with_padding():
-    annotations = _make_annotations([10], [10], ["Coral"])
-    label2id = {"Coral": 1}
-    padding = 2
-    mask = create_annotation_mask(annotations, (50, 50), label2id, padding=padding)
-
-    # The padded region [8:12, 8:12] should all be 1
-    assert np.all(mask[8:12, 8:12] == 1)
-    # Outside padding should be 0
-    assert mask[7, 10] == 0
-    assert mask[12, 10] == 0
-
-
-def test_create_annotation_mask_padding_bounds_clamped():
-    """Annotation at top-left corner with large padding must not raise IndexError."""
-    annotations = _make_annotations([0], [0], ["Coral"])
-    label2id = {"Coral": 1}
-    # Should not raise even though padding extends outside image bounds
-    mask = create_annotation_mask(annotations, (20, 20), label2id, padding=5)
-    assert mask[0, 0] == 1
-
-
-def test_create_annotation_mask_unknown_label_skipped(caplog):
-    annotations = _make_annotations([5, 10], [5, 10], ["Coral", "UnknownLabel"])
-    label2id = {"Coral": 1}
-
-    with caplog.at_level("WARNING", logger="mermaidseg.datasets.utils"):
-        mask = create_annotation_mask(annotations, (20, 20), label2id)
-
-    # Known label is written
-    assert mask[5, 5] == 1
-    # Unknown label point stays 0
-    assert mask[10, 10] == 0
-    # A warning was emitted
-    assert "unknown label" in caplog.text.lower() or "UnknownLabel" in caplog.text
-
-
-def test_create_annotation_mask_empty():
-    annotations = _make_annotations([], [], [])
-    mask = create_annotation_mask(annotations, (10, 10), {"Coral": 1})
-    assert np.all(mask == 0)
-
-
-def test_create_annotation_mask_all_null_labels():
-    annotations = _make_annotations([5], [5], [None])
-    mask = create_annotation_mask(annotations, (10, 10), {"Coral": 1})
-    assert np.all(mask == 0)
-
-
-def test_get_image_s3_success():
-    s3 = MagicMock()
-    s3.get_object.return_value = _make_s3_response(_valid_png_bytes())
-
-    image = get_image_s3(s3, "my-bucket", "path/to/image.png")
-
-    assert image is not None
-    s3.get_object.assert_called_once_with(Bucket="my-bucket", Key="path/to/image.png")
-
-
-def test_get_image_s3_thumbnail_modifies_key():
-    s3 = MagicMock()
-    s3.get_object.return_value = _make_s3_response(_valid_png_bytes())
-
-    get_image_s3(s3, "my-bucket", "path/to/image.png", thumbnail=True)
-
-    s3.get_object.assert_called_once_with(Bucket="my-bucket", Key="path/to/image_thumbnail.png")
-
-
-def test_get_image_s3_client_error_raises_data_load_error(caplog):
-    from botocore.exceptions import ClientError
-
-    s3 = MagicMock()
-    s3.get_object.side_effect = ClientError(
-        {"Error": {"Code": "NoSuchKey", "Message": "The specified key does not exist."}},
-        "GetObject",
-    )
-
-    with caplog.at_level("WARNING", logger="mermaidseg.datasets.utils"):
-        with pytest.raises(DataLoadError):
-            get_image_s3(s3, "my-bucket", "missing/image.png")
-
-    assert "NoSuchKey" in caplog.text or "S3 error" in caplog.text
-
-
-def test_get_image_s3_corrupted_image_raises_data_load_error(caplog):
-    s3 = MagicMock()
-    s3.get_object.return_value = _make_s3_response(b"not-a-valid-image")
-
-    with caplog.at_level("WARNING", logger="mermaidseg.datasets.utils"):
-        with pytest.raises(DataLoadError):
-            get_image_s3(s3, "my-bucket", "corrupt/image.png")
-
-    assert "corrupt" in caplog.text.lower() or "PIL" in caplog.text
-
-
-def _make_minimal_dataset() -> BaseCoralDataset:
-    """Build the smallest valid BaseCoralDataset (no real images needed)."""
+@pytest.fixture
+def minimal_dataset() -> BaseCoralDataset:
+    """Smallest valid BaseCoralDataset — no real images needed."""
     df_annotations = pd.DataFrame(
         {
             "image_id": ["img1", "img2"],
@@ -161,57 +36,16 @@ def _make_minimal_dataset() -> BaseCoralDataset:
         .drop_duplicates()
         .reset_index(drop=True)
     )
-    class_subset = ["Coral", "Sand"]
-    ds = BaseCoralDataset.__new__(BaseCoralDataset)
-    # Bypass __init__ by setting attributes directly
-    ds.df_annotations = df_annotations
-    ds.df_images = df_images
-    ds.split = None
-    ds.transform = None
-    ds.padding = None
-    ds.class_subset = class_subset
-    ds.num_classes = len(class_subset) + 1
-    ds.id2label = {1: "Coral", 2: "Sand"}
-    ds.label2id = {"Coral": 1, "Sand": 2}
-    ds.concept_mapping_flag = False
-    return ds
+    return BaseCoralDataset(
+        df_annotations=df_annotations,
+        df_images=df_images,
+        class_subset=["Coral", "Sand"],
+    )
 
 
-def test_collate_fn_filters_none_items(caplog):
-    ds = _make_minimal_dataset()
-    h, w = 4, 4
-    img = torch.zeros(3, h, w)
-    msk = torch.zeros(h, w, dtype=torch.long)
-    batch = [(img, msk), (None, None), (img, msk), (None, None)]
-
-    with caplog.at_level("WARNING", logger="mermaidseg.datasets.dataset"):
-        images, masks = ds.collate_fn(batch)
-
-    assert images.shape[0] == 2
-    assert masks.shape[0] == 2
-    assert "skipped 2/4" in caplog.text
-
-
-def test_collate_fn_all_none_returns_empty_tensors(caplog):
-    ds = _make_minimal_dataset()
-    batch = [(None, None), (None, None)]
-
-    with caplog.at_level("WARNING", logger="mermaidseg.datasets.dataset"):
-        images, masks = ds.collate_fn(batch)
-
-    assert images.numel() == 0
-    assert masks.numel() == 0
-    assert "entire batch" in caplog.text
-
-
-class _AlwaysFailDataset(BaseCoralDataset):
-    """Minimal subclass whose read_image always raises."""
-
-    def read_image(self, **row_kwargs) -> Any:
-        raise RuntimeError("simulated read failure")
-
-
-def test_base_dataset_getitem_skips_and_logs_on_read_failure(caplog):
+@pytest.fixture
+def single_image_annotations() -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Single-image annotations and images DataFrames."""
     df_annotations = pd.DataFrame(
         {
             "image_id": ["img1"],
@@ -227,7 +61,103 @@ def test_base_dataset_getitem_skips_and_logs_on_read_failure(caplog):
         .drop_duplicates()
         .reset_index(drop=True)
     )
+    return df_annotations, df_images
 
+
+class _AlwaysFailDataset(BaseCoralDataset):
+    """Minimal subclass whose read_image always raises."""
+
+    def read_image(self, **row_kwargs) -> Any:
+        raise RuntimeError("simulated read failure")
+
+
+# --- create_annotation_mask ---
+
+
+def test_create_annotation_mask_basic():
+    annotations = _make_annotations([10, 20, 30], [5, 15, 25], ["Coral", "Sand", "Rubble"])
+    label2id = {"Coral": 1, "Sand": 2, "Rubble": 3}
+    mask = create_annotation_mask(annotations, (50, 50), label2id)
+
+    assert mask[10, 5] == 1
+    assert mask[20, 15] == 2
+    assert mask[30, 25] == 3
+    assert mask[0, 0] == 0
+
+
+def test_create_annotation_mask_with_padding():
+    annotations = _make_annotations([10], [10], ["Coral"])
+    mask = create_annotation_mask(annotations, (50, 50), {"Coral": 1}, padding=2)
+
+    assert np.all(mask[8:12, 8:12] == 1)
+    assert mask[7, 10] == 0
+    assert mask[12, 10] == 0
+
+
+def test_create_annotation_mask_padding_bounds_clamped():
+    """Large padding at image corners must clamp to bounds without raising IndexError."""
+    annotations = _make_annotations([0, 19], [0, 19], ["Coral", "Coral"])
+    mask = create_annotation_mask(annotations, (20, 20), {"Coral": 1}, padding=5)
+
+    assert np.all(mask[0:5, 0:5] == 1)
+    assert np.all(mask[14:20, 14:20] == 1)
+
+
+def test_create_annotation_mask_unknown_label_skipped(caplog):
+    annotations = _make_annotations([5, 10], [5, 10], ["Coral", "UnknownLabel"])
+
+    with caplog.at_level("WARNING", logger="mermaidseg.datasets.utils"):
+        mask = create_annotation_mask(annotations, (20, 20), {"Coral": 1})
+
+    assert mask[5, 5] == 1
+    assert mask[10, 10] == 0
+    assert "unknown label" in caplog.text.lower() or "UnknownLabel" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "rows,cols,labels",
+    [
+        ([], [], []),
+        ([5], [5], [None]),
+    ],
+    ids=["empty", "all_null_labels"],
+)
+def test_create_annotation_mask_produces_zero_mask(rows, cols, labels):
+    annotations = _make_annotations(rows, cols, labels)
+    mask = create_annotation_mask(annotations, (10, 10), {"Coral": 1})
+    assert np.all(mask == 0)
+
+
+# --- BaseCoralDataset.collate_fn ---
+
+
+def test_collate_fn_filters_none_items(minimal_dataset, caplog):
+    img = torch.zeros(3, 4, 4)
+    msk = torch.zeros(4, 4, dtype=torch.long)
+    batch = [(img, msk), (None, None), (img, msk), (None, None)]
+
+    with caplog.at_level("WARNING", logger="mermaidseg.datasets.dataset"):
+        images, masks = minimal_dataset.collate_fn(batch)
+
+    assert images.shape[0] == 2
+    assert masks.shape[0] == 2
+    assert "skipped 2/4" in caplog.text
+
+
+def test_collate_fn_all_none_returns_empty_tensors(minimal_dataset, caplog):
+    with caplog.at_level("WARNING", logger="mermaidseg.datasets.dataset"):
+        images, masks = minimal_dataset.collate_fn([(None, None), (None, None)])
+
+    assert images.numel() == 0
+    assert masks.numel() == 0
+    assert "entire batch" in caplog.text
+
+
+# --- BaseCoralDataset.__getitem__ ---
+
+
+def test_base_dataset_getitem_skips_and_logs_on_read_failure(single_image_annotations, caplog):
+    df_annotations, df_images = single_image_annotations
     ds = _AlwaysFailDataset(
         df_annotations=df_annotations,
         df_images=df_images,
@@ -240,9 +170,3 @@ def test_base_dataset_getitem_skips_and_logs_on_read_failure(caplog):
     assert result == (None, None)
     assert "img1" in caplog.text
     assert "RuntimeError" in caplog.text
-
-
-def test_data_load_error_importable():
-    from mermaidseg.datasets.utils import DataLoadError as DLE
-
-    assert issubclass(DLE, Exception)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,248 @@
+"""Unit tests for mermaidseg.datasets.utils and BaseCoralDataset error handling."""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from mermaidseg.datasets.dataset import BaseCoralDataset
+from mermaidseg.datasets.utils import DataLoadError, create_annotation_mask, get_image_s3
+
+
+def _make_annotations(rows, cols, labels):
+    """Build a minimal annotations DataFrame."""
+    return pd.DataFrame({"row": rows, "col": cols, "benthic_attribute_name": labels})
+
+
+def _valid_png_bytes():
+    """Return raw bytes for a tiny valid 2x2 RGB PNG."""
+    from PIL import Image
+
+    buf = io.BytesIO()
+    img = Image.new("RGB", (2, 2), color=(255, 0, 0))
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_s3_response(data: bytes):
+    """Return a mock boto3 get_object response dict."""
+    body = MagicMock()
+    body.read.return_value = data
+    return {"Body": body}
+
+
+def test_create_annotation_mask_basic():
+    annotations = _make_annotations([10, 20, 30], [5, 15, 25], ["Coral", "Sand", "Rubble"])
+    label2id = {"Coral": 1, "Sand": 2, "Rubble": 3}
+    mask = create_annotation_mask(annotations, (50, 50), label2id)
+
+    assert mask[10, 5] == 1
+    assert mask[20, 15] == 2
+    assert mask[30, 25] == 3
+    # All other pixels should be background
+    assert mask[0, 0] == 0
+
+
+def test_create_annotation_mask_with_padding():
+    annotations = _make_annotations([10], [10], ["Coral"])
+    label2id = {"Coral": 1}
+    padding = 2
+    mask = create_annotation_mask(annotations, (50, 50), label2id, padding=padding)
+
+    # The padded region [8:12, 8:12] should all be 1
+    assert np.all(mask[8:12, 8:12] == 1)
+    # Outside padding should be 0
+    assert mask[7, 10] == 0
+    assert mask[12, 10] == 0
+
+
+def test_create_annotation_mask_padding_bounds_clamped():
+    """Annotation at top-left corner with large padding must not raise IndexError."""
+    annotations = _make_annotations([0], [0], ["Coral"])
+    label2id = {"Coral": 1}
+    # Should not raise even though padding extends outside image bounds
+    mask = create_annotation_mask(annotations, (20, 20), label2id, padding=5)
+    assert mask[0, 0] == 1
+
+
+def test_create_annotation_mask_unknown_label_skipped(caplog):
+    annotations = _make_annotations([5, 10], [5, 10], ["Coral", "UnknownLabel"])
+    label2id = {"Coral": 1}
+
+    with caplog.at_level("WARNING", logger="mermaidseg.datasets.utils"):
+        mask = create_annotation_mask(annotations, (20, 20), label2id)
+
+    # Known label is written
+    assert mask[5, 5] == 1
+    # Unknown label point stays 0
+    assert mask[10, 10] == 0
+    # A warning was emitted
+    assert "unknown label" in caplog.text.lower() or "UnknownLabel" in caplog.text
+
+
+def test_create_annotation_mask_empty():
+    annotations = _make_annotations([], [], [])
+    mask = create_annotation_mask(annotations, (10, 10), {"Coral": 1})
+    assert np.all(mask == 0)
+
+
+def test_create_annotation_mask_all_null_labels():
+    annotations = _make_annotations([5], [5], [None])
+    mask = create_annotation_mask(annotations, (10, 10), {"Coral": 1})
+    assert np.all(mask == 0)
+
+
+def test_get_image_s3_success():
+    s3 = MagicMock()
+    s3.get_object.return_value = _make_s3_response(_valid_png_bytes())
+
+    image = get_image_s3(s3, "my-bucket", "path/to/image.png")
+
+    assert image is not None
+    s3.get_object.assert_called_once_with(Bucket="my-bucket", Key="path/to/image.png")
+
+
+def test_get_image_s3_thumbnail_modifies_key():
+    s3 = MagicMock()
+    s3.get_object.return_value = _make_s3_response(_valid_png_bytes())
+
+    get_image_s3(s3, "my-bucket", "path/to/image.png", thumbnail=True)
+
+    s3.get_object.assert_called_once_with(Bucket="my-bucket", Key="path/to/image_thumbnail.png")
+
+
+def test_get_image_s3_client_error_raises_data_load_error(caplog):
+    from botocore.exceptions import ClientError
+
+    s3 = MagicMock()
+    s3.get_object.side_effect = ClientError(
+        {"Error": {"Code": "NoSuchKey", "Message": "The specified key does not exist."}},
+        "GetObject",
+    )
+
+    with caplog.at_level("WARNING", logger="mermaidseg.datasets.utils"):
+        with pytest.raises(DataLoadError):
+            get_image_s3(s3, "my-bucket", "missing/image.png")
+
+    assert "NoSuchKey" in caplog.text or "S3 error" in caplog.text
+
+
+def test_get_image_s3_corrupted_image_raises_data_load_error(caplog):
+    s3 = MagicMock()
+    s3.get_object.return_value = _make_s3_response(b"not-a-valid-image")
+
+    with caplog.at_level("WARNING", logger="mermaidseg.datasets.utils"):
+        with pytest.raises(DataLoadError):
+            get_image_s3(s3, "my-bucket", "corrupt/image.png")
+
+    assert "corrupt" in caplog.text.lower() or "PIL" in caplog.text
+
+
+def _make_minimal_dataset() -> BaseCoralDataset:
+    """Build the smallest valid BaseCoralDataset (no real images needed)."""
+    df_annotations = pd.DataFrame(
+        {
+            "image_id": ["img1", "img2"],
+            "region_id": [1, 2],
+            "region_name": ["r1", "r2"],
+            "benthic_attribute_name": ["Coral", "Sand"],
+            "row": [10, 20],
+            "col": [10, 20],
+        }
+    )
+    df_images = (
+        df_annotations[["image_id", "region_id", "region_name"]]
+        .drop_duplicates()
+        .reset_index(drop=True)
+    )
+    class_subset = ["Coral", "Sand"]
+    ds = BaseCoralDataset.__new__(BaseCoralDataset)
+    # Bypass __init__ by setting attributes directly
+    ds.df_annotations = df_annotations
+    ds.df_images = df_images
+    ds.split = None
+    ds.transform = None
+    ds.padding = None
+    ds.class_subset = class_subset
+    ds.num_classes = len(class_subset) + 1
+    ds.id2label = {1: "Coral", 2: "Sand"}
+    ds.label2id = {"Coral": 1, "Sand": 2}
+    ds.concept_mapping_flag = False
+    return ds
+
+
+def test_collate_fn_filters_none_items(caplog):
+    ds = _make_minimal_dataset()
+    h, w = 4, 4
+    img = torch.zeros(3, h, w)
+    msk = torch.zeros(h, w, dtype=torch.long)
+    batch = [(img, msk), (None, None), (img, msk), (None, None)]
+
+    with caplog.at_level("WARNING", logger="mermaidseg.datasets.dataset"):
+        images, masks = ds.collate_fn(batch)
+
+    assert images.shape[0] == 2
+    assert masks.shape[0] == 2
+    assert "skipped 2/4" in caplog.text
+
+
+def test_collate_fn_all_none_returns_empty_tensors(caplog):
+    ds = _make_minimal_dataset()
+    batch = [(None, None), (None, None)]
+
+    with caplog.at_level("WARNING", logger="mermaidseg.datasets.dataset"):
+        images, masks = ds.collate_fn(batch)
+
+    assert images.numel() == 0
+    assert masks.numel() == 0
+    assert "entire batch" in caplog.text
+
+
+class _AlwaysFailDataset(BaseCoralDataset):
+    """Minimal subclass whose read_image always raises."""
+
+    def read_image(self, **row_kwargs) -> Any:
+        raise RuntimeError("simulated read failure")
+
+
+def test_base_dataset_getitem_skips_and_logs_on_read_failure(caplog):
+    df_annotations = pd.DataFrame(
+        {
+            "image_id": ["img1"],
+            "region_id": [1],
+            "region_name": ["r1"],
+            "benthic_attribute_name": ["Coral"],
+            "row": [5],
+            "col": [5],
+        }
+    )
+    df_images = (
+        df_annotations[["image_id", "region_id", "region_name"]]
+        .drop_duplicates()
+        .reset_index(drop=True)
+    )
+
+    ds = _AlwaysFailDataset(
+        df_annotations=df_annotations,
+        df_images=df_images,
+        class_subset=["Coral"],
+    )
+
+    with caplog.at_level("WARNING", logger="mermaidseg.datasets.dataset"):
+        result = ds[0]
+
+    assert result == (None, None)
+    assert "img1" in caplog.text
+    assert "RuntimeError" in caplog.text
+
+
+def test_data_load_error_importable():
+    from mermaidseg.datasets.utils import DataLoadError as DLE
+
+    assert issubclass(DLE, Exception)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -103,6 +103,22 @@ def test_create_annotation_mask_padding_bounds_clamped():
     assert np.all(mask[14:20, 14:20] == 1)
 
 
+def test_create_annotation_mask_overlapping_padding():
+    """When padding regions overlap, later annotations should overwrite earlier ones."""
+    # Two annotations close together: (10, 10) and (10, 14)
+    # With padding=3, their regions will overlap at rows 7-13, cols 10-17
+    annotations = _make_annotations([10, 10], [10, 14], ["Coral", "Sand"])
+    mask = create_annotation_mask(annotations, (20, 20), {"Coral": 1, "Sand": 2}, padding=3)
+
+    # The overlap region (cols 12-13) should have Sand (value 2) since Sand annotation is second
+    assert mask[10, 12] == 2
+    assert mask[10, 13] == 2
+
+    # Non-overlapping parts should have their respective values
+    assert mask[10, 9] == 1  # Coral only
+    assert mask[10, 16] == 2  # Sand only
+
+
 def test_create_annotation_mask_unknown_label_skipped(caplog):
     annotations = _make_annotations([5, 10], [5, 10], ["Coral", "UnknownLabel"])
 


### PR DESCRIPTION
https://github.com/data-mermaid/mermaid-segmentation/issues/14

Note: These have been tested in sagemaker and runs with both Coralnet and Mermaid 8000 x 8000 samples each. 
There have been gains to performance by adjusting the data loader's settings, as well as adding in skips for errors so it doesn't crash when encountering strange data on s3.   

I will keep investigating and benchmarking so we can quantify the speed up from 6hrs for one epoch. 

## Error handling

get_image_s3 now raises a typed DataLoadError instead of crashing with a raw exception

- __getitem__ logs the image ID and error type when skipping a bad image
- collate_fn logs how many items were dropped per batch
- All HTTP requests now have a 30s timeout and check for failure status codes

 Performance

- create_annotation_mask now uses numpy array indexing instead of iterating row by row
- DataLoaders in Base_Pipeline have `pin_memory` and `persistent_workers` enabled
- New: CombinedCoralDataset Wraps MERMAID and CoralNet datasets into one with a shared label space. Validates that all constituent datasets use the same class mapping at construction time.

New: Combined_Pipeline notebook End-to-end training notebook for joint MERMAID + CoralNet runs, with per-source subsampling and a shared base config (combined_mermaid_coralnet.yaml).

Tests tests/test_datasets.py covers annotation mask creation, collate_fn batch filtering, and __getitem__ failure logging — using fixtures and parametrize.