### PR TITLE
CoralNet resized training parquet + dataset consumption (#126, #127)

### DIFF
--- a/configs/base_coralnet.yaml
+++ b/configs/base_coralnet.yaml
@@ -7,6 +7,9 @@ logger:
 
 data:
   name: "CoralNetDataset"
+  # Resized training parquet: per-image resolved S3 key (resized or original) with row/col
+  # pre-scaled to the loaded image. Built by scripts/build_coralnet_training_parquet.py (#126).
+  annotations_path: "etl-outputs/coralnet/20260526_807b611/coralnet_training_resized_20260526_807b611.parquet"
   batch_size: 16
   class_subset: "../configs/run1_class_subset.csv"
   whitelist_sources:

--- a/mermaidseg/datasets/coralnet/coralnet_dataset.py
+++ b/mermaidseg/datasets/coralnet/coralnet_dataset.py
@@ -77,6 +77,10 @@ class CoralNetDataset(BaseCoralDataset):
 
     SOURCE_NAME = "coralnet"
 
+    # Columns every CoralNet annotations parquet must provide. ``source_label_name`` is derived
+    # from ``coralnet_id``; ``image_s3_key`` is optional (present only in the resized parquet).
+    REQUIRED_COLUMNS: tuple[str, ...] = ("source_id", "image_id", "row", "col", "coralnet_id")
+
     annotations_path: str
     source_ids: list[int | str]
     source_bucket: str
@@ -131,6 +135,12 @@ class CoralNetDataset(BaseCoralDataset):
         """
         annotations_path = f"s3://{self.source_bucket}/{self.annotations_path}"
         df_annotations = pd.read_parquet(annotations_path)
+        missing = set(self.REQUIRED_COLUMNS) - set(df_annotations.columns)
+        if missing:
+            raise ValueError(
+                f"CoralNet annotations parquet at {annotations_path} is missing required "
+                f"columns: {sorted(missing)}"
+            )
         df_annotations["source_label_name"] = df_annotations["coralnet_id"].astype(str)
         columns = ["source_id", "image_id", "row", "col", "coralnet_id", "source_label_name"]
         # The resized training parquet carries a per-image resolved S3 key (resized or original)

--- a/mermaidseg/datasets/coralnet/coralnet_dataset.py
+++ b/mermaidseg/datasets/coralnet/coralnet_dataset.py
@@ -132,20 +132,33 @@ class CoralNetDataset(BaseCoralDataset):
         annotations_path = f"s3://{self.source_bucket}/{self.annotations_path}"
         df_annotations = pd.read_parquet(annotations_path)
         df_annotations["source_label_name"] = df_annotations["coralnet_id"].astype(str)
-        df_annotations = df_annotations[
-            ["source_id", "image_id", "row", "col", "coralnet_id", "source_label_name"]
-        ]
+        columns = ["source_id", "image_id", "row", "col", "coralnet_id", "source_label_name"]
+        # The resized training parquet carries a per-image resolved S3 key (resized or original)
+        # with row/col already scaled to that image. The legacy parquet omits it, in which case
+        # read_image falls back to constructing the original key.
+        if "image_s3_key" in df_annotations.columns:
+            columns.append("image_s3_key")
+        df_annotations = df_annotations[columns]
 
         df_images = self._derive_df_images_from_annotations(df_annotations)
         return df_annotations, df_images
 
     def _derive_df_images_from_annotations(self, df_annotations: pd.DataFrame) -> pd.DataFrame:
+        columns = ["source_id", "image_id"]
+        if "image_s3_key" in df_annotations.columns:
+            columns.append("image_s3_key")
         return (
-            df_annotations[["source_id", "image_id"]]
+            df_annotations[columns]
             .drop_duplicates(subset=["source_id", "image_id"])
             .reset_index(drop=True)
         )
 
-    def read_image(self, image_id: str, source_id: str, **row_kwargs: Any) -> NDArray[Any]:
-        key = f"{self.source_s3_prefix}/s{source_id}/images/{image_id}.jpg"
+    def read_image(
+        self,
+        image_id: str,
+        source_id: str,
+        image_s3_key: str | None = None,
+        **row_kwargs: Any,
+    ) -> NDArray[Any]:
+        key = image_s3_key or f"{self.source_s3_prefix}/s{source_id}/images/{image_id}.jpg"
         return np.array(get_image_s3(s3=self.s3, bucket=self.source_bucket, key=key).convert("RGB"))

--- a/mermaidseg/datasets/coralnet/preprocessing/manifest.py
+++ b/mermaidseg/datasets/coralnet/preprocessing/manifest.py
@@ -167,7 +167,16 @@ def build_training_manifest(
             load_height=load_height,
             uses_resized_image=use_resized,
         )
-        .filter((~joined.needs_resize) | use_resized)  # noqa: PD004 — ibis API
+        # Keep sub-threshold or completed-resize images, and only those with known original
+        # dimensions — null dims (e.g. header_status="not_found") can't be scaled or validated,
+        # and DuckDB's greatest(NULL, 0) would silently collapse their coords to (0, 0).
+        .filter(
+            ((~joined.needs_resize) | use_resized)  # noqa: PD004 — ibis API
+            & joined.width.notnull()
+            & joined.height.notnull()
+            & (joined.width > 0)
+            & (joined.height > 0)
+        )
         .select(
             "source_id",
             "image_id",

--- a/mermaidseg/datasets/coralnet/preprocessing/manifest.py
+++ b/mermaidseg/datasets/coralnet/preprocessing/manifest.py
@@ -200,10 +200,14 @@ def build_training_manifest(
         (out.row.cast("float64") * scale_y).floor().cast("int64"), out.load_height - 1
     )
 
+    # row/col and load dims are bounded by the resize threshold (<= 2048), so int16 stores them
+    # losslessly at a quarter of int64 — they dominate the file size at annotation scale.
     return (
         out.mutate(
-            row=ibis.greatest(row_scaled, ibis.literal(0)),
-            col=ibis.greatest(col_scaled, ibis.literal(0)),
+            row=ibis.greatest(row_scaled, ibis.literal(0)).cast("int16"),
+            col=ibis.greatest(col_scaled, ibis.literal(0)).cast("int16"),
+            load_width=out.load_width.cast("int16"),
+            load_height=out.load_height.cast("int16"),
             source_label_name=out.coralnet_id.cast("string"),
         )
         .select(

--- a/mermaidseg/datasets/coralnet/preprocessing/manifest.py
+++ b/mermaidseg/datasets/coralnet/preprocessing/manifest.py
@@ -107,3 +107,107 @@ def build_manifest(
         )
         .order_by(["source_id", "image_id"])
     )
+
+
+def build_training_manifest(
+    annotations: ibis.Table,
+    images: ibis.Table,
+    checkpoint: ibis.Table,
+    output_prefix: str,
+    threshold: int = 2048,
+) -> ibis.Table:
+    """Build the annotation-level training parquet consumed by ``CoralNetDataset``.
+
+    Resolves the S3 key of the image to actually load (resized when the image was resized,
+    original otherwise) and rescales each point annotation's ``row``/``col`` to the loaded
+    image's dimensions, so the dataset needs no runtime scaling. Images that ``needs_resize``
+    but whose resize did not complete are excluded entirely (their annotations are dropped).
+
+    Args:
+        annotations: Annotation rows with [source_id, image_id, row, col, coralnet_id].
+        images: Image metadata with [source_id, image_id, s3_key, width, height, needs_resize, ...].
+        checkpoint: Resize checkpoint/manifest with [source_id, image_id, status, ...].
+        output_prefix: S3 prefix under which resized images live (e.g. ``"dev/images"``).
+        threshold: Resize threshold (longest edge in pixels) used when the corpus was resized.
+
+    Returns:
+        Annotation-level table with columns:
+        [source_id, image_id, row, col, coralnet_id, source_label_name, image_s3_key,
+         load_width, load_height, uses_resized_image]. ``row``/``col`` are already scaled
+        to (load_height, load_width).
+    """
+    joined = images.left_join(checkpoint, ["source_id", "image_id"])
+
+    # Treat a resize as usable only when the image needed resizing AND its checkpoint row
+    # completed; images absent from the checkpoint get a null status (-> not completed).
+    use_resized = joined.needs_resize & (joined.status.fill_null("") == "completed")  # noqa: PD004 — ibis API
+
+    resized_key = (
+        ibis.literal(f"{output_prefix}/resized/s")
+        + joined.source_id.cast("string")
+        + "/images/"
+        + joined.image_id
+        + ".jpg"
+    )
+
+    # Scale the longest edge to the threshold, flooring like the resize worker's int().
+    longest = ibis.greatest(joined.width, joined.height)
+    scale = ibis.literal(threshold).cast("float64") / longest.cast("float64")
+    load_width = ibis.ifelse(
+        use_resized, (joined.width.cast("float64") * scale).floor().cast("int64"), joined.width
+    )
+    load_height = ibis.ifelse(
+        use_resized, (joined.height.cast("float64") * scale).floor().cast("int64"), joined.height
+    )
+
+    image_manifest = (
+        joined.mutate(
+            image_s3_key=ibis.ifelse(use_resized, resized_key, joined.s3_key),
+            load_width=load_width,
+            load_height=load_height,
+            uses_resized_image=use_resized,
+        )
+        .filter((~joined.needs_resize) | use_resized)  # noqa: PD004 — ibis API
+        .select(
+            "source_id",
+            "image_id",
+            "image_s3_key",
+            "load_width",
+            "load_height",
+            "uses_resized_image",
+            orig_width=ibis._.width,
+            orig_height=ibis._.height,
+        )
+    )
+
+    # Inner join drops annotations of excluded images.
+    out = annotations.inner_join(image_manifest, ["source_id", "image_id"])
+    scale_x = out.load_width.cast("float64") / out.orig_width.cast("float64")
+    scale_y = out.load_height.cast("float64") / out.orig_height.cast("float64")
+    col_scaled = ibis.least(
+        (out.col.cast("float64") * scale_x).floor().cast("int64"), out.load_width - 1
+    )
+    row_scaled = ibis.least(
+        (out.row.cast("float64") * scale_y).floor().cast("int64"), out.load_height - 1
+    )
+
+    return (
+        out.mutate(
+            row=ibis.greatest(row_scaled, ibis.literal(0)),
+            col=ibis.greatest(col_scaled, ibis.literal(0)),
+            source_label_name=out.coralnet_id.cast("string"),
+        )
+        .select(
+            "source_id",
+            "image_id",
+            "row",
+            "col",
+            "coralnet_id",
+            "source_label_name",
+            "image_s3_key",
+            "load_width",
+            "load_height",
+            "uses_resized_image",
+        )
+        .order_by(["source_id", "image_id", "row", "col"])
+    )

--- a/scripts/build_coralnet_training_parquet.py
+++ b/scripts/build_coralnet_training_parquet.py
@@ -1,0 +1,97 @@
+"""Build the annotation-level CoralNet training parquet (resized URLs + scaled coords).
+
+Joins the ETL annotations parquet onto the images parquet + resize checkpoint(s), resolves the
+S3 key of the image to actually load (resized when completed, original for sub-threshold images),
+rescales each point annotation to the loaded image's dimensions, and excludes images that
+``needs_resize`` but whose resize did not complete. The result is consumed directly by
+``CoralNetDataset``.
+
+Usage (SageMaker):
+    uv run python scripts/build_coralnet_training_parquet.py \
+        --checkpoints outputs/resize_full_*.parquet outputs/resize_rgba_*.parquet
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from mermaidseg.datasets.coralnet.etl.io import make_ibis_connection
+from mermaidseg.datasets.coralnet.preprocessing.manifest import (
+    build_training_manifest,
+    combine_checkpoints,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bucket", default="dev-datamermaid-sm-sources")
+    parser.add_argument("--run", default="20260526_807b611")
+    parser.add_argument("--output-prefix", default="dev/images")
+    parser.add_argument("--threshold", type=int, default=2048)
+    parser.add_argument(
+        "--checkpoints",
+        nargs="+",
+        required=True,
+        help="Resize checkpoint parquets; the most recent resize_timestamp wins per image",
+    )
+    parser.add_argument(
+        "--annotations",
+        default=None,
+        help="Annotations parquet (default: s3://{bucket}/etl-outputs/coralnet/{run}/coralnet_annotations_{run}.parquet)",
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Destination (default: s3://{bucket}/etl-outputs/coralnet/{run}/coralnet_training_resized_{run}.parquet)",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    base = f"s3://{args.bucket}/etl-outputs/coralnet/{args.run}"
+    annotations_uri = args.annotations or f"{base}/coralnet_annotations_{args.run}.parquet"
+    images_uri = f"{base}/coralnet_images_{args.run}.parquet"
+    out = args.out or f"{base}/coralnet_training_resized_{args.run}.parquet"
+
+    con = make_ibis_connection()
+
+    logger.info("Loading %d checkpoint(s)", len(args.checkpoints))
+    checkpoints = [con.read_parquet(p) for p in args.checkpoints]
+    for path, t in zip(args.checkpoints, checkpoints, strict=True):
+        logger.info("  %s: %d rows", path, t.count().execute())
+    combined = combine_checkpoints(checkpoints)
+    logger.info("Combined checkpoint: %d rows", combined.count().execute())
+
+    logger.info("Loading %s", annotations_uri)
+    annotations = con.read_parquet(annotations_uri)
+    logger.info("Loading %s", images_uri)
+    images = con.read_parquet(images_uri)
+
+    manifest = build_training_manifest(
+        annotations=annotations,
+        images=images,
+        checkpoint=combined,
+        output_prefix=args.output_prefix,
+        threshold=args.threshold,
+    )
+
+    n_annotations = annotations.count().execute()
+    n_out = manifest.count().execute()
+    n_resized = manifest.filter(manifest.uses_resized_image).count().execute()  # noqa: PD004 — ibis API
+    logger.info(
+        "Training manifest: %d annotation rows (%d excluded), %d on resized images",
+        n_out,
+        n_annotations - n_out,
+        n_resized,
+    )
+
+    manifest.to_parquet(out)
+    logger.info("Wrote %s", out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_coralnet_training_parquet.py
+++ b/scripts/build_coralnet_training_parquet.py
@@ -78,9 +78,15 @@ def main() -> int:
         threshold=args.threshold,
     )
 
+    # Single pass over the (joined) manifest for both counts; n_annotations is a cheap
+    # parquet-metadata count.
+    summary = manifest.aggregate(
+        total=manifest.count(),
+        resized=manifest.uses_resized_image.cast("int64").sum(),  # noqa: PD004 — ibis API
+    ).execute()
+    n_out = int(summary["total"].iloc[0])
+    n_resized = int(summary["resized"].iloc[0])
     n_annotations = annotations.count().execute()
-    n_out = manifest.count().execute()
-    n_resized = manifest.filter(manifest.uses_resized_image).count().execute()  # noqa: PD004 — ibis API
     logger.info(
         "Training manifest: %d annotation rows (%d excluded), %d on resized images",
         n_out,
@@ -88,7 +94,7 @@ def main() -> int:
         n_resized,
     )
 
-    manifest.to_parquet(out)
+    manifest.to_parquet(out, compression="zstd", row_group_size=122880)
     logger.info("Wrote %s", out)
     return 0
 

--- a/tests/datasets/coralnet/test_coralnet_dataset_resized.py
+++ b/tests/datasets/coralnet/test_coralnet_dataset_resized.py
@@ -1,0 +1,121 @@
+"""CoralNetDataset consuming the resized training parquet (per-image image_s3_key).
+
+These tests are hermetic: parquet reads, the boto3 client, and S3 image fetches are all stubbed, so
+nothing touches AWS.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+from PIL import Image
+
+import mermaidseg.datasets.coralnet.coralnet_dataset as cnd
+from mermaidseg.datasets.coralnet.coralnet_dataset import CoralNetDataset
+
+
+def _make_dataset(monkeypatch, df_annotations, captured_keys, image_provider, **base_kwargs):
+    """Build a CoralNetDataset offline.
+
+    ``df_annotations`` is returned in place of any S3 parquet read. ``image_provider`` maps a
+    requested S3 key to a PIL image; every requested key is appended to ``captured_keys``.
+    """
+    monkeypatch.setattr(pd, "read_parquet", lambda *a, **k: df_annotations.copy())
+    monkeypatch.setattr(cnd.boto3, "client", lambda *a, **k: MagicMock())
+
+    def fake_get_image_s3(s3, bucket, key, **kwargs):
+        captured_keys.append(key)
+        return image_provider(key)
+
+    monkeypatch.setattr(cnd, "get_image_s3", fake_get_image_s3)
+    return CoralNetDataset(**base_kwargs)
+
+
+def _resized_parquet_df():
+    """One image, two points, with a resolved resized image_s3_key (new-parquet shape)."""
+    return pd.DataFrame(
+        {
+            "source_id": [1, 1],
+            "image_id": ["img1", "img1"],
+            "row": [10, 5],
+            "col": [20, 7],
+            "coralnet_id": [82, 82],
+            "source_label_name": ["82", "82"],
+            "image_s3_key": ["dev/images/resized/s1/images/img1.jpg"] * 2,
+        }
+    )
+
+
+def test_read_image_prefers_resolved_key(monkeypatch):
+    """When the parquet carries image_s3_key, read_image loads exactly that key."""
+    keys: list[str] = []
+    ds = _make_dataset(
+        monkeypatch,
+        _resized_parquet_df(),
+        keys,
+        lambda key: Image.new("RGB", (50, 30)),
+    )
+    # df_images must carry the resolved key through to read_image.
+    assert "image_s3_key" in ds.df_images.columns
+    ds.read_image(
+        image_id="img1", source_id="1", image_s3_key="dev/images/resized/s1/images/img1.jpg"
+    )
+    assert keys[-1] == "dev/images/resized/s1/images/img1.jpg"
+
+
+def test_read_image_falls_back_to_constructed_key(monkeypatch):
+    """Legacy parquet (no image_s3_key) -> read_image constructs the original key."""
+    legacy = _resized_parquet_df().drop(columns=["image_s3_key"])
+    keys: list[str] = []
+    ds = _make_dataset(monkeypatch, legacy, keys, lambda key: Image.new("RGB", (50, 30)))
+    assert "image_s3_key" not in ds.df_images.columns
+    ds.read_image(image_id="img1", source_id="1")
+    assert keys[-1] == "coralnet-public-images/s1/images/img1.jpg"
+
+
+def test_getitem_places_label_at_point_with_correct_orientation(monkeypatch):
+    """End-to-end alignment: the (row, col) from the parquet lands at mask[row, col] on the loaded
+    image, with row indexing height and col indexing width (guards a row/col transpose).
+
+    Uses a single point and a non-square image so a transpose would move the label.
+    """
+    df = pd.DataFrame(
+        {
+            "source_id": [1],
+            "image_id": ["img1"],
+            "row": [10],
+            "col": [20],
+            "coralnet_id": [82],
+            "source_label_name": ["82"],
+            "image_s3_key": ["dev/images/resized/s1/images/img1.jpg"],
+        }
+    )
+    keys: list[str] = []
+    # PIL size is (width, height) -> numpy array shape (30, 50, 3): H=30, W=50.
+    ds = _make_dataset(monkeypatch, df, keys, lambda key: Image.new("RGB", (50, 30)), padding=None)
+
+    image, mask = ds[0]
+
+    assert keys == ["dev/images/resized/s1/images/img1.jpg"]
+    assert image.shape == (30, 50, 3)
+    assert mask.shape == (30, 50)  # (height, width) — matches the loaded image
+    # Single foreground class -> local id 1, placed exactly at (row=10, col=20).
+    assert mask[10, 20] == 1
+    assert int((mask != 0).sum()) == 1  # nothing else set; no transpose to (20, 10)
+
+
+def test_collate_fn_skips_failed_loads(monkeypatch):
+    """A (None, None) failed-load item is dropped; the surviving sample is stacked."""
+    import torch
+
+    keys: list[str] = []
+    ds = _make_dataset(
+        monkeypatch, _resized_parquet_df(), keys, lambda key: Image.new("RGB", (8, 8))
+    )
+    good_img = np.zeros((3, 8, 8), dtype=np.float32)
+    good_mask = np.zeros((8, 8), dtype=np.int64)
+    images, masks = ds.collate_fn([(None, None), (good_img, good_mask)])
+    assert isinstance(images, torch.Tensor)
+    assert images.shape[0] == 1 and masks.shape[0] == 1

--- a/tests/datasets/coralnet/test_coralnet_dataset_resized.py
+++ b/tests/datasets/coralnet/test_coralnet_dataset_resized.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
+import pytest
 from PIL import Image
 
 import mermaidseg.datasets.coralnet.coralnet_dataset as cnd
@@ -104,6 +105,13 @@ def test_getitem_places_label_at_point_with_correct_orientation(monkeypatch):
     # Single foreground class -> local id 1, placed exactly at (row=10, col=20).
     assert mask[10, 20] == 1
     assert int((mask != 0).sum()) == 1  # nothing else set; no transpose to (20, 10)
+
+
+def test_missing_required_column_raises(monkeypatch):
+    """A parquet missing a required column fails fast with a clear error, not a pandas KeyError."""
+    bad = _resized_parquet_df().drop(columns=["coralnet_id"])
+    with pytest.raises(ValueError, match="missing required columns.*coralnet_id"):
+        _make_dataset(monkeypatch, bad, [], lambda key: Image.new("RGB", (8, 8)))
 
 
 def test_collate_fn_skips_failed_loads(monkeypatch):

--- a/tests/datasets/coralnet/test_preprocessing.py
+++ b/tests/datasets/coralnet/test_preprocessing.py
@@ -529,6 +529,10 @@ def test_training_manifest_scales_coords_and_excludes():
     assert (out["row"] >= 0).all() and (out["row"] < out["load_height"]).all()
     assert (out["col"] >= 0).all() and (out["col"] < out["load_width"]).all()
 
+    # Coords/dims are stored as int16 (bounded by the 2048 resize threshold) to keep the file small.
+    for c in ("row", "col", "load_width", "load_height"):
+        assert out[c].dtype == "int16", (c, out[c].dtype)
+
     # Sub-threshold image: original key, coords unchanged, source_label_name = str(coralnet_id).
     sub = out[out["image_id"] == "sub"].iloc[0]
     assert sub["image_s3_key"] == "coralnet-public-images/s1/images/sub.jpg"

--- a/tests/datasets/coralnet/test_preprocessing.py
+++ b/tests/datasets/coralnet/test_preprocessing.py
@@ -477,17 +477,19 @@ def test_training_manifest_scales_coords_and_excludes():
     key; needs_resize-but-not-completed images (failed / absent from checkpoint) excluded."""
     images = pd.DataFrame(
         {
-            "source_id": [1, 1, 1, 1],
-            "image_id": ["sub", "big", "fail", "missing"],
+            "source_id": [1, 1, 1, 1, 1],
+            "image_id": ["sub", "big", "fail", "missing", "nodims"],
             "s3_key": [
                 "coralnet-public-images/s1/images/sub.jpg",
                 "coralnet-public-images/s1/images/big.jpg",
                 "coralnet-public-images/s1/images/fail.jpg",
                 "coralnet-public-images/s1/images/missing.jpg",
+                "coralnet-public-images/s1/images/nodims.jpg",
             ],
-            "width": [1000, 4000, 5000, 6000],
-            "height": [800, 2000, 3000, 3000],
-            "needs_resize": [False, True, True, True],
+            # "nodims" has unknown dimensions (e.g. header_status="not_found").
+            "width": [1000, 4000, 5000, 6000, None],
+            "height": [800, 2000, 3000, 3000, None],
+            "needs_resize": [False, True, True, True, False],
         }
     )
     # "missing" needs_resize but has no checkpoint row at all -> must be excluded.
@@ -502,11 +504,11 @@ def test_training_manifest_scales_coords_and_excludes():
     )
     annotations = pd.DataFrame(
         {
-            "source_id": [1, 1, 1, 1, 1],
-            "image_id": ["sub", "big", "big", "fail", "missing"],
-            "row": [400, 1000, 1999, 10, 10],
-            "col": [500, 2000, 3999, 10, 10],
-            "coralnet_id": [82, 91, 91, 7, 7],
+            "source_id": [1, 1, 1, 1, 1, 1],
+            "image_id": ["sub", "big", "big", "fail", "missing", "nodims"],
+            "row": [400, 1000, 1999, 10, 10, 10],
+            "col": [500, 2000, 3999, 10, 10, 10],
+            "coralnet_id": [82, 91, 91, 7, 7, 7],
         }
     )
 
@@ -518,8 +520,14 @@ def test_training_manifest_scales_coords_and_excludes():
         threshold=2048,
     ).to_pandas()
 
-    # Only sub-threshold + completed-resize images survive.
+    # Only sub-threshold + completed-resize images with known dims survive
+    # ("fail"/"missing" excluded for incomplete resize, "nodims" for null dimensions).
     assert set(out["image_id"]) == {"sub", "big"}
+
+    # Every surviving point is in bounds (no nulls, no out-of-range from null-dim collapse).
+    assert out["load_width"].notna().all() and out["load_height"].notna().all()
+    assert (out["row"] >= 0).all() and (out["row"] < out["load_height"]).all()
+    assert (out["col"] >= 0).all() and (out["col"] < out["load_width"]).all()
 
     # Sub-threshold image: original key, coords unchanged, source_label_name = str(coralnet_id).
     sub = out[out["image_id"] == "sub"].iloc[0]

--- a/tests/datasets/coralnet/test_preprocessing.py
+++ b/tests/datasets/coralnet/test_preprocessing.py
@@ -17,6 +17,7 @@ from mermaidseg.datasets.coralnet.preprocessing.inspect import (
 )
 from mermaidseg.datasets.coralnet.preprocessing.manifest import (
     build_manifest,
+    build_training_manifest,
     combine_checkpoints,
 )
 from mermaidseg.datasets.coralnet.preprocessing.resize import (
@@ -469,6 +470,74 @@ def test_manifest_dimensions_and_keys_match_resize():
     assert manifest.loc["above", "output_s3_key"] == _resized_s3_key_for(
         "etl-outputs/coralnet", 2, "above", threshold
     )
+
+
+def test_training_manifest_scales_coords_and_excludes():
+    """Sub-threshold coords unchanged + original key; resized coords floored to load dims + resized
+    key; needs_resize-but-not-completed images (failed / absent from checkpoint) excluded."""
+    images = pd.DataFrame(
+        {
+            "source_id": [1, 1, 1, 1],
+            "image_id": ["sub", "big", "fail", "missing"],
+            "s3_key": [
+                "coralnet-public-images/s1/images/sub.jpg",
+                "coralnet-public-images/s1/images/big.jpg",
+                "coralnet-public-images/s1/images/fail.jpg",
+                "coralnet-public-images/s1/images/missing.jpg",
+            ],
+            "width": [1000, 4000, 5000, 6000],
+            "height": [800, 2000, 3000, 3000],
+            "needs_resize": [False, True, True, True],
+        }
+    )
+    # "missing" needs_resize but has no checkpoint row at all -> must be excluded.
+    checkpoint = pd.DataFrame(
+        {
+            "source_id": [1, 1],
+            "image_id": ["big", "fail"],
+            "status": ["completed", "failed"],
+            "resize_timestamp": [datetime.now(), None],
+            "error_message": [None, "decode failed"],
+        }
+    )
+    annotations = pd.DataFrame(
+        {
+            "source_id": [1, 1, 1, 1, 1],
+            "image_id": ["sub", "big", "big", "fail", "missing"],
+            "row": [400, 1000, 1999, 10, 10],
+            "col": [500, 2000, 3999, 10, 10],
+            "coralnet_id": [82, 91, 91, 7, 7],
+        }
+    )
+
+    out = build_training_manifest(
+        annotations=ibis.memtable(annotations),
+        images=ibis.memtable(images),
+        checkpoint=ibis.memtable(checkpoint),
+        output_prefix="dev/images",
+        threshold=2048,
+    ).to_pandas()
+
+    # Only sub-threshold + completed-resize images survive.
+    assert set(out["image_id"]) == {"sub", "big"}
+
+    # Sub-threshold image: original key, coords unchanged, source_label_name = str(coralnet_id).
+    sub = out[out["image_id"] == "sub"].iloc[0]
+    assert sub["image_s3_key"] == "coralnet-public-images/s1/images/sub.jpg"
+    assert (int(sub["row"]), int(sub["col"])) == (400, 500)
+    assert bool(sub["uses_resized_image"]) is False
+    assert sub["source_label_name"] == "82"
+
+    # Resized image: resized key, dims floored to threshold (4000 -> 2048, 2000 -> 1024).
+    big = out[out["image_id"] == "big"]
+    assert (big["image_s3_key"] == "dev/images/resized/s1/images/big.jpg").all()
+    assert big["uses_resized_image"].all()
+    assert (big["load_width"] == 2048).all() and (big["load_height"] == 1024).all()
+    coords = set(zip(big["row"].astype(int), big["col"].astype(int), strict=True))
+    # (1000,2000) -> (floor(1000*1024/2000), floor(2000*2048/4000)) = (512, 1024)
+    assert (512, 1024) in coords
+    # (1999,3999) -> (floor(1999*1024/2000), floor(3999*2048/4000)) = (1023, 2047), within bounds
+    assert (1023, 2047) in coords
 
 
 # ============================================================================

--- a/tests/datasets/coralnet/test_preprocessing.py
+++ b/tests/datasets/coralnet/test_preprocessing.py
@@ -548,6 +548,79 @@ def test_training_manifest_scales_coords_and_excludes():
     assert (1023, 2047) in coords
 
 
+def _build_one_image_manifest(orig_w, orig_h, row, col, *, threshold=2048):
+    """Run build_training_manifest for a single image+point; return (out_df, needs_resize)."""
+    needs = max(orig_w, orig_h) > threshold
+    images = pd.DataFrame(
+        {
+            "source_id": [1],
+            "image_id": ["x"],
+            "s3_key": ["coralnet-public-images/s1/images/x.jpg"],
+            "width": [orig_w],
+            "height": [orig_h],
+            "needs_resize": [needs],
+        }
+    )
+    checkpoint = pd.DataFrame(
+        {
+            "source_id": [1],
+            "image_id": ["x"],
+            "status": ["completed"],
+            "resize_timestamp": [datetime.now()],
+            "error_message": [None],
+        }
+    )
+    annotations = pd.DataFrame(
+        {"source_id": [1], "image_id": ["x"], "row": [row], "col": [col], "coralnet_id": [82]}
+    )
+    out = build_training_manifest(
+        annotations=ibis.memtable(annotations),
+        images=ibis.memtable(images),
+        checkpoint=ibis.memtable(checkpoint),
+        output_prefix="dev/images",
+        threshold=threshold,
+    ).to_pandas()
+    return out, needs
+
+
+@pytest.mark.parametrize(
+    "orig_w,orig_h",
+    [
+        (4000, 2000),  # landscape, resized
+        (2000, 4000),  # portrait, resized
+        (3000, 3000),  # square, resized (non-power-of-2 ratio)
+        (2049, 2049),  # just over threshold
+        (800, 600),  # sub-threshold, not resized
+        (2048, 1000),  # longest == threshold, not resized
+    ],
+)
+def test_training_manifest_load_dims_and_coords_match_real_resize(orig_w, orig_h):
+    """Builder load dims + scaled coords agree with the actual PIL resize (oracle), and a far-corner
+    point stays in bounds after the floor+clip."""
+    threshold = 2048
+    r, c = orig_h - 1, orig_w - 1  # far corner stresses the clip
+    out, needs = _build_one_image_manifest(orig_w, orig_h, r, c, threshold=threshold)
+    assert len(out) == 1
+    rowd = out.iloc[0]
+
+    buf = BytesIO()
+    Image.new("RGB", (orig_w, orig_h)).save(buf, format="JPEG")
+    buf.seek(0)
+    resized = Image.open(resize_image_to_threshold(buf, threshold=threshold))
+    resized.load()
+
+    # Oracle: recorded load dims == dimensions the real resize produced.
+    assert int(rowd["load_width"]) == resized.width
+    assert int(rowd["load_height"]) == resized.height
+    assert bool(rowd["uses_resized_image"]) == needs
+
+    # Coords scale by load/orig (same factor the builder uses) and stay in bounds.
+    assert int(rowd["col"]) == min(int(c * resized.width / orig_w), resized.width - 1)
+    assert int(rowd["row"]) == min(int(r * resized.height / orig_h), resized.height - 1)
+    assert 0 <= int(rowd["row"]) < resized.height
+    assert 0 <= int(rowd["col"]) < resized.width
+
+
 # ============================================================================
 # Image inspection and robustness tests
 # ============================================================================

--- a/tests/datasets/coralnet/test_training_manifest_properties.py
+++ b/tests/datasets/coralnet/test_training_manifest_properties.py
@@ -1,0 +1,94 @@
+"""Property-based invariants for build_training_manifest coordinate scaling.
+
+Uses hypothesis to fuzz image shapes / point positions / thresholds and assert invariants the
+scaling must always satisfy. hypothesis is a dev-only convenience and is intentionally NOT in
+pyproject.toml, so this module self-skips wherever it isn't installed.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import ibis
+import pandas as pd
+import pytest
+
+pytest.importorskip("hypothesis")
+
+from hypothesis import assume, given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+from mermaidseg.datasets.coralnet.preprocessing.manifest import (  # noqa: E402
+    build_training_manifest,
+)
+
+
+@st.composite
+def shape_point_threshold(draw):
+    """Realistic image shape, an in-bounds point, and a resize threshold."""
+    w = draw(st.integers(min_value=64, max_value=12000))
+    h = draw(st.integers(min_value=64, max_value=12000))
+    # Keep aspect ratios within a sane range so a tiny threshold can't floor an edge to 0.
+    assume(0.1 <= w / h <= 10)
+    col = draw(st.integers(min_value=0, max_value=w - 1))
+    row = draw(st.integers(min_value=0, max_value=h - 1))
+    threshold = draw(st.integers(min_value=256, max_value=4096))
+    return w, h, row, col, threshold
+
+
+@settings(max_examples=150, deadline=None)
+@given(shape_point_threshold())
+def test_scaling_invariants(params):
+    w, h, row, col, threshold = params
+    needs = max(w, h) > threshold
+
+    images = pd.DataFrame(
+        {
+            "source_id": [1],
+            "image_id": ["x"],
+            "s3_key": ["coralnet-public-images/s1/images/x.jpg"],
+            "width": [w],
+            "height": [h],
+            "needs_resize": [needs],
+        }
+    )
+    checkpoint = pd.DataFrame(
+        {
+            "source_id": [1],
+            "image_id": ["x"],
+            "status": ["completed"],
+            "resize_timestamp": [datetime.now()],
+            "error_message": [None],
+        }
+    )
+    annotations = pd.DataFrame(
+        {"source_id": [1], "image_id": ["x"], "row": [row], "col": [col], "coralnet_id": [82]}
+    )
+
+    out = build_training_manifest(
+        annotations=ibis.memtable(annotations),
+        images=ibis.memtable(images),
+        checkpoint=ibis.memtable(checkpoint),
+        output_prefix="dev/images",
+        threshold=threshold,
+    ).to_pandas()
+
+    # Image with valid dims is always kept (resized when over threshold, else original).
+    assert len(out) == 1
+    r = out.iloc[0]
+    lw, lh = int(r["load_width"]), int(r["load_height"])
+    out_row, out_col = int(r["row"]), int(r["col"])
+
+    # Load dims never upscale and never exceed the threshold's longest edge.
+    assert 1 <= lw <= w and 1 <= lh <= h
+    assert max(lw, lh) <= threshold or not needs
+    assert bool(r["uses_resized_image"]) == needs
+
+    # Scaled point is always a valid index into the loaded image.
+    assert 0 <= out_row < lh
+    assert 0 <= out_col < lw
+
+    # Downscaling never increases an index; a non-resized image is the identity.
+    assert out_row <= row and out_col <= col
+    if not needs:
+        assert (out_row, out_col) == (row, col)


### PR DESCRIPTION
## Summary

Builds the resized-image CoralNet **training parquet** and makes `CoralNetDataset` consume it, so training reads pre-resized images with annotations already scaled to them. Implements #126 (build the parquet) and #127 (dataset consumes it).

> **Stacked on #125** — base is `feat/coralnet-resize-pipeline`, not `main`. The builder reuses `build_manifest`/`combine_checkpoints`/`make_ibis_connection` from that PR, so this should merge after #125. The diff here is exactly the 5 commits below.

## Why

Original CoralNet images are large (5000px+), making S3 download + decode the training bottleneck. The resize pipeline (#125) already uploads 2048px-longest-edge JPEGs. This PR connects that to training:

1. A new builder joins annotations + images + the resize manifest into one annotation-level parquet that records, per point, the **resolved S3 key** (resized when available, else original) and `row`/`col` **pre-scaled** to the image that will actually be loaded.
2. `CoralNetDataset` reads that key and the pre-scaled coords — no runtime scaling, no change to `BaseCoralDataset`/`create_annotation_mask`.

## What's included

**#126 — builder (`mermaidseg/datasets/coralnet/preprocessing/manifest.py::build_training_manifest` + `scripts/build_coralnet_training_parquet.py`)**
- Starts from the **images** parquet (all images), left-joins the resize checkpoint/manifest.
- Per-image routing: `needs_resize=False` → original key, coords unchanged; `needs_resize=True & status="completed"` → resized key, coords scaled by `load_dim/orig_dim` (floored, clipped to bounds).
- **Excludes**: needs-resize images that didn't complete (failed/skipped/absent) **and** images with null dimensions (`header_status="not_found"`) — the latter would otherwise have their coords silently collapsed to `(0,0)` by DuckDB's `greatest(NULL,0)`.

**#127 — dataset (`mermaidseg/datasets/coralnet/coralnet_dataset.py`)**
- Carries optional `image_s3_key` from the parquet through `df_images` into `read_image`; falls back to the constructed original key for the legacy parquet (backward compatible).
- Adds `REQUIRED_COLUMNS` validation (Pacific-style) for a clear error on the wrong parquet.
- `configs/base_coralnet.yaml` points at the new parquet.

**Storage hygiene**
- zstd compression and int16 `row`/`col`/`load_*` (bounded by the 2048 threshold). zstd is the disk win (84.5 → 72.2 MiB); int16 is ~neutral on disk but trims ~0.5 GB of RAM on the whole-file pandas load. Single-pass count logging in the CLI.

## Artifact

`s3://dev-datamermaid-sm-sources/etl-outputs/coralnet/20260526_807b611/coralnet_training_resized_20260526_807b611.parquet`
- 20,315,787 annotation rows · 69,839 excluded · 17,610,452 (~87%) on resized images · 72.2 MiB.

## Out of scope / follow-ups

- The LinearDINOv3 baseline run itself (#12) — config scaffold + `scripts/train.py --dry-run`.
- DRYing `build_training_manifest`↔`build_manifest` and the two CLI scripts (both touch #125's code; left for a follow-up).
- Image-level sharding (WebDataset/FFCV) — the larger DL-throughput lever, separate effort.

** Note:** Heads-up: PR #113's config refactor deletes the base_coralnet.yaml we edited. Next: decide whether
we will have to rebase or re-home the parquet path to an env var. 

Closes: #126, #127