### PR TITLE
Slim core dependencies; move training/ETL/viz to extras

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Run unit tests
         # --all-extras: heavy deps (mlflow, torchmetrics, ibis, matplotlib, ...) moved out of
         # core into optional extras; tests import those modules, so install everything.
-        run: uv run --all-extras --group tests pytest -m "not slow and not integration" --cov=mermaidseg --cov-report=term-missing
+        run: uv run --all-extras --group tests pytest -m "not slow and not integration and not live" --cov=mermaidseg --cov-report=term-missing

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,4 +15,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
       - name: Run unit tests
-        run: uv run --group tests pytest -m "not slow and not integration" --cov=mermaidseg --cov-report=term-missing
+        # --all-extras: heavy deps (mlflow, torchmetrics, ibis, matplotlib, ...) moved out of
+        # core into optional extras; tests import those modules, so install everything.
+        run: uv run --all-extras --group tests pytest -m "not slow and not integration" --cov=mermaidseg --cov-report=term-missing

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
-.PHONY: sync logs lcc-log check kernel
+.PHONY: help sync logs lcc-log check kernel
+
+help:
+	@echo "MermaidSeg Makefile targets:"
+	@echo "  make sync     — git pull + uv sync --all-extras + register Jupyter kernel (SageMaker LCC)"
+	@echo "  make kernel   — register Jupyter kernel only (uses --all-extras)"
+	@echo "  make check    — validate env vars, AWS session, MLflow version (uses --all-extras)"
+	@echo "  make logs     — tail logs/train_*.log"
+	@echo "  make lcc-log  — tail ~/lcc-setup.log (LCC background sync progress)"
 
 # Re-sync the uv environment and Jupyter kernel from the current branch.
 # Equivalent to re-running the LCC without restarting the space.
@@ -6,9 +14,10 @@ sync:
 	bash scripts/sync_env.sh
 
 # Register the Jupyter kernel only (no git pull, no uv sync).
-# Useful after a full uv sync already ran.
+# --all-extras so ipykernel (now in the `notebooks` extra) is present and not
+# pruned from the env by `uv run`.
 kernel:
-	uv run python -m ipykernel install \
+	uv run --all-extras python -m ipykernel install \
 		--user \
 		--name=mermaid-seg \
 		--display-name "Python (mermaid-seg)"
@@ -23,8 +32,9 @@ lcc-log:
 	tail -f ~/lcc-setup.log
 
 # Validate the notebook environment: env vars, AWS session, MLflow version.
+# --all-extras: nb_setup imports mlflow (now in the `training` extra).
 check:
-	uv run python -c "\
+	uv run --all-extras python -c "\
 from nbs.nb_setup import check_env, check_aws_session, check_mlflow_version; \
 check_env(); \
 check_aws_session(); \

--- a/README.md
+++ b/README.md
@@ -141,12 +141,12 @@ uv sync --group dev --all-extras
 
 **Run all unit tests:**
 ```bash
-uv run --all-extras --group dev pytest -m "not slow and not integration"
+uv run --all-extras --group dev pytest -m "not slow and not integration and not live"
 ```
 
 **Run only unit tests (skip integration tests):**
 ```bash
-uv run --all-extras --group dev pytest -m "not integration"
+uv run --all-extras --group dev pytest -m "not integration and not live"
 ```
 
 **Run specific test file:**

--- a/README.md
+++ b/README.md
@@ -32,20 +32,38 @@ export MLFLOW_TRACKING_URI=arn:aws:sagemaker:{region}:{account-id}:mlflow-app/{a
 hf auth login
 # Or add your token to .env: echo "HF_TOKEN=hf_xxxxxxxxxxxx" >> .env
 
-# Install core dependencies
+# Install core dependencies (inference + data-loading runtime only)
 uv sync
 ```
 
 **Install optional extras / groups** as needed:
-```bash
-uv sync --group dev          # tests + lint (contributor setup)
-uv sync --extra training     # mlflow, sagemaker-mlflow, torchmetrics, wandb
-uv sync --extra notebooks    # Jupyter + plotting + ibis/duckdb ETL + CoralNet scraper
-uv sync --extra demo         # gradio demo app
-uv sync --all-extras         # everything (equivalent to the `all` extra)
 
-# Combine
-uv sync --group dev --extra notebooks
+| What you're doing | Command |
+|-------------------|---------|
+| Run the model / inference | `uv sync` |
+| Train + experiment tracking (mlflow, sagemaker-mlflow, torchmetrics, wandb) | `uv sync --extra training` |
+| Notebooks / plotting / ibis-duckdb ETL / CoralNet scraper | `uv sync --extra notebooks` |
+| Gradio demo (`demo/`) | `uv sync --extra demo` |
+| Contributor checkout (tests + lint + docformatter) | `uv sync --group dev` |
+| Everything | `uv sync --group dev --all-extras` |
+
+```bash
+# Examples
+uv sync --extra training --extra notebooks   # train from Jupyter
+uv sync --group dev --all-extras             # full contributor setup
+```
+
+> `--group` selects PEP-735 dependency groups (`dev`, `tests`, `lint`); `--extra`
+> selects optional features. Pass the same flags to `uv run` when a command needs
+> them (e.g. `uv run --extra notebooks coralnet-etl …`).
+
+**SageMaker JupyterLab** — after `git pull` or when `pyproject.toml` changes:
+
+```bash
+make sync      # pull, uv sync --all-extras, register kernel
+make check     # verify AWS / MLflow / env vars
+make kernel    # re-register kernel only
+make lcc-log   # tail background LCC setup log
 ```
 
 
@@ -115,23 +133,25 @@ To evaluate any trained segmentation model, you can use the notebook `nbs/Model_
 
 ### Running Tests
 
+Install test dependencies first (CI uses `--all-extras` because tests import mlflow, ibis, etc.):
+
 ```bash
-uv sync --group tests
+uv sync --group dev --all-extras
 ```
 
-**Run all tests:**
+**Run all unit tests:**
 ```bash
-uv run pytest
+uv run --all-extras --group dev pytest -m "not slow and not integration"
 ```
 
 **Run only unit tests (skip integration tests):**
 ```bash
-uv run pytest -m "not integration"
+uv run --all-extras --group dev pytest -m "not integration"
 ```
 
 **Run specific test file:**
 ```bash
-uv run pytest tests/test_logger.py -v
+uv run --all-extras --group dev pytest tests/test_logger.py -v
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -36,15 +36,16 @@ hf auth login
 uv sync
 ```
 
-**Install optional dependency groups** as needed:
+**Install optional extras / groups** as needed:
 ```bash
-uv sync --group dev         # tests + lint (contributor setup)
-uv sync --group notebooks   # Jupyter, hvplot, ibis, great-tables
-uv sync --extra scraping    # selenium, webdriver-manager
-uv sync --extra smp         # segmentation-models-pytorch (optional model backend)
+uv sync --group dev          # tests + lint (contributor setup)
+uv sync --extra training     # mlflow, sagemaker-mlflow, torchmetrics, wandb
+uv sync --extra notebooks    # Jupyter + plotting + ibis/duckdb ETL + CoralNet scraper
+uv sync --extra demo         # gradio demo app
+uv sync --all-extras         # everything (equivalent to the `all` extra)
 
 # Combine
-uv sync --group dev --group notebooks
+uv sync --group dev --extra notebooks
 ```
 
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -35,13 +35,13 @@ uv sync --extra demo
 export DEMO_CHECKPOINT=/path/to/model_checkpoint
 export DEMO_MODEL_CONFIG=configs/model_config_cbm_dpt_lora_vitl.yaml
 # optional: export DEMO_TAXONOMY_CSV=configs/class_to_concepts.csv
-uv run python demo/app.py --port 7860
+uv run --extra demo python demo/app.py --port 7860
 ```
 
 Or pass paths explicitly:
 
 ```bash
-uv run python demo/app.py \
+uv run --extra demo python demo/app.py \
   --checkpoint /path/to/checkpoint \
   --model-config configs/model_config_cbm_dpt_lora_vitl.yaml \
   --taxonomy-csv configs/class_to_concepts.csv

--- a/mermaidseg/datasets/coralnet/README.md
+++ b/mermaidseg/datasets/coralnet/README.md
@@ -44,17 +44,17 @@ training runs keep working until you publish a new default. See
 When the audit parquet shows `not is_complete` for some `source_id` values,
 export them (for example via `incomplete_df.parquet` in the EDA notebook), then:
 
-1. `uv run coralnet-remediate probe --audit-parquet … --incomplete-parquet …`
+1. `uv run --extra notebooks coralnet-remediate probe --audit-parquet … --incomplete-parquet …`
    merges audit columns with a live CoralNet probe and writes
    `reconciliation_report.parquet`.
-2. `uv run coralnet-remediate redownload --report reconciliation_report.parquet`
+2. `uv run --extra notebooks coralnet-remediate redownload --report reconciliation_report.parquet`
    applies categorized fixes (omit `--dry-run` for real uploads). Sources whose
    overview shows **Confirmed: 0** (parsed from the Image Status table) get
    `skip_no_confirmed_annotations` and are not redownloaded. Optionally use
    `--clean-prefix` plus `CORALNET_*` credentials in the environment
    (`CORALNET_USERNAME` / `CORALNET_PASSWORD`).
 3. Re-audit only touched IDs:
-   `uv run coralnet-etl audit --source-ids-file incomplete_df.parquet …`.
+   `uv run --extra notebooks coralnet-etl audit --source-ids-file incomplete_df.parquet …`.
 
 Bulk rescrape of newly listed public sources:
 Sources with **Confirmed: 0** on the overview page are skipped at download time (same rule as remediation).
@@ -76,17 +76,18 @@ print(n_ok, n_total, img_dir)
 `python -m mermaidseg.datasets.coralnet.scraper.scrape_coralnet_s3`
 (supports `--audit-parquet`, `--force`, `--no-legacy-skip-annotations`; see `-h`).
 
-**Offline tests** (CI default):
+**Offline tests** (CI default; needs `--all-extras` because tests import ibis/mlflow helpers):
 
 ```sh
-uv run pytest tests/datasets/coralnet/ -q
+uv sync --group dev --all-extras
+uv run --all-extras --group dev pytest tests/datasets/coralnet/ -q
 ```
 
 **Live validation** (Playwright against coralnet.ucsd.edu; not run in CI):
 
 ```sh
-uv run sync --extra test-live
-uv run playwright install chromium
+uv sync --extra test-live
+uv run --extra test-live playwright install chromium
 uv run --extra test-live pytest tests/datasets/coralnet/test_live_smoke.py -m live -v
 ```
 

--- a/mermaidseg/datasets/coralnet/README.md
+++ b/mermaidseg/datasets/coralnet/README.md
@@ -65,7 +65,7 @@ Local image smoke test for a single source (writes JPEGs under `outputs/`; publi
 such as 7238 do not require CoralNet credentials):
 
 ```sh
-uv run python -c "
+uv run --extra notebooks python -c "
 from pathlib import Path
 from mermaidseg.datasets.coralnet.scraper.downloader import CoralNetDownloader
 dest = Path('outputs/coralnet-source-7238-test/s7238')
@@ -105,7 +105,7 @@ export CORALNET_USERNAME='you@example.com'
 export CORALNET_PASSWORD='your-password'
 
 # Quick login check (requests, same path as the scraper)
-uv run python -c "
+uv run --extra notebooks python -c "
 import os, sys
 from mermaidseg.datasets.coralnet.scraper.downloader import CoralNetDownloader
 u, p = os.environ.get('CORALNET_USERNAME'), os.environ.get('CORALNET_PASSWORD')

--- a/nbs/nb_setup.py
+++ b/nbs/nb_setup.py
@@ -79,14 +79,14 @@ def check_mlflow_version() -> None:
 
     The Serverless MLflow App runs 3.2.0+; mismatched versions break the
     'Models (Experimental)' tab and produce different S3 artifact paths.
-    Fix: run ``uv sync --group notebooks`` from the project directory.
+    Fix: run ``uv sync --extra training`` (or ``uv sync --all-extras``) from the project directory.
     """
     version = mlflow.__version__
     if tuple(int(x) for x in version.split(".")[:2]) < (3, 0):
         warnings.warn(
             f"MLflow {version} is older than 3.x. The Serverless App runs 3.x; "
             "artifact paths and the 'Models (Experimental)' tab may behave differently.\n"
-            "Fix: uv sync --group notebooks",
+            "Fix: uv sync --extra training  (or: uv sync --all-extras)",
             stacklevel=2,
         )
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,35 +7,25 @@ name = "mermaidseg"
 version = "0.1.0"
 description = "A package for the segmentation of MERMAID coral data."
 requires-python = ">=3.11"
+# Core = the inference + data-loading runtime (what the demo / model import chain needs).
+# Training and notebook/exploration tooling (plotting, ETL, scraper) live in optional
+# extras below; install everything with `mermaidseg[all]`. See [project.optional-dependencies].
 dependencies = [
     "albumentations",
-    "beautifulsoup4",
     "boto3",
-    "numpy>=1.24,<2",
-    "pandas",
-    "pillow",
-    "requests",
-    "torch>=2.4,<2.8",
-    "transformers",
     "datasets>=3.0",
-    "s3fs",
-    "segmentation-models-pytorch",
-    "mlflow",
-    "pyyaml",
-    "tqdm",
-    "torchmetrics",
-    "anytree",
-    "openpyxl",
-    "ipykernel>=7.2.0",
-    "matplotlib>=3.10.8",
     "huggingface-hub>=0.36.2",
-    "seaborn>=0.13.2",
+    "numpy>=1.24,<2",
     "opencv-python-headless>=4.11.0.86",
-    "sagemaker-mlflow>=0.2.0",
-    "requests-auth-aws-sigv4>=0.7",
-    "safetensors>=0.4.0",
-    "ibis-framework[duckdb]>=9.0",
+    "pandas",
     "peft>=0.19.1",
+    "pillow",
+    "pyyaml",
+    "requests",
+    "safetensors>=0.4.0",
+    "torch>=2.4,<2.8",
+    "tqdm",
+    "transformers",
 ]
 
 [project.scripts]
@@ -43,22 +33,37 @@ coralnet-etl = "mermaidseg.datasets.coralnet.etl.__main__:main"
 coralnet-remediate = "mermaidseg.datasets.coralnet.scraper.remediate_incomplete:main"
 
 [project.optional-dependencies]
+# Experiment tracking + training-time metrics (logger.py, model/eval.py).
+training = [
+    "mlflow",
+    "sagemaker-mlflow>=0.2.0",
+    "torchmetrics",
+    "wandb>=0.25.0",
+]
+# Interactive / exploratory tooling: notebooks + plotting (viz), ibis/duckdb ETL
+# (datasets/coralnet/etl, preprocessing), and the CoralNet scraper
+# (datasets/coralnet/scraper).
 notebooks = [
     "jupyter",
     "ipywidgets",
-    "wandb>=0.25.0",
+    "ipykernel>=7.2.0",
     "hvplot>=0.12.2",
     "great-tables>=0.21.0",
-]
-scraping = [
+    "matplotlib>=3.10.8",
+    "ibis-framework[duckdb]>=9.0",
     "selenium",
     "webdriver-manager",
+    "beautifulsoup4",
 ]
 test-live = [
     "playwright>=1.50",
 ]
 demo = [
-    "gradio>=5.0",
+    "gradio>=6.0",
+]
+# Everything: convenience for CI / dev / full local installs.
+all = [
+    "mermaidseg[training,notebooks,demo]",
 ]
 
 [dependency-groups]

--- a/scripts/lcc_setup.sh
+++ b/scripts/lcc_setup.sh
@@ -71,14 +71,14 @@ nohup bash -c "
   export PATH=\"$HOME/.local/bin:\$PATH\"
   cd '$PROJECT_DIR'
   echo \"[LCC bg] Starting uv sync \$(date)\"
-  uv sync --group notebooks --locked
+  uv sync --all-extras --locked
   echo \"[LCC bg] uv sync complete \$(date)\"
-  uv run python -m ipykernel install \
+  uv run --all-extras python -m ipykernel install \
       --user \
       --name=mermaid-seg \
       --display-name 'Python (mermaid-seg)'
   echo '[LCC bg] Kernel registered: mermaid-seg'
-  uv run python -c \"
+  uv run --all-extras python -c \"
 import mermaidseg, mlflow
 v = getattr(mermaidseg, '__version__', 'dev')
 print(f'[LCC bg] OK: mermaidseg={v}, mlflow={mlflow.__version__}')

--- a/scripts/sync_env.sh
+++ b/scripts/sync_env.sh
@@ -27,17 +27,17 @@ if [ "$NO_PULL" = false ]; then
     git pull --ff-only
 fi
 
-echo "Syncing uv environment (--group notebooks --locked)..."
-uv sync --group notebooks --locked
+echo "Syncing uv environment (--all-extras --locked)..."
+uv sync --all-extras --locked
 
 echo "Registering Jupyter kernel..."
-uv run python -m ipykernel install \
+uv run --all-extras python -m ipykernel install \
     --user \
     --name=mermaid-seg \
     --display-name "Python (mermaid-seg)"
 
 echo "Sanity check..."
-uv run python -c "
+uv run --all-extras python -c "
 import mermaidseg, mlflow
 v = getattr(mermaidseg, '__version__', 'dev')
 print(f'OK: mermaidseg={v}, mlflow={mlflow.__version__}')

--- a/uv.lock
+++ b/uv.lock
@@ -237,15 +237,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anytree"
-version = "2.13.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/a8/eb55fab589c56f9b6be2b3fd6997aa04bb6f3da93b01154ce6fc8e799db2/anytree-2.13.0.tar.gz", hash = "sha256:c9d3aa6825fdd06af7ebb05b4ef291d2db63e62bb1f9b7d9b71354be9d362714", size = 48389, upload-time = "2025-04-08T21:06:30.662Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/98/f6aa7fe0783e42be3093d8ef1b0ecdc22c34c0d69640dfb37f56925cb141/anytree-2.13.0-py3-none-any.whl", hash = "sha256:4cbcf10df36b1f1cba131b7e487ff3edafc9d6e932a3c70071b5b768bab901ff", size = 45077, upload-time = "2025-04-08T21:06:29.494Z" },
-]
-
-[[package]]
 name = "appnope"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1204,15 +1195,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/b1/1464f468d2e5813f5808de95df9d3113a645a5bfa2ffcaecbc542ddae272/duckdb-1.5.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be37680ddb380015cb37318e378c53511c45c4f0d8fac5599d22b7d092b9217a", size = 21434056, upload-time = "2026-04-13T11:30:01.238Z" },
     { url = "https://files.pythonhosted.org/packages/ce/32/6673607e024722473fa7aafdd29c0e3dd231dd528f6cd8b5797fbeeb229d/duckdb-1.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:0b291786014df1133f8f18b9df4d004484613146e858d71a21791e0fcca16cf4", size = 13633667, upload-time = "2026-04-13T11:30:04.05Z" },
     { url = "https://files.pythonhosted.org/packages/7a/e3/9d34173ec068631faea3ea6e73050700729363e7e33306a9a3218e5cdc61/duckdb-1.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:c9f3e0b71b8a50fccfb42794899285d9d318ce2503782b9dd54868e5ecd0ad31", size = 14402513, upload-time = "2026-04-13T11:30:06.609Z" },
-]
-
-[[package]]
-name = "et-xmlfile"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
 ]
 
 [[package]]
@@ -2724,54 +2706,65 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "albumentations" },
-    { name = "anytree" },
-    { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "datasets" },
     { name = "huggingface-hub", version = "0.36.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
     { name = "huggingface-hub", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
-    { name = "ibis-framework", extra = ["duckdb"] },
-    { name = "ipykernel" },
-    { name = "matplotlib" },
-    { name = "mlflow" },
     { name = "numpy" },
     { name = "opencv-python-headless" },
-    { name = "openpyxl" },
     { name = "pandas" },
     { name = "peft" },
     { name = "pillow" },
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "requests-auth-aws-sigv4" },
-    { name = "s3fs" },
     { name = "safetensors" },
-    { name = "sagemaker-mlflow" },
-    { name = "seaborn" },
-    { name = "segmentation-models-pytorch" },
     { name = "torch" },
-    { name = "torchmetrics" },
     { name = "tqdm" },
     { name = "transformers", version = "4.57.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
     { name = "transformers", version = "5.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "beautifulsoup4" },
+    { name = "gradio" },
+    { name = "great-tables" },
+    { name = "hvplot" },
+    { name = "ibis-framework", extra = ["duckdb"] },
+    { name = "ipykernel" },
+    { name = "ipywidgets" },
+    { name = "jupyter" },
+    { name = "matplotlib" },
+    { name = "mlflow" },
+    { name = "sagemaker-mlflow" },
+    { name = "selenium" },
+    { name = "torchmetrics" },
+    { name = "wandb" },
+    { name = "webdriver-manager" },
+]
 demo = [
     { name = "gradio" },
 ]
 notebooks = [
+    { name = "beautifulsoup4" },
     { name = "great-tables" },
     { name = "hvplot" },
+    { name = "ibis-framework", extra = ["duckdb"] },
+    { name = "ipykernel" },
     { name = "ipywidgets" },
     { name = "jupyter" },
-    { name = "wandb" },
-]
-scraping = [
+    { name = "matplotlib" },
     { name = "selenium" },
     { name = "webdriver-manager" },
 ]
 test-live = [
     { name = "playwright" },
+]
+training = [
+    { name = "mlflow" },
+    { name = "sagemaker-mlflow" },
+    { name = "torchmetrics" },
+    { name = "wandb" },
 ]
 
 [package.dev-dependencies]
@@ -2794,44 +2787,39 @@ tests = [
 [package.metadata]
 requires-dist = [
     { name = "albumentations" },
-    { name = "anytree" },
-    { name = "beautifulsoup4" },
+    { name = "beautifulsoup4", marker = "extra == 'notebooks'" },
     { name = "boto3" },
     { name = "datasets", specifier = ">=3.0" },
-    { name = "gradio", marker = "extra == 'demo'", specifier = ">=5.0" },
+    { name = "gradio", marker = "extra == 'demo'", specifier = ">=6.0" },
     { name = "great-tables", marker = "extra == 'notebooks'", specifier = ">=0.21.0" },
     { name = "huggingface-hub", specifier = ">=0.36.2" },
     { name = "hvplot", marker = "extra == 'notebooks'", specifier = ">=0.12.2" },
-    { name = "ibis-framework", extras = ["duckdb"], specifier = ">=9.0" },
-    { name = "ipykernel", specifier = ">=7.2.0" },
+    { name = "ibis-framework", extras = ["duckdb"], marker = "extra == 'notebooks'", specifier = ">=9.0" },
+    { name = "ipykernel", marker = "extra == 'notebooks'", specifier = ">=7.2.0" },
     { name = "ipywidgets", marker = "extra == 'notebooks'" },
     { name = "jupyter", marker = "extra == 'notebooks'" },
-    { name = "matplotlib", specifier = ">=3.10.8" },
-    { name = "mlflow" },
+    { name = "matplotlib", marker = "extra == 'notebooks'", specifier = ">=3.10.8" },
+    { name = "mermaidseg", extras = ["training", "notebooks", "demo"], marker = "extra == 'all'" },
+    { name = "mlflow", marker = "extra == 'training'" },
     { name = "numpy", specifier = ">=1.24,<2" },
     { name = "opencv-python-headless", specifier = ">=4.11.0.86" },
-    { name = "openpyxl" },
     { name = "pandas" },
     { name = "peft", specifier = ">=0.19.1" },
     { name = "pillow" },
     { name = "playwright", marker = "extra == 'test-live'", specifier = ">=1.50" },
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "requests-auth-aws-sigv4", specifier = ">=0.7" },
-    { name = "s3fs" },
     { name = "safetensors", specifier = ">=0.4.0" },
-    { name = "sagemaker-mlflow", specifier = ">=0.2.0" },
-    { name = "seaborn", specifier = ">=0.13.2" },
-    { name = "segmentation-models-pytorch" },
-    { name = "selenium", marker = "extra == 'scraping'" },
+    { name = "sagemaker-mlflow", marker = "extra == 'training'", specifier = ">=0.2.0" },
+    { name = "selenium", marker = "extra == 'notebooks'" },
     { name = "torch", specifier = ">=2.4,<2.8" },
-    { name = "torchmetrics" },
+    { name = "torchmetrics", marker = "extra == 'training'" },
     { name = "tqdm" },
     { name = "transformers" },
-    { name = "wandb", marker = "extra == 'notebooks'", specifier = ">=0.25.0" },
-    { name = "webdriver-manager", marker = "extra == 'scraping'" },
+    { name = "wandb", marker = "extra == 'training'", specifier = ">=0.25.0" },
+    { name = "webdriver-manager", marker = "extra == 'notebooks'" },
 ]
-provides-extras = ["notebooks", "scraping", "test-live", "demo"]
+provides-extras = ["training", "notebooks", "test-live", "demo", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3406,18 +3394,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/5c/c139a7876099916879609372bfa513b7f1257f7f1a908b0bdc1c2328241b/opencv_python_headless-4.11.0.86-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e0a27c19dd1f40ddff94976cfe43066fbbe9dfbb2ec1907d66c19caef42a57b", size = 49969856, upload-time = "2025-01-16T13:53:29.654Z" },
     { url = "https://files.pythonhosted.org/packages/95/dd/ed1191c9dc91abcc9f752b499b7928aacabf10567bb2c2535944d848af18/opencv_python_headless-4.11.0.86-cp37-abi3-win32.whl", hash = "sha256:f447d8acbb0b6f2808da71fddd29c1cdd448d2bc98f72d9bb78a7a898fc9621b", size = 29324425, upload-time = "2025-01-16T13:52:49.048Z" },
     { url = "https://files.pythonhosted.org/packages/86/8a/69176a64335aed183529207ba8bc3d329c2999d852b4f3818027203f50e6/opencv_python_headless-4.11.0.86-cp37-abi3-win_amd64.whl", hash = "sha256:6c304df9caa7a6a5710b91709dd4786bf20a74d57672b3c31f7033cc638174ca", size = 39402386, upload-time = "2025-01-16T13:52:56.418Z" },
-]
-
-[[package]]
-name = "openpyxl"
-version = "3.1.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "et-xmlfile" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]
@@ -4711,18 +4687,6 @@ wheels = [
 ]
 
 [[package]]
-name = "requests-auth-aws-sigv4"
-version = "0.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/bc/f695cd7d54327f925e22293d5b71b312dcdee0d8e720defc7a7a5f16a5ae/requests-auth-aws-sigv4-0.7.tar.gz", hash = "sha256:3d2a475cccbf85d4c93b8bd052d072e5c3f8e77022fd621b69a5b11ac2c139c8", size = 8128, upload-time = "2021-02-16T21:31:04.325Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/cd/112ece576115a8afa62faf3c10d13fb8c72233197926f3ea6321cc2cc44e/requests_auth_aws_sigv4-0.7-py3-none-any.whl", hash = "sha256:1f6c7f63a0696a8f131a2ff21a544380f43c11f54d72600f6f2a1d402bd41d41", size = 12075, upload-time = "2021-02-16T21:31:03.444Z" },
-]
-
-[[package]]
 name = "rfc3339-validator"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -4899,19 +4863,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
     { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
     { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
-]
-
-[[package]]
-name = "s3fs"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-    { name = "fsspec" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/504cb277632c4d325beabbd03bb43778f0decb9be22d9e0e6c62f44540c7/s3fs-0.4.2.tar.gz", hash = "sha256:2ca5de8dc18ad7ad350c0bd01aef0406aa5d0fff78a561f0f710f9d9858abdd0", size = 57527, upload-time = "2020-03-31T15:24:26.388Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/e4/b8fc59248399d2482b39340ec9be4bb2493846ac23641b43115a7e5cd675/s3fs-0.4.2-py3-none-any.whl", hash = "sha256:91c1dfb45e5217bd441a7a560946fe865ced6225ff7eb0fb459fe6e601a95ed3", size = 19791, upload-time = "2020-03-31T15:24:24.952Z" },
 ]
 
 [[package]]
@@ -5092,40 +5043,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
     { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
     { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
-]
-
-[[package]]
-name = "seaborn"
-version = "0.13.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "matplotlib" },
-    { name = "numpy" },
-    { name = "pandas" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696, upload-time = "2024-01-25T13:21:52.551Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987", size = 294914, upload-time = "2024-01-25T13:21:49.598Z" },
-]
-
-[[package]]
-name = "segmentation-models-pytorch"
-version = "0.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "huggingface-hub", version = "0.36.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
-    { name = "huggingface-hub", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "safetensors" },
-    { name = "timm" },
-    { name = "torch" },
-    { name = "torchvision" },
-    { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/15/fa/d5a29d49240fb10bdead608b4d0c6805684a8f63b1f65863502be65b1ca4/segmentation_models_pytorch-0.5.0.tar.gz", hash = "sha256:cabba8aced6ef7bdcd6288dd9e1dc2840848aa819d539c455bd07aeceb2fdf96", size = 105150, upload-time = "2025-04-17T10:43:45.755Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/62/a50e5ac6191a498ad631e54df13d7e2d7eeb1325b15ee9ea1ee3ec065aaa/segmentation_models_pytorch-0.5.0-py3-none-any.whl", hash = "sha256:c34e09047771aa4dd8878b4f899e8125700cd1f8f7db16e58c37204154151a05", size = 154789, upload-time = "2025-04-17T10:43:43.668Z" },
 ]
 
 [[package]]
@@ -5507,23 +5424,6 @@ wheels = [
 ]
 
 [[package]]
-name = "timm"
-version = "1.0.26"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "huggingface-hub", version = "0.36.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
-    { name = "huggingface-hub", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or sys_platform != 'darwin'" },
-    { name = "pyyaml" },
-    { name = "safetensors" },
-    { name = "torch" },
-    { name = "torchvision" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/1e/e924b3b2326a856aaf68586f9c52a5fc81ef45715eca408393b68c597e0e/timm-1.0.26.tar.gz", hash = "sha256:f66f082f2f381cf68431c22714c8b70f723837fa2a185b155961eab90f2d5b10", size = 2419859, upload-time = "2026-03-23T18:12:10.272Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/e9/bebf3d50e3fc847378988235f87c37ad3ac26d386041ab915d15e92025cd/timm-1.0.26-py3-none-any.whl", hash = "sha256:985c330de5ccc3a2aa0224eb7272e6a336084702390bb7e3801f3c91603d3683", size = 2568766, upload-time = "2026-03-23T18:12:08.062Z" },
-]
-
-[[package]]
 name = "tinycss2"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5694,34 +5594,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/34/39b8b749333db56c0585d7a11fa62a283c087bb1dfc897d69fb8cedbefb1/torchmetrics-1.9.0.tar.gz", hash = "sha256:a488609948600df52d3db4fcdab02e62aab2a85ef34da67037dc3e65b8512faa", size = 581765, upload-time = "2026-03-09T17:41:22.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/a2/c7f6ebf546f8f644edf0f999aa98ece106986a77a7b922316bf6414ff825/torchmetrics-1.9.0-py3-none-any.whl", hash = "sha256:bfdcbff3dd1d96b3374bb2496eb39f23c4b28b8a845b6a18c313688e0d2d9ca1", size = 983384, upload-time = "2026-03-09T17:41:19.756Z" },
-]
-
-[[package]]
-name = "torchvision"
-version = "0.22.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "torch" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/00/bdab236ef19da050290abc2b5203ff9945c84a1f2c7aab73e8e9c8c85669/torchvision-0.22.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4addf626e2b57fc22fd6d329cf1346d474497672e6af8383b7b5b636fba94a53", size = 1947827, upload-time = "2025-06-04T17:43:10.84Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/d0/18f951b2be3cfe48c0027b349dcc6fde950e3dc95dd83e037e86f284f6fd/torchvision-0.22.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:8b4a53a6067d63adba0c52f2b8dd2290db649d642021674ee43c0c922f0c6a69", size = 2514021, upload-time = "2025-06-04T17:43:07.608Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/1a/63eb241598b36d37a0221e10af357da34bd33402ccf5c0765e389642218a/torchvision-0.22.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b7866a3b326413e67724ac46f1ee594996735e10521ba9e6cdbe0fa3cd98c2f2", size = 7487300, upload-time = "2025-06-04T17:42:58.349Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/73/1b009b42fe4a7774ba19c23c26bb0f020d68525c417a348b166f1c56044f/torchvision-0.22.1-cp311-cp311-win_amd64.whl", hash = "sha256:bb3f6df6f8fd415ce38ec4fd338376ad40c62e86052d7fc706a0dd51efac1718", size = 1707989, upload-time = "2025-06-04T17:43:14.332Z" },
-    { url = "https://files.pythonhosted.org/packages/02/90/f4e99a5112dc221cf68a485e853cc3d9f3f1787cb950b895f3ea26d1ea98/torchvision-0.22.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:153f1790e505bd6da123e21eee6e83e2e155df05c0fe7d56347303067d8543c5", size = 1947827, upload-time = "2025-06-04T17:43:11.945Z" },
-    { url = "https://files.pythonhosted.org/packages/25/f6/53e65384cdbbe732cc2106bb04f7fb908487e4fb02ae4a1613ce6904a122/torchvision-0.22.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:964414eef19459d55a10e886e2fca50677550e243586d1678f65e3f6f6bac47a", size = 2514576, upload-time = "2025-06-04T17:43:02.707Z" },
-    { url = "https://files.pythonhosted.org/packages/17/8b/155f99042f9319bd7759536779b2a5b67cbd4f89c380854670850f89a2f4/torchvision-0.22.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:699c2d70d33951187f6ed910ea05720b9b4aaac1dcc1135f53162ce7d42481d3", size = 7485962, upload-time = "2025-06-04T17:42:43.606Z" },
-    { url = "https://files.pythonhosted.org/packages/05/17/e45d5cd3627efdb47587a0634179a3533593436219de3f20c743672d2a79/torchvision-0.22.1-cp312-cp312-win_amd64.whl", hash = "sha256:75e0897da7a8e43d78632f66f2bdc4f6e26da8d3f021a7c0fa83746073c2597b", size = 1707992, upload-time = "2025-06-04T17:42:53.207Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/30/fecdd09fb973e963da68207fe9f3d03ec6f39a935516dc2a98397bf495c6/torchvision-0.22.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9c3ae3319624c43cc8127020f46c14aa878406781f0899bb6283ae474afeafbf", size = 1947818, upload-time = "2025-06-04T17:42:51.954Z" },
-    { url = "https://files.pythonhosted.org/packages/55/f4/b45f6cd92fa0acfac5e31b8e9258232f25bcdb0709a604e8b8a39d76e411/torchvision-0.22.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:4a614a6a408d2ed74208d0ea6c28a2fbb68290e9a7df206c5fef3f0b6865d307", size = 2471597, upload-time = "2025-06-04T17:42:48.838Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/b0/3cffd6a285b5ffee3fe4a31caff49e350c98c5963854474d1c4f7a51dea5/torchvision-0.22.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:7ee682be589bb1a002b7704f06b8ec0b89e4b9068f48e79307d2c6e937a9fdf4", size = 7485894, upload-time = "2025-06-04T17:43:01.371Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/1d/0ede596fedc2080d18108149921278b59f220fbb398f29619495337b0f86/torchvision-0.22.1-cp313-cp313-win_amd64.whl", hash = "sha256:2566cafcfa47ecfdbeed04bab8cef1307c8d4ef75046f7624b9e55f384880dfe", size = 1708020, upload-time = "2025-06-04T17:43:06.085Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/ca/e9a06bd61ee8e04fb4962a3fb524fe6ee4051662db07840b702a9f339b24/torchvision-0.22.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:043d9e35ed69c2e586aff6eb9e2887382e7863707115668ac9d140da58f42cba", size = 2137623, upload-time = "2025-06-04T17:43:05.028Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/c8/2ebe90f18e7ffa2120f5c3eab62aa86923185f78d2d051a455ea91461608/torchvision-0.22.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:27142bcc8a984227a6dcf560985e83f52b82a7d3f5fe9051af586a2ccc46ef26", size = 2476561, upload-time = "2025-06-04T17:42:59.691Z" },
-    { url = "https://files.pythonhosted.org/packages/94/8b/04c6b15f8c29b39f0679589753091cec8b192ab296d4fdaf9055544c4ec9/torchvision-0.22.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ef46e065502f7300ad6abc98554131c35dc4c837b978d91306658f1a65c00baa", size = 7658543, upload-time = "2025-06-04T17:42:46.064Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/c0/131628e6d42682b0502c63fd7f647b8b5ca4bd94088f6c85ca7225db8ac4/torchvision-0.22.1-cp313-cp313t-win_amd64.whl", hash = "sha256:7414eeacfb941fa21acddcd725f1617da5630ec822e498660a4b864d7d998075", size = 1629892, upload-time = "2025-06-04T17:42:57.156Z" },
 ]
 
 [[package]]

--- a/wiki/Code-Style.md
+++ b/wiki/Code-Style.md
@@ -47,7 +47,7 @@ A focused change is easier to review, easier to revert if something goes wrong, 
 
 ## Before opening a PR
 
-- Run `uv run --all-extras --group dev pytest -m "not slow and not integration"` — all tests should pass
+- Run `uv run --all-extras --group dev pytest -m "not slow and not integration and not live"` — all tests should pass
 - Run `uv run --group dev ruff check .` — no errors
 - Run `uv run --group dev pre-commit run --all-files` — ensure local hooks pass before pushing (expensive in GitHub Actions)
 - Read through your own diff before assigning a reviewer — catch the obvious things yourself first

--- a/wiki/Code-Style.md
+++ b/wiki/Code-Style.md
@@ -11,8 +11,8 @@ Pre-commit runs [Ruff](https://docs.astral.sh/ruff/) on every commit, handling f
 If a commit fails because of a Ruff error, fix the flagged issue and commit again. You can also run Ruff manually:
 
 ```bash
-uv run ruff check .       # show linting errors
-uv run ruff format .      # auto-format code
+uv run --group dev ruff check .       # show linting errors
+uv run --group dev ruff format .      # auto-format code
 ```
 
 Ruff handles: import order, unused imports, unused variables, formatting consistency, and a broad set of common Python mistakes. You don't need to think about most of this — just let the hook run.
@@ -47,7 +47,7 @@ A focused change is easier to review, easier to revert if something goes wrong, 
 
 ## Before opening a PR
 
-- Run `uv run pytest` — all tests should pass
-- Run `uv run ruff check .` — no errors
-- Run `uv run pre-commit .` - to ensure local hooks are run before pushing (expensive in Github Actions)
+- Run `uv run --all-extras --group dev pytest -m "not slow and not integration"` — all tests should pass
+- Run `uv run --group dev ruff check .` — no errors
+- Run `uv run --group dev pre-commit run --all-files` — ensure local hooks pass before pushing (expensive in GitHub Actions)
 - Read through your own diff before assigning a reviewer — catch the obvious things yourself first

--- a/wiki/CoralNet-ETL.md
+++ b/wiki/CoralNet-ETL.md
@@ -19,19 +19,21 @@ artifact lives in the MERMAID API project.
 
 ## Quickstart
 
-Assumes `uv` is set up and AWS SSO is signed in.
+Assumes `uv` is set up and AWS SSO is signed in. The ETL uses ibis/duckdb, which
+live in the `notebooks` extra — install it once (`uv sync --extra notebooks`) and
+pass `--extra notebooks` to `uv run`.
 
 ```sh
 export AWS_PROFILE=mermaid-core
 
 # Dev smoke test (5 sources, low worker count) — finishes in a minute or two.
-uv run coralnet-etl all \
+uv run --extra notebooks coralnet-etl all \
   --limit-sources 5 \
   --output-dir ./outputs/coralnet-etl-dev \
   --workers 4
 
 # Full run + upload to the canonical ETL output prefix.
-uv run coralnet-etl all \
+uv run --extra notebooks coralnet-etl all \
   --workers 32 \
   --upload-to-s3
 ```

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -81,22 +81,54 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 ## 3. Install dependencies
 
+The core install is the inference + data-loading runtime only. Everything else
+lives in **optional extras** — install the ones for your workflow:
+
 ```bash
-uv sync --group tests --group lint --group notebooks
+uv sync                              # core only (run the model / inference)
+uv sync --group dev --all-extras     # contributors: tests + lint + every extra
 ```
+
+| What you're doing | Command |
+|-------------------|---------|
+| Run the model / inference | `uv sync` |
+| Train + experiment tracking (mlflow, sagemaker-mlflow, torchmetrics, wandb) | `uv sync --extra training` |
+| Notebooks / plotting / ibis-duckdb ETL / CoralNet scraper | `uv sync --extra notebooks` |
+| Gradio demo (`demo/`) | `uv sync --extra demo` |
+| Contributor checkout (tests + lint + docformatter) | `uv sync --group dev` |
+| Everything | `uv sync --group dev --all-extras` |
+
+> `--group` selects PEP-735 dependency groups (`dev`, `tests`, `lint`); `--extra`
+> selects optional features. `uv run` only keeps what the *last* sync requested, so
+> pass the same `--extra`/`--all-extras` flags to `uv run` when a command needs them
+> (e.g. `uv run --extra notebooks coralnet-etl …`).
+
+## 3b. SageMaker JupyterLab shortcuts
+
+On SageMaker spaces, use the Makefile after pulling or when dependencies change:
+
+```bash
+make sync      # git pull + uv sync --all-extras + register kernel
+make check     # verify MLFLOW_TRACKING_URI, AWS session, MLflow version
+make kernel    # re-register kernel only (no git pull)
+make lcc-log   # tail background LCC setup log
+```
+
+Run `make help` for the full list. After `make sync`, restart the Jupyter kernel
+(**Kernel → Restart Kernel**) so new packages are picked up.
 
 ## 4. Install pre-commit hooks
 
 Pre-commit runs Ruff (linting and formatting) automatically on each commit. Install it once:
 
 ```bash
-uv run pre-commit install
+uv run --group dev pre-commit install
 ```
 
 Verify it is installed correctly :
 
 ```bash
-uv run pre-commit --version
+uv run --group dev pre-commit --version
 ```
 
 ## 5. Set up your environment file
@@ -164,7 +196,7 @@ Ask the team lead for the `MLFLOW_TRACKING_URI` value (it points to the SageMake
 ## 10. Confirm everything works
 
 ```bash
-uv run pytest -m "not slow and not integration"
+uv run --all-extras --group dev pytest -m "not slow and not integration"
 ```
 
 All tests should pass. If they do, you're set up correctly.

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -196,7 +196,7 @@ Ask the team lead for the `MLFLOW_TRACKING_URI` value (it points to the SageMake
 ## 10. Confirm everything works
 
 ```bash
-uv run --all-extras --group dev pytest -m "not slow and not integration"
+uv run --all-extras --group dev pytest -m "not slow and not integration and not live"
 ```
 
 All tests should pass. If they do, you're set up correctly.

--- a/wiki/Reproducibility.md
+++ b/wiki/Reproducibility.md
@@ -61,7 +61,7 @@ MLflow run logged automatically
 Once an idea has been validated in a notebook, graduate to `scripts/train.py` for the full experiment. Scripts produce clean, repeatable runs that aren't affected by notebook state, are straightforward to re-run identically, and produce the model checkpoints suitable for sharing or deployment via MLflow.
 
 ```bash
-uv run python scripts/train.py --config configs/my_experiment.yaml
+uv run --extra training python scripts/train.py --config configs/my_experiment.yaml
 ```
 
 If you're preparing a model to share with the team or register in MLflow for model registration, it should ideally been trained through `train.py`, not a notebook.

--- a/wiki/Using-Notebooks.md
+++ b/wiki/Using-Notebooks.md
@@ -17,14 +17,34 @@ Jupyter notebooks are the primary way to run training and evaluation experiments
 
 ## Kernel setup
 
-Always use the project's virtual environment as your Jupyter kernel. After running `uv sync`, the kernel should appear in JupyterLab as something like **"Python (mermaid-segmentation)"** or the name of the project directory.
+Training notebooks need both the `notebooks` extra (Jupyter, plotting) and the
+`training` extra (MLflow). On SageMaker, `make sync` installs everything via
+`--all-extras`.
+
+```bash
+uv sync --extra notebooks --extra training   # local training setup
+# or
+uv sync --all-extras                         # everything
+```
+
+After sync, the kernel appears in JupyterLab as **Python (mermaid-seg)**.
 
 If the kernel isn't available:
+
 ```bash
-uv run python -m ipykernel install --user --name mermaid-segmentation
+make kernel
+# or manually:
+uv run --all-extras python -m ipykernel install --user --name mermaid-seg \
+  --display-name "Python (mermaid-seg)"
 ```
 
 Then restart JupyterLab and select it from the kernel menu.
+
+Validate the environment (env vars, AWS, MLflow):
+
+```bash
+make check
+```
 
 ---
 


### PR DESCRIPTION
## Slim core dependencies; move optional tooling to extras

Core `dependencies` had grown to 28 entries, many only needed for training, experiment tracking, ETL, plotting, or notebooks — so a plain `pip install mermaidseg` pulled in mlflow, sagemaker-mlflow, ibis/duckdb, databricks-sdk, Flask, ipykernel, matplotlib, selenium, … This slows every install (e.g. the HF Spaces demo).

### Changes
- **Core: 28 → 15 deps** — inference + data-loading only (torch, transformers, peft, datasets, boto3, albumentations, opencv, numpy, pandas, pillow, pyyaml, requests, safetensors, tqdm, huggingface-hub).
- **Extras:**
  - `training` = mlflow, sagemaker-mlflow, torchmetrics, wandb  (`logger.py`, `model/eval.py`)
  - `notebooks` = Jupyter stack + **matplotlib** (viz) + **ibis-framework[duckdb]** (coralnet ETL) + **selenium / webdriver-manager / beautifulsoup4** (coralnet scraper) — i.e. all interactive/exploration/data tooling in one extra
  - `demo` = gradio
  - `all` = `mermaidseg[training,notebooks,demo]`
- **Dropped (unused anywhere in `mermaidseg/`/`scripts/`):** s3fs, segmentation-models-pytorch, anytree, openpyxl, seaborn, requests-auth-aws-sigv4.
- **CI:** `tests.yml` now runs `uv run --all-extras --group tests …`.
- **README** setup section updated to the new extras.
- Regenerated `uv.lock`.

### Verification
- **core-only** install → demo import chain (`mermaidseg.model.models`, `dataset_reconciliation.concepts`) imports; `mermaidseg.logger` correctly fails (mlflow is now an extra).
- **`mermaidseg[all]`** → `logger`, `model.eval`, `visualization`, `coralnet.etl.io` all import.
- **`mermaidseg[notebooks]`** → pulls matplotlib, ibis/duckdb, selenium, webdriver-manager, beautifulsoup4, jupyter, hvplot, great-tables (the merged set).
- `uv lock` resolves cleanly.

### Notes
- Consumers needing training/ETL/viz/scraping must install the matching extra (`uv sync --all-extras`, or `mermaidseg[notebooks]` / `[training]`). CI is updated; **please check any SageMaker / Makefile / deployment scripts** that bare-`pip install mermaidseg`.
- The HF Spaces demo (#156) pins `mermaidseg` to a pre-slim SHA; it won't pick up the lighter install until repinned to a commit containing this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
