### PR TITLE
feat(sagemaker): generic SageMaker job launcher infrastructure (#131)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,14 +10,12 @@
 
 # AWS Profile (recommended: use 'mermaid-core' profile for S3 access)
 # AWS_PROFILE=mermaid-core
-
-# AWS Credentials (if not using ~/.aws/credentials)
-# Only needed if you're not using AWS profiles
-# AWS_ACCESS_KEY_ID=your_access_key_here
-# AWS_SECRET_ACCESS_KEY=your_secret_key_here
 # AWS_DEFAULT_REGION=us-east-1
 
-# MLflow Tracking (SageMaker MLflow App ARN, URL, or local path)
-# Set via: export MLFLOW_TRACKING_URI=arn:aws:sagemaker:us-east-1:123456789:mlflow-app/mermaid-mlflow
-# Or set in a notebook cell: os.environ["MLFLOW_TRACKING_URI"] = "arn:..."
-# MLFLOW_TRACKING_URI=arn:aws:sagemaker:us-east-1:123456789:mlflow-app/mermaid-mlflow
+# SageMaker launcher (make sm-check / sm-dry-run / sm-launch) — get values from team lead
+# SM_AWS_PROFILE=wcs-launcher
+# SM_ROLE_ARN=arn:aws:iam::ACCOUNT_ID:role/dev-sm-execution-role
+# MLFLOW_TRACKING_URI=arn:aws:sagemaker:us-east-1:ACCOUNT_ID:mlflow-app/app-XXXXXXXX
+# HF_TOKEN_SECRET_ARN=arn:aws:secretsmanager:us-east-1:ACCOUNT_ID:secret:hf-token-XXXX
+
+# AWS Credentials (if not using ~/.aws/credentials)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,4 +30,4 @@ repos:
     rev: v1.7.8
     hooks:
       - id: docformatter
-        args: [--wrap-summaries, "100", --wrap-descriptions, "100", --in-place]
+        args: [--black, --in-place]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: sync logs lcc-log check kernel
+.PHONY: sync logs lcc-log check kernel \
+	sm-sync sm-check sm-dry-run sm-launch sm-smoke sm-require-env
 
 # Re-sync the uv environment and Jupyter kernel from the current branch.
 # Equivalent to re-running the LCC without restarting the space.
@@ -29,3 +30,43 @@ from nbs.nb_setup import check_env, check_aws_session, check_mlflow_version; \
 check_env(); \
 check_aws_session(); \
 check_mlflow_version()"
+
+# --- SageMaker TrainingJob (see wiki/SageMaker-Jobs.md) ---
+# Account ARNs in .env (gitignored), loaded by direnv. Login: aws sso login --profile wcs-sso
+SM_CONFIG_DIR ?= sagemaker/configs/example
+SM_RUN_CONFIG ?= sagemaker/runs/example-training.yaml
+
+# Read from environment (.env + direnv). Profile name is not a secret.
+SM_AWS_ENV = AWS_DEFAULT_REGION=$(AWS_DEFAULT_REGION) AWS_PROFILE=$(SM_AWS_PROFILE)
+
+sm-require-env:
+	@test -n "$$SM_ROLE_ARN" || (echo "SM_ROLE_ARN not set — add to .env (see .env.example)" && exit 1)
+	@test -n "$$MLFLOW_TRACKING_URI" || (echo "MLFLOW_TRACKING_URI not set — add to .env (see .env.example)" && exit 1)
+	@test -n "$$SM_AWS_PROFILE" || (echo "SM_AWS_PROFILE not set — add to .env (e.g. wcs-launcher)" && exit 1)
+
+sm-sync:
+	uv sync --extra sagemaker
+
+sm-check: sm-require-env
+	$(SM_AWS_ENV) uv run --extra sagemaker python scripts/check_sagemaker_env.py \
+		--role-arn $(SM_ROLE_ARN) \
+		--check-hf-token
+
+sm-dry-run: sm-require-env
+	$(SM_AWS_ENV) uv run --extra sagemaker python scripts/launch_training.py \
+		--run-config $(SM_RUN_CONFIG) \
+		--config-dir $(SM_CONFIG_DIR)/ \
+		--mlflow-tracking-uri $(MLFLOW_TRACKING_URI) \
+		--role-arn $(SM_ROLE_ARN) \
+		--dry-run
+
+sm-launch: sm-require-env
+	$(SM_AWS_ENV) uv run --extra sagemaker python scripts/launch_training.py \
+		--run-config $(SM_RUN_CONFIG) \
+		--config-dir $(SM_CONFIG_DIR)/ \
+		--mlflow-tracking-uri $(MLFLOW_TRACKING_URI) \
+		--role-arn $(SM_ROLE_ARN) \
+		$(if $(HF_TOKEN),--hf-token $(HF_TOKEN),)
+
+sm-smoke:
+	bash docker/jobs/local_smoke.sh training

--- a/docker/jobs/CLAUDE.md
+++ b/docker/jobs/CLAUDE.md
@@ -1,0 +1,44 @@
+# docker/jobs/
+
+Container definition for SageMaker jobs launched by
+`scripts/launch_training.py` and `scripts/launch_processing.py`. One
+image, both job types — the launcher chooses which in-container
+entrypoint runs via `CONTAINER_ENTRYPOINT_SCRIPT`.
+
+## Files
+
+| File | What |
+| ---- | ---- |
+| `Dockerfile` | GPU image (PyTorch 2.4.1 CUDA 12.4, Python 3.11) with mermaidseg installed editable |
+| `entrypoint.sh` | Shim: `exec`s the script named by `CONTAINER_ENTRYPOINT_SCRIPT` |
+| `local_smoke.sh` | Build + run-locally test (`bash local_smoke.sh [training\|processing]`) |
+
+## Tag convention
+
+- `training-latest`, `training-smoke`, `training-YYYY-MM-DD`
+- `processing-latest`, `processing-smoke`, `processing-YYYY-MM-DD`
+- `user-<name>-<purpose>-YYYY-MM-DD`
+
+See `mermaid-api/iac/sagemaker-launcher-convention.md` for authoritative rules.
+
+## Build/push
+
+ECR push requires the launcher role (`dev-mermaid-sagemaker-launcher-role`, profile
+`wcs-launcher`). The default SageMaker SSO role (`mermaid-core`) can pull but NOT push —
+pushing with it fails `ecr:InitiateLayerUpload ... no identity-based policy allows`. The
+`docker login` credential is what's checked on push, so log in with `--profile wcs-launcher`.
+
+```bash
+cd mermaid-segmentation
+ACCT=554812291621
+IMG=$ACCT.dkr.ecr.us-east-1.amazonaws.com/mermaid-segmentation-jobs
+
+# --profile wcs-launcher: the role with ECR push permission (NOT mermaid-core)
+aws ecr get-login-password --region us-east-1 --profile wcs-launcher \
+    | docker login --username AWS --password-stdin \
+        $ACCT.dkr.ecr.us-east-1.amazonaws.com
+
+docker buildx build --platform linux/amd64 \
+    -t $IMG:training-latest -f docker/jobs/Dockerfile .
+docker push $IMG:training-latest
+```

--- a/docker/jobs/Dockerfile
+++ b/docker/jobs/Dockerfile
@@ -1,0 +1,42 @@
+# GPU image for mermaid-segmentation SageMaker jobs (TrainingJob +
+# ProcessingJob). Built from the mermaid-segmentation/ directory:
+#   docker buildx build --platform linux/amd64 \
+#       -t <ECR_URI>:training-<tag> -f docker/jobs/Dockerfile .
+#
+# Same image runs both Training and Processing — the launcher selects
+# which entrypoint script to invoke via CONTAINER_ENTRYPOINT_SCRIPT.
+#
+# Base: pytorch/pytorch:2.4.1-cuda12.4-cudnn9-runtime (Python 3.11, torch 2.4.1)
+# Matches pyproject.toml requires-python>=3.11, torch>=2.4,<2.8.
+#
+# See docker/jobs/CLAUDE.md for build/push recipe and tagging conventions.
+
+ARG BASE_IMAGE=pytorch/pytorch:2.4.1-cuda12.4-cudnn9-runtime
+FROM ${BASE_IMAGE}
+ARG HF_TOKEN
+ENV HF_TOKEN=$HF_TOKEN
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git build-essential libgl1 libglib2.0-0 && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/ml/code
+
+# Project itself (editable so scripts/ stays importable).
+COPY pyproject.toml README.md ./
+COPY mermaidseg ./mermaidseg
+COPY scripts ./scripts
+COPY configs ./configs
+
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -e .
+
+COPY docker/jobs/entrypoint.sh /opt/ml/code/entrypoint.sh
+RUN chmod +x /opt/ml/code/entrypoint.sh
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    AWS_DEFAULT_REGION=us-east-1
+
+ENTRYPOINT ["/opt/ml/code/entrypoint.sh"]

--- a/docker/jobs/entrypoint.sh
+++ b/docker/jobs/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# SageMaker container entrypoint shim. Dispatches to the script named
+# by CONTAINER_ENTRYPOINT_SCRIPT (set by the launcher from the YAML's
+# job.entrypoint). The same image serves both TrainingJob and
+# ProcessingJob; the env var picks the right entrypoint script.
+set -euo pipefail
+cd /opt/ml/code
+
+# TrainingJob containers receive `train` as the first arg by convention.
+# ProcessingJob containers don't. Drop `train` only if present.
+if [ "${1:-}" = "train" ]; then
+    shift
+fi
+
+SCRIPT="${CONTAINER_ENTRYPOINT_SCRIPT:-scripts/sagemaker_train_entrypoint.py}"
+exec python -u "${SCRIPT}" "$@"

--- a/docker/jobs/local_smoke.sh
+++ b/docker/jobs/local_smoke.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Local smoke test for the mermaid-segmentation jobs image.
+# Builds the image, runs the entrypoint against a tiny config-dir,
+# asserts the in-container entrypoint loads without crashing.
+#
+# Usage: bash docker/jobs/local_smoke.sh [training|processing]
+# Default: training.
+
+set -euo pipefail
+
+KIND="${1:-training}"
+case "$KIND" in training|processing) ;; *) echo "Usage: $0 [training|processing]" >&2; exit 2 ;; esac
+
+cd "$(dirname "$0")/../.."
+
+IMAGE="mermaid-segmentation-jobs:${KIND}-smoke-local"
+
+echo "[smoke] Building ${IMAGE}..."
+docker buildx build --platform linux/amd64 --load \
+    -t "${IMAGE}" -f docker/jobs/Dockerfile .
+
+if [ "$KIND" = "training" ]; then
+    echo "[smoke] Running training entrypoint (expect 'Loaded run YAML')..."
+    docker run --rm \
+        -v "$(pwd)/sagemaker/configs/example:/opt/ml/input/data/config:ro" \
+        -e CONTAINER_ENTRYPOINT_SCRIPT=scripts/sagemaker_train_entrypoint.py \
+        "${IMAGE}" 2>&1 | head -20 | tee /tmp/seg_smoke.log
+    grep -q "Loaded run YAML" /tmp/seg_smoke.log || { echo "[smoke] FAILED"; exit 1; }
+else
+    echo "[smoke] Running processing entrypoint --help..."
+    docker run --rm \
+        -e CONTAINER_ENTRYPOINT_SCRIPT=scripts/sagemaker_processing_entrypoint.py \
+        "${IMAGE}" --task=eval --help | head -5
+fi
+
+echo "[smoke] OK"

--- a/mermaidseg/logger.py
+++ b/mermaidseg/logger.py
@@ -94,8 +94,8 @@ def get_mlflow_tracking_uri(config_uri: str | None = None) -> str:
 def mlflow_connect(uri: str | None = None) -> timedelta:
     """Set the MLflow tracking URI and verify connectivity.
 
-    Returns the time taken to establish the connection. The connection test may take a long time to
-    fail unless ``MLFLOW_HTTP_REQUEST_MAX_RETRIES`` is set to a low number.
+    Returns the time taken to establish the connection. The connection test may take a
+    long time to fail unless ``MLFLOW_HTTP_REQUEST_MAX_RETRIES`` is set to a low number.
     """
     if uri is None:
         uri = get_mlflow_tracking_uri()
@@ -108,6 +108,11 @@ def mlflow_connect(uri: str | None = None) -> timedelta:
             logger.warning(
                 "URI is a SageMaker ARN but sagemaker-mlflow is not installed. Install with: pip install sagemaker-mlflow"
             )
+
+    # MLflow 3.x disallows file-store backends by default. Set the opt-out
+    # env var automatically for local paths so dry-runs work without extra setup.
+    if uri and not uri.startswith(("http", "arn:")):
+        os.environ.setdefault("MLFLOW_ALLOW_FILE_STORE", "true")
 
     mlflow.set_tracking_uri(uri=uri)
     try:
@@ -167,8 +172,8 @@ def resume_run(run_id: str) -> mlflow.ActiveRun:
 class Logger:
     """MLflow-focused logger for experiment tracking during training and evaluation.
 
-    wandb support is deprecated; pass ``enable_wandb=True`` to use the legacy ``WandbLogger``
-    delegate during the deprecation period.
+    wandb support is deprecated; pass ``enable_wandb=True`` to use the legacy
+    ``WandbLogger`` delegate during the deprecation period.
     """
 
     def __init__(
@@ -446,8 +451,8 @@ class Logger:
     def log_reconciliation(self, registry) -> None:
         """Log the joint :class:`SourceLabelRegistry` artifacts to MLflow.
 
-        Saves ``global_id2source``, ``target_id2label``, ``source_to_target`` and (when present)
-        ``concept_id2name`` so MLflow runs are self-describing.
+        Saves ``global_id2source``, ``target_id2label``, ``source_to_target`` and (when
+        present) ``concept_id2name`` so MLflow runs are self-describing.
         """
         if not self._ensure_active_run():
             return
@@ -610,7 +615,8 @@ class Logger:
         return self._wandb_logger is not None
 
     def _ensure_active_run(self) -> bool:
-        """Guarantee an active MLflow run exists, resuming the original when possible."""
+        """Guarantee an active MLflow run exists, resuming the original when
+        possible."""
         if not self._mlflow_active:
             return False
         try:
@@ -669,15 +675,15 @@ class Logger:
     ):
         """Save a model checkpoint locally and/or to MLflow.
 
-        Local persistence is controlled by ``save_local_checkpoints``. MLflow logging is independent
-        of local persistence.
+        Local persistence is controlled by ``save_local_checkpoints``. MLflow logging is
+        independent of local persistence.
 
-        When ``is_best`` is True (the default), the checkpoint is also written to the ``best-model``
-        artifact path and tagged accordingly.  Pass ``is_best=False`` to save a checkpoint without
-        overwriting the current best model.
+        When ``is_best`` is True (the default), the checkpoint is also written to the
+        ``best-model`` artifact path and tagged accordingly.  Pass ``is_best=False`` to
+        save a checkpoint without overwriting the current best model.
 
-        Checkpoint files are named ``model_epoch{epoch}`` — resuming from a previous epoch will
-        overwrite the file unless ``checkpoint_dir`` or ``run_name`` differs.
+        Checkpoint files are named ``model_epoch{epoch}`` — resuming from a previous
+        epoch will overwrite the file unless ``checkpoint_dir`` or ``run_name`` differs.
         """
         timestamp = time.strftime("%Y%m%d%H%M%S")
 

--- a/mermaidseg/sagemaker/__init__.py
+++ b/mermaidseg/sagemaker/__init__.py
@@ -1,0 +1,1 @@
+"""SageMaker launcher support for mermaid-segmentation."""

--- a/mermaidseg/sagemaker/launcher_config.py
+++ b/mermaidseg/sagemaker/launcher_config.py
@@ -1,0 +1,97 @@
+"""Pydantic schema for the SageMaker launcher YAML.
+
+This module is intentionally a near-duplicate of mermaid-classifier's launcher schema
+(same shape, separate copy — no shared Python code per the cross-repo design). The
+launcher cares about the `job:` block plus an optional `processing:` or `training:`
+block. The container entrypoint consumes whatever other top-level blocks the seg
+workflow needs (typically a `config:` block matching the existing
+`mermaidseg.io.ConfigDict` shape).
+
+See `mermaid-api/iac/sagemaker-launcher-convention.md` for the authoritative schema.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class JobConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name_prefix: str
+    image: str
+    entrypoint: str
+    instance_type: str
+    instance_count: int = 1
+    volume_gb: int = Field(gt=0)
+    max_runtime_hours: int = Field(gt=0)
+    use_spot: bool = False
+    env: dict[str, str] = Field(default_factory=dict)
+    tags: dict[str, str] = Field(default_factory=dict)
+
+
+class ShardConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    items_from: str
+    items_column: str | None = None
+    workers: int = Field(gt=0)
+    per_worker_arg: str
+
+
+class ProcessingConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    container_args: list[str] = Field(default_factory=list)
+    shard: ShardConfig | None = None
+
+
+class TrainingChannel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    s3_uri: str
+    input_mode: Literal["File", "FastFile", "Pipe"] = "File"
+
+
+class TrainingConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    hyperparameters: dict[str, str | int | float | bool] = Field(default_factory=dict)
+    channels: dict[str, TrainingChannel] = Field(default_factory=dict)
+
+
+class RunConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    job: JobConfig
+    processing: ProcessingConfig | None = None
+    training: TrainingConfig | None = None
+
+
+class _LooseRunConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    job: JobConfig
+    processing: ProcessingConfig | None = None
+    training: TrainingConfig | None = None
+
+
+def parse_run_config(
+    yaml_text: str,
+    *,
+    kind: Literal["training", "processing"],
+    strict: bool = True,
+) -> RunConfig | _LooseRunConfig:
+    data = yaml.safe_load(os.path.expandvars(yaml_text))
+    if not isinstance(data, dict):
+        from pydantic import ValidationError
+
+        raise ValidationError.from_exception_data(
+            "RunConfig", [{"type": "model_type", "loc": (), "input": data}]
+        )
+    model = RunConfig if strict else _LooseRunConfig
+    return model.model_validate(data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ notebooks = [
     "hvplot>=0.12.2",
     "great-tables>=0.21.0",
 ]
+sagemaker = [
+    "sagemaker>=2.0,<3.0",
+]
 scraping = [
     "selenium",
     "webdriver-manager",

--- a/sagemaker/configs/example/run.yaml
+++ b/sagemaker/configs/example/run.yaml
@@ -1,0 +1,19 @@
+job:
+  name_prefix: mermaidseg-example
+  image: mermaid-segmentation-jobs:training-latest
+  entrypoint: scripts/sagemaker_train_entrypoint.py
+  instance_type: ml.g5.2xlarge
+  volume_gb: 200
+  max_runtime_hours: 4
+
+# Consumed by scripts/sagemaker_train_entrypoint.py (NOT the launcher).
+# Example: smoke test with CBM data (1 epoch, small batch).
+config:
+  config_model: configs/model_config_cbm.yaml
+  config_training: configs/training_config_cbm.yaml
+  config_data: configs/data_config.yaml
+  config_logger: configs/logger_config.yaml
+  overrides:
+    run-name: mermaidseg-sagemaker-smoke
+    epochs: 1
+    batch-size: 4

--- a/sagemaker/runs/example-processing.yaml
+++ b/sagemaker/runs/example-processing.yaml
@@ -1,0 +1,13 @@
+job:
+  name_prefix: mermaidseg-eval-example
+  image: mermaid-segmentation-jobs:processing-latest
+  entrypoint: scripts/sagemaker_processing_entrypoint.py
+  instance_type: ml.g5.xlarge
+  volume_gb: 100
+  max_runtime_hours: 2
+
+processing:
+  container_args:
+    - --task=eval
+    - --checkpoint-uri=s3://dev-datamermaid-sm-data/runs/<replace-with-real-run>/output/checkpoint.pt
+    - --eval-set=val

--- a/sagemaker/runs/example-training.yaml
+++ b/sagemaker/runs/example-training.yaml
@@ -1,0 +1,16 @@
+job:
+  name_prefix: mermaidseg-example
+  image: mermaid-segmentation-jobs:training-latest
+  entrypoint: scripts/sagemaker_train_entrypoint.py
+  instance_type: ml.g5.2xlarge
+  volume_gb: 200
+  max_runtime_hours: 4
+
+# Consumed by scripts/sagemaker_train_entrypoint.py (NOT the launcher).
+config:
+  config_path: configs/model_config_dinov3_base.yaml
+  overrides:
+    run-name: mermaidseg-sagemaker-smoke
+    epochs: 1
+    batch-size: 4
+    lr: 0.00005

--- a/scripts/check_sagemaker_env.py
+++ b/scripts/check_sagemaker_env.py
@@ -1,0 +1,223 @@
+"""Preflight checks for SageMaker training job launch."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from importlib.metadata import PackageNotFoundError, version
+from typing import NamedTuple
+
+import boto3
+from botocore.exceptions import ClientError, NoCredentialsError
+
+
+class CheckResult(NamedTuple):
+    name: str
+    ok: bool
+    detail: str
+    fatal: bool = False
+
+
+MIN_SAGEMAKER_VERSION = (2, 200, 0)
+MIN_BOTO3_VERSION = (1, 26, 0)
+
+
+def _parse_version(raw: str) -> tuple[int, ...]:
+    """Parse version string into tuple of ints."""
+    parts: list[int] = []
+    for piece in raw.split("."):
+        digits = "".join(ch for ch in piece if ch.isdigit())
+        if digits:
+            parts.append(int(digits))
+    return tuple(parts)
+
+
+def check_sagemaker_sdk() -> CheckResult:
+    """Check SageMaker SDK is installed and recent enough."""
+    try:
+        installed = version("sagemaker")
+    except PackageNotFoundError:
+        return CheckResult(
+            "sagemaker SDK",
+            False,
+            "not installed — run: uv sync --extra sagemaker",
+            fatal=True,
+        )
+    if _parse_version(installed) < MIN_SAGEMAKER_VERSION:
+        return CheckResult(
+            "sagemaker SDK",
+            False,
+            f"found {installed}, need >= {'.'.join(map(str, MIN_SAGEMAKER_VERSION))}",
+            fatal=True,
+        )
+    return CheckResult("sagemaker SDK", True, f"v{installed}")
+
+
+def check_boto3() -> CheckResult:
+    """Check boto3 is installed."""
+    try:
+        installed = version("boto3")
+    except PackageNotFoundError:
+        return CheckResult(
+            "boto3",
+            False,
+            "not installed — run: pip install boto3",
+            fatal=True,
+        )
+    if _parse_version(installed) < MIN_BOTO3_VERSION:
+        return CheckResult(
+            "boto3",
+            False,
+            f"found {installed}, need >= {'.'.join(map(str, MIN_BOTO3_VERSION))}",
+            fatal=True,
+        )
+    return CheckResult("boto3", True, f"v{installed}")
+
+
+def check_aws_credentials() -> CheckResult:
+    """Check AWS credentials are available."""
+    try:
+        session = boto3.Session()
+        creds = session.get_credentials()
+        if not creds:
+            return CheckResult(
+                "AWS credentials",
+                False,
+                "not found — run: aws sso login --profile <profile>",
+                fatal=True,
+            )
+        return CheckResult("AWS credentials", True, "available")
+    except NoCredentialsError as e:
+        return CheckResult(
+            "AWS credentials",
+            False,
+            f"error: {e}",
+            fatal=True,
+        )
+
+
+def check_sagemaker_role(role_arn: str) -> CheckResult:
+    """Check SageMaker execution role ARN format (not verifying permissions)."""
+    role_name = role_arn.split("/")[-1]
+    if not role_arn.startswith("arn:aws:iam::"):
+        return CheckResult(
+            "SageMaker role",
+            False,
+            f"invalid ARN format: {role_arn}",
+            fatal=True,
+        )
+    return CheckResult("SageMaker role", True, role_name)
+
+
+def check_sagemaker_region() -> CheckResult:
+    """Check SageMaker is available in the region."""
+    try:
+        session = boto3.Session()
+        region = session.region_name
+        if not region:
+            return CheckResult(
+                "AWS region",
+                False,
+                "not set — run: export AWS_DEFAULT_REGION=us-east-1",
+                fatal=True,
+            )
+        sm = boto3.client("sagemaker", region_name=region)
+        sm.list_training_jobs(MaxResults=1)
+        return CheckResult("AWS region", True, region)
+    except ClientError as e:
+        return CheckResult(
+            "AWS region",
+            False,
+            f"error: {e.response['Error']['Message']}",
+            fatal=True,
+        )
+
+
+def check_hf_token(secret_arn: str | None) -> CheckResult:
+    """Check HuggingFace token (if needed for model access)."""
+    if not secret_arn:
+        return CheckResult(
+            "HuggingFace token",
+            True,
+            "optional (use --check-hf-token to validate)",
+        )
+    try:
+        secrets = boto3.client("secretsmanager")
+        secrets.get_secret_value(SecretId=secret_arn)
+        return CheckResult("HuggingFace token", True, secret_arn)
+    except ClientError as e:
+        return CheckResult(
+            "HuggingFace token",
+            False,
+            f"not found: {e.response['Error']['Message']}",
+            fatal=False,
+        )
+
+
+def main():
+    """Run all checks and report results."""
+    parser = argparse.ArgumentParser(
+        description="Preflight checks for SageMaker training job launch"
+    )
+    parser.add_argument(
+        "--role-arn",
+        required=True,
+        help="SageMaker execution role ARN (from SM_ROLE_ARN env var)",
+    )
+    parser.add_argument(
+        "--hf-token-secret-arn",
+        help="Optional AWS Secrets Manager ARN for HuggingFace token",
+    )
+    parser.add_argument(
+        "--check-hf-token",
+        action="store_true",
+        help="Require HuggingFace token to be present",
+    )
+    args = parser.parse_args()
+
+    checks = [
+        check_sagemaker_sdk(),
+        check_boto3(),
+        check_aws_credentials(),
+        check_sagemaker_region(),
+        check_sagemaker_role(args.role_arn),
+    ]
+
+    if args.check_hf_token or args.hf_token_secret_arn:
+        checks.append(check_hf_token(args.hf_token_secret_arn))
+
+    # Print results
+    print("\n" + "=" * 60)
+    print("SageMaker Preflight Checks")
+    print("=" * 60 + "\n")
+
+    failed = []
+    for check in checks:
+        status = "✓" if check.ok else "✗"
+        print(f"{status} {check.name:30s} {check.detail}")
+        if not check.ok:
+            failed.append(check)
+
+    print("\n" + "=" * 60)
+    if not failed:
+        print("✓ All checks passed! Ready to launch SageMaker training.")
+        print("=" * 60 + "\n")
+        return 0
+
+    fatal_failed = [c for c in failed if c.fatal]
+    if fatal_failed:
+        print("✗ Failed checks (blocking):")
+        for check in fatal_failed:
+            print(f"  - {check.name}: {check.detail}")
+        print("=" * 60 + "\n")
+        return 1
+
+    print("⚠ Failed checks (non-blocking):")
+    for check in failed:
+        print(f"  - {check.name}: {check.detail}")
+    print("=" * 60 + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/launch_processing.py
+++ b/scripts/launch_processing.py
@@ -1,0 +1,237 @@
+"""Launch SageMaker ProcessingJob(s) for mermaid-segmentation.
+
+Reads a per-run YAML and submits one or more CreateProcessingJob calls
+via raw boto3. With `processing.shard:` set, fans out N parallel
+ProcessingJobs each running the container against a sharded subset of
+items. See
+`mermaid-api/iac/sagemaker-launcher-convention.md` for the schema and
+canonical ARNs.
+
+Example
+-------
+    uv run python scripts/launch_processing.py \\
+        --run-config sagemaker/runs/my-eval.yaml \\
+        --config-dir sagemaker/configs/my-eval/
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+import boto3
+
+from mermaidseg.sagemaker.launcher_config import RunConfig, parse_run_config
+
+ACCOUNT = "554812291621"
+REGION = "us-east-1"
+EXEC_ROLE = f"arn:aws:iam::{ACCOUNT}:role/dev-sm-execution-role"
+STAGING_BUCKET = "dev-datamermaid-sm-data"
+ECR_HOST = f"{ACCOUNT}.dkr.ecr.{REGION}.amazonaws.com"
+KNOWN_SHORT_REPOS = {"mermaid-segmentation-jobs"}
+TERMINAL_STATES = {"Completed", "Failed", "Stopped"}
+DEFAULT_POLL_INTERVAL_S = 60
+
+log = logging.getLogger("launch_processing")
+
+
+def expand_image_uri(image: str) -> str:
+    if ".dkr.ecr." in image:
+        return image
+    if ":" not in image:
+        raise ValueError(f"Image {image!r} must be `<repo>:<tag>` or a full ECR URI.")
+    repo, _ = image.split(":", 1)
+    if repo not in KNOWN_SHORT_REPOS:
+        raise ValueError(f"Unknown short-form repo {repo!r}. Known: {sorted(KNOWN_SHORT_REPOS)}.")
+    return f"{ECR_HOST}/{image}"
+
+
+def make_run_id(prefix: str) -> str:
+    return f"{prefix}-{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}"
+
+
+def chunk_items(items: list[str], n_workers: int) -> list[list[str]]:
+    if n_workers <= 0:
+        raise ValueError(f"n_workers must be positive, got {n_workers}")
+    chunks: list[list[str]] = [[] for _ in range(n_workers)]
+    for i, item in enumerate(items):
+        chunks[i % n_workers].append(item)
+    return [c for c in chunks if c]
+
+
+def load_items(csv_path: Path, column: str | None) -> list[str]:
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        if column is None:
+            column = reader.fieldnames[0]
+        elif column not in reader.fieldnames:
+            raise ValueError(f"Column {column!r} not in {csv_path}: {reader.fieldnames}")
+        return [row[column] for row in reader if row[column]]
+
+
+def build_processing_request(
+    *,
+    cfg: RunConfig,
+    run_id: str,
+    worker_idx: int,
+    worker_items: list[str] | None,
+) -> dict:
+    job = cfg.job
+    proc = cfg.processing
+    container_args = list(proc.container_args)
+    if worker_items is not None:
+        assert proc.shard is not None
+        container_args.extend([proc.shard.per_worker_arg, ",".join(worker_items)])
+    return {
+        "ProcessingJobName": f"{run_id}-{worker_idx}",
+        "RoleArn": EXEC_ROLE,
+        "AppSpecification": {
+            "ImageUri": expand_image_uri(job.image),
+            "ContainerArguments": container_args,
+        },
+        "ProcessingResources": {
+            "ClusterConfig": {
+                "InstanceCount": 1,
+                "InstanceType": job.instance_type,
+                "VolumeSizeInGB": job.volume_gb,
+            },
+        },
+        "StoppingCondition": {"MaxRuntimeInSeconds": job.max_runtime_hours * 3600},
+        "Environment": {
+            "AWS_DEFAULT_REGION": REGION,
+            "CONTAINER_ENTRYPOINT_SCRIPT": job.entrypoint,
+            **job.env,
+        },
+        "Tags": (
+            [
+                {"Key": "Project", "Value": "mermaid-segmentation"},
+                {"Key": "RunId", "Value": run_id},
+                {"Key": "WorkerIdx", "Value": str(worker_idx)},
+            ]
+            + [{"Key": k, "Value": v} for k, v in job.tags.items()]
+        ),
+    }
+
+
+def _configure_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        stream=sys.stdout,
+    )
+
+
+def _make_sagemaker_client():
+    from botocore.config import Config
+
+    return boto3.client(
+        "sagemaker",
+        config=Config(region_name=REGION, retries={"mode": "adaptive", "max_attempts": 10}),
+    )
+
+
+def _wait_for_completion(client, job_names, poll_interval_s=DEFAULT_POLL_INTERVAL_S):
+    status = dict.fromkeys(job_names, "Pending")
+    while True:
+        for name in job_names:
+            if status[name] in TERMINAL_STATES:
+                continue
+            resp = client.describe_processing_job(ProcessingJobName=name)
+            status[name] = resp["ProcessingJobStatus"]
+        unfinished = [n for n, s in status.items() if s not in TERMINAL_STATES]
+        if not unfinished:
+            return status
+        log.info(
+            "Polling: %d/%d still running; sleeping %ds",
+            len(unfinished),
+            len(job_names),
+            poll_interval_s,
+        )
+        time.sleep(poll_interval_s)
+
+
+def _upload_config_dir(config_dir: Path, run_id: str, s3_client):
+    key_prefix = f"runs/{run_id}/config"
+    for p in sorted(config_dir.rglob("*")):
+        if not p.is_file():
+            continue
+        rel = p.relative_to(config_dir)
+        s3_client.upload_file(str(p), STAGING_BUCKET, f"{key_prefix}/{rel}")
+    return f"s3://{STAGING_BUCKET}/{key_prefix}/"
+
+
+def main(argv=None):
+    _configure_logging()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-config", required=True, type=Path)
+    parser.add_argument("--config-dir", required=True, type=Path)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--no-wait", action="store_true")
+    args = parser.parse_args(argv)
+
+    cfg = parse_run_config(args.run_config.read_text(), kind="processing", strict=True)
+    if cfg.processing is None:
+        log.error("YAML must include a `processing:` block.")
+        sys.exit(2)
+    if not args.config_dir.is_dir():
+        log.error("Config dir does not exist: %s", args.config_dir)
+        sys.exit(2)
+
+    run_id = make_run_id(cfg.job.name_prefix)
+    if cfg.processing.shard:
+        items = load_items(
+            args.config_dir / cfg.processing.shard.items_from, cfg.processing.shard.items_column
+        )
+        chunks = chunk_items(items, cfg.processing.shard.workers)
+        requests = [
+            build_processing_request(cfg=cfg, run_id=run_id, worker_idx=i, worker_items=c)
+            for i, c in enumerate(chunks)
+        ]
+    else:
+        requests = [
+            build_processing_request(cfg=cfg, run_id=run_id, worker_idx=0, worker_items=None)
+        ]
+
+    if args.dry_run:
+        print("=" * 60)
+        print("DRY RUN -- not submitting")
+        print("=" * 60)
+        print(f"run_id:    {run_id}")
+        print(f"workers:   {len(requests)}")
+        print(f"image:     {expand_image_uri(cfg.job.image)}")
+        for i, r in enumerate(requests):
+            print(f"  [{i}] {r['AppSpecification']['ContainerArguments']}")
+        return
+
+    s3_client = boto3.client("s3", region_name=REGION)
+    _upload_config_dir(args.config_dir.resolve(), run_id, s3_client)
+    sm_client = _make_sagemaker_client()
+    job_names = []
+    for req in requests:
+        sm_client.create_processing_job(**req)
+        job_names.append(req["ProcessingJobName"])
+        log.info("Submitted %s", req["ProcessingJobName"])
+
+    cw_url = (
+        f"https://{REGION}.console.aws.amazon.com/cloudwatch/home"
+        f"?region={REGION}#logsV2:log-groups/log-group/"
+        f"$252Faws$252Fsagemaker$252FProcessingJobs"
+    )
+    log.info("CloudWatch: %s", cw_url)
+
+    if args.no_wait:
+        return
+    statuses = _wait_for_completion(sm_client, job_names)
+    failures = [n for n, s in statuses.items() if s != "Completed"]
+    if failures:
+        log.error("%d job(s) did not complete: %s", len(failures), failures)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/launch_training.py
+++ b/scripts/launch_training.py
@@ -1,0 +1,207 @@
+"""Launch a mermaid-segmentation training run as a SageMaker TrainingJob.
+
+Reads a per-run YAML and submits CreateTrainingJob via the SageMaker
+SDK's Estimator. The script is script-agnostic: it doesn't know what
+the named `job.entrypoint` does. See
+`mermaid-api/iac/sagemaker-launcher-convention.md` for the schema and
+canonical ARNs.
+
+Example
+-------
+    uv run python scripts/launch_training.py \\
+        --run-config sagemaker/runs/my-run.yaml \\
+        --config-dir sagemaker/configs/my-run/ \\
+        --mlflow-tracking-uri arn:aws:sagemaker:us-east-1:554812291621:mlflow-app/app-EJVJ6AVFDWW2
+
+    # Submit and return immediately (no streaming logs):
+    uv run python scripts/launch_training.py \\
+        --run-config sagemaker/runs/my-run.yaml \\
+        --config-dir sagemaker/configs/my-run/ \\
+        --mlflow-tracking-uri arn:aws:sagemaker:us-east-1:554812291621:mlflow-app/app-EJVJ6AVFDWW2 \\
+        --no-wait
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import boto3
+
+from mermaidseg.sagemaker.launcher_config import RunConfig, parse_run_config
+
+ACCOUNT = "554812291621"
+REGION = "us-east-1"
+EXEC_ROLE = f"arn:aws:iam::{ACCOUNT}:role/dev-sm-execution-role"
+STAGING_BUCKET = "dev-datamermaid-sm-data"
+ECR_HOST = f"{ACCOUNT}.dkr.ecr.{REGION}.amazonaws.com"
+KNOWN_SHORT_REPOS = {"mermaid-segmentation-jobs"}
+
+log = logging.getLogger("launch_training")
+
+
+def expand_image_uri(image: str) -> str:
+    if ".dkr.ecr." in image:
+        return image
+    if ":" not in image:
+        raise ValueError(f"Image {image!r} must be `<repo>:<tag>` or a full ECR URI.")
+    repo, _ = image.split(":", 1)
+    if repo not in KNOWN_SHORT_REPOS:
+        raise ValueError(f"Unknown short-form repo {repo!r}. Known: {sorted(KNOWN_SHORT_REPOS)}.")
+    return f"{ECR_HOST}/{image}"
+
+
+def make_run_id(prefix: str) -> str:
+    return f"{prefix}-{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}"
+
+
+def build_estimator_kwargs(
+    *,
+    cfg: RunConfig,
+    run_id: str,
+    staging_bucket: str,
+    mlflow_uri: str,
+    sm_session,
+    role: str,
+    hf_token: str | None = None,
+) -> dict:
+    job = cfg.job
+    env = {
+        "MLFLOW_TRACKING_URI": mlflow_uri,
+        "AWS_DEFAULT_REGION": REGION,
+        "CONTAINER_ENTRYPOINT_SCRIPT": job.entrypoint,
+        **job.env,
+    }
+    if hf_token:
+        env["HF_TOKEN"] = hf_token
+    kwargs = {
+        "image_uri": expand_image_uri(job.image),
+        "role": role,
+        "instance_count": job.instance_count,
+        "instance_type": job.instance_type,
+        "volume_size": job.volume_gb,
+        "max_run": job.max_runtime_hours * 3600,
+        "output_path": f"s3://{staging_bucket}/runs/{run_id}/output/",
+        "environment": env,
+        "sagemaker_session": sm_session,
+        "base_job_name": job.name_prefix,
+        "tags": [{"Key": k, "Value": v} for k, v in job.tags.items()],
+    }
+    if job.use_spot:
+        kwargs["use_spot_instances"] = True
+        kwargs["max_wait"] = job.max_runtime_hours * 3600 + 3600
+    return kwargs
+
+
+def _configure_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        stream=sys.stdout,
+    )
+
+
+def _cloudwatch_url(run_id: str) -> str:
+    return (
+        f"https://{REGION}.console.aws.amazon.com/cloudwatch/home"
+        f"?region={REGION}#logsV2:log-groups/log-group/"
+        f"$252Faws$252Fsagemaker$252FTrainingJobs"
+        f"/log-events/{run_id}"
+    )
+
+
+def main(argv=None):
+    _configure_logging()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-config", required=True, type=Path)
+    parser.add_argument("--config-dir", required=True, type=Path)
+    parser.add_argument("--mlflow-tracking-uri", required=True)
+    parser.add_argument("--role-arn", default=EXEC_ROLE)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--no-wait", action="store_true")
+    parser.add_argument(
+        "--hf-token",
+        default=None,
+        help="HuggingFace token to pass as HF_TOKEN env var to the container (for gated models).",
+    )
+    args = parser.parse_args(argv)
+
+    cfg = parse_run_config(args.run_config.read_text(), kind="training", strict=False)
+    if not args.config_dir.is_dir():
+        log.error("Config dir does not exist: %s", args.config_dir)
+        sys.exit(2)
+
+    run_id = make_run_id(cfg.job.name_prefix)
+    cw_url = _cloudwatch_url(run_id)
+
+    if args.dry_run:
+        print("=" * 60)
+        print("DRY RUN -- not submitting")
+        print("=" * 60)
+        print(f"run_id:        {run_id}")
+        print(f"role:          {args.role_arn}")
+        print(f"image:         {expand_image_uri(cfg.job.image)}")
+        print(f"entrypoint:    {cfg.job.entrypoint}")
+        print(f"instance:      {cfg.job.instance_type} (x{cfg.job.instance_count})")
+        print(f"volume_gb:     {cfg.job.volume_gb}")
+        print(f"max_runtime:   {cfg.job.max_runtime_hours}h")
+        print(f"output:        s3://{STAGING_BUCKET}/runs/{run_id}/output/")
+        print(f"CloudWatch:    {cw_url}")
+        return
+
+    # Imported lazily so the module and its pure-logic helpers (build_estimator_kwargs,
+    # expand_image_uri, CLI parsing) import without the optional `sagemaker` SDK; only actual
+    # job submission needs it. Keeps these unit tests runnable in CI without the extra.
+    from sagemaker.estimator import Estimator
+    from sagemaker.inputs import TrainingInput
+    from sagemaker.session import Session
+
+    boto_session = boto3.Session(region_name=REGION)
+    sm_session = Session(boto_session=boto_session)
+    key_prefix = f"runs/{run_id}/config"
+    sm_session.upload_data(
+        path=str(args.config_dir.resolve()), bucket=STAGING_BUCKET, key_prefix=key_prefix
+    )
+
+    kwargs = build_estimator_kwargs(
+        cfg=cfg,
+        run_id=run_id,
+        staging_bucket=STAGING_BUCKET,
+        mlflow_uri=args.mlflow_tracking_uri,
+        sm_session=sm_session,
+        role=args.role_arn,
+        hf_token=args.hf_token,
+    )
+
+    log.info("Run ID:       %s", run_id)
+    log.info("CloudWatch:   %s", cw_url)
+    log.info("MLflow:       %s", args.mlflow_tracking_uri)
+
+    estimator = Estimator(**kwargs)
+    inputs = {
+        "config": TrainingInput(s3_data=f"s3://{STAGING_BUCKET}/{key_prefix}/", input_mode="File"),
+    }
+    if cfg.training:
+        for name, ch in cfg.training.channels.items():
+            inputs[name] = TrainingInput(s3_data=ch.s3_uri, input_mode=ch.input_mode)
+
+    log.info("Submitting TrainingJob...")
+    estimator.fit(
+        inputs=inputs,
+        wait=not args.no_wait,
+        logs=("All" if not args.no_wait else None),
+        job_name=run_id,
+    )
+    if args.no_wait:
+        log.info("Job submitted (--no-wait); run_id: %s", run_id)
+        log.info("CloudWatch: %s", cw_url)
+        return
+    log.info("Job %s reached terminal state.", run_id)
+    log.info("CloudWatch: %s", cw_url)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sagemaker_processing_entrypoint.py
+++ b/scripts/sagemaker_processing_entrypoint.py
@@ -1,0 +1,51 @@
+"""In-container entrypoint for a mermaid-segmentation ProcessingJob.
+
+ProcessingJobs are diverse (eval, inference, batch transform, mask generation, etc.).
+This entrypoint reads the run YAML, dispatches on the `processing:` block's
+`--task=<name>` container_arg, and routes to the matching subroutine in mermaidseg/. Add
+new tasks as the team needs them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+log = logging.getLogger("seg_processing_entrypoint")
+
+
+def _configure_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        stream=sys.stdout,
+    )
+
+
+def main():
+    _configure_logging()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--task",
+        required=True,
+        choices=["eval", "inference"],
+        help="Which processing routine to run.",
+    )
+    # Pass-through args specific to each task.
+    args, extra = parser.parse_known_args()
+    log.info("Running processing task=%s extra=%s", args.task, extra)
+    if args.task == "eval":
+        from mermaidseg.eval import run_eval  # implemented in mermaidseg
+
+        run_eval(extra)
+    elif args.task == "inference":
+        from mermaidseg.inference import run_inference
+
+        run_inference(extra)
+    else:
+        raise SystemExit(f"Unknown task: {args.task}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sagemaker_train_entrypoint.py
+++ b/scripts/sagemaker_train_entrypoint.py
@@ -1,0 +1,87 @@
+"""In-container entrypoint for a mermaid-segmentation TrainingJob.
+
+Reads the run YAML from /opt/ml/input/data/config/, applies any top-level `env:` keys,
+then invokes the existing training pipeline (scripts/train.py) with the seg-specific
+`config:` block translated into CLI flags.
+
+This is the **launcher-facing entrypoint** — the surface the launcher script names via
+CONTAINER_ENTRYPOINT_SCRIPT. The training pipeline itself stays in mermaidseg/ and
+scripts/train.py; this file is a thin adapter that bridges the run-YAML world to the
+existing CLI-driven entrypoint.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+log = logging.getLogger("seg_train_entrypoint")
+CONFIG_DIR = Path("/opt/ml/input/data/config")
+
+
+def _configure_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        stream=sys.stdout,
+    )
+
+
+def _find_run_yaml() -> Path:
+    yamls = sorted(CONFIG_DIR.rglob("*.yaml")) + sorted(CONFIG_DIR.rglob("*.yml"))
+    candidates = [p for p in yamls if "job:" in p.read_text()[:200]]
+    if not candidates:
+        raise SystemExit(f"No run YAML with a job: block under {CONFIG_DIR}")
+    if len(candidates) > 1:
+        raise SystemExit(f"Multiple candidate run YAMLs under {CONFIG_DIR}: {candidates}")
+    return candidates[0]
+
+
+def main():
+    _configure_logging()
+    run_yaml = _find_run_yaml()
+    log.info("Loaded run YAML: %s", run_yaml)
+    data = yaml.safe_load(run_yaml.read_text())
+
+    # Apply env: from job block (launcher already injected these into
+    # the container env, but if a user lands here via `docker run`
+    # directly the YAML is the source of truth.)
+    for k, v in (data.get("job", {}).get("env") or {}).items():
+        os.environ.setdefault(k, str(v))
+
+    # The seg-specific `config:` block names split-config paths (same as
+    # scripts/train.py) plus optional CLI overrides as a flat dict.
+    seg = data.get("config")
+    if seg is None:
+        raise SystemExit("Run YAML missing top-level `config:` block.")
+
+    config_flags = {
+        "config_data": seg.get("config_data", "configs/data_config.yaml"),
+        "config_model": seg.get("config_model", "configs/model_config_cbm.yaml"),
+        "config_training": seg.get("config_training", "configs/training_config_cbm.yaml"),
+        "config_logger": seg.get("config_logger", "configs/logger_config.yaml"),
+    }
+    overrides = seg.get("overrides", {})
+
+    if os.getenv("SMOKE_TEST"):
+        log.info("Smoke test OK — skipping train.py invocation")
+        return
+
+    cmd = [sys.executable, "-u", "scripts/train.py"]
+    for flag, path in config_flags.items():
+        cmd += [f"--{flag.replace('_', '-')}", path]
+    for k, v in overrides.items():
+        cmd += [f"--{k}", str(v)]
+
+    log.info("Invoking: %s", " ".join(cmd))
+    rc = subprocess.call(cmd)
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/sagemaker_launcher/test_launch_processing.py
+++ b/tests/sagemaker_launcher/test_launch_processing.py
@@ -1,0 +1,71 @@
+"""Tests for scripts.launch_processing (mermaid-segmentation)."""
+
+from __future__ import annotations
+
+import csv
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import launch_processing as lp  # type: ignore  # noqa: E402
+
+
+class ChunkItemsTest(unittest.TestCase):
+    def test_round_robin(self):
+        self.assertEqual(len(lp.chunk_items(["a", "b", "c", "d", "e"], n_workers=2)), 2)
+
+    def test_drop_empty_when_workers_exceed_items(self):
+        self.assertEqual(len(lp.chunk_items(["a", "b"], n_workers=5)), 2)
+
+    def test_zero_workers_raises(self):
+        with self.assertRaises(ValueError):
+            lp.chunk_items(["a"], n_workers=0)
+
+
+class LoadItemsTest(unittest.TestCase):
+    def test_auto_detect_first_column(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "ids.csv"
+            with open(p, "w") as f:
+                w = csv.writer(f)
+                w.writerow(["site_id", "extra"])
+                w.writerow(["1", "x"])
+                w.writerow(["2", "y"])
+            self.assertEqual(lp.load_items(p, column=None), ["1", "2"])
+
+
+class BuildProcessingRequestTest(unittest.TestCase):
+    @patch("launch_processing.datetime")
+    def test_request_shape(self, mock_dt):
+        mock_dt.now.return_value.strftime.return_value = "20260525T120000Z"
+        from mermaidseg.sagemaker.launcher_config import parse_run_config
+
+        run_yaml = (
+            "job:\n"
+            "  name_prefix: mermaidseg-eval\n"
+            "  image: mermaid-segmentation-jobs:processing-latest\n"
+            "  entrypoint: scripts/sagemaker_processing_entrypoint.py\n"
+            "  instance_type: ml.g5.xlarge\n"
+            "  volume_gb: 100\n"
+            "  max_runtime_hours: 6\n"
+            "processing:\n"
+            "  container_args:\n"
+            "    - --task=eval\n"
+        )
+        cfg = parse_run_config(run_yaml, kind="processing", strict=True)
+        req = lp.build_processing_request(
+            cfg=cfg, run_id="mermaidseg-eval-20260525T120000Z", worker_idx=0, worker_items=None
+        )
+        self.assertEqual(req["ProcessingJobName"], "mermaidseg-eval-20260525T120000Z-0")
+        self.assertEqual(req["RoleArn"], "arn:aws:iam::554812291621:role/dev-sm-execution-role")
+        self.assertEqual(
+            req["AppSpecification"]["ImageUri"],
+            "554812291621.dkr.ecr.us-east-1.amazonaws.com/mermaid-segmentation-jobs:processing-latest",
+        )
+        self.assertIn("--task=eval", req["AppSpecification"]["ContainerArguments"])

--- a/tests/sagemaker_launcher/test_launch_training.py
+++ b/tests/sagemaker_launcher/test_launch_training.py
@@ -1,0 +1,101 @@
+"""Tests for scripts.launch_training (mermaid-segmentation)."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import launch_training as lt  # type: ignore  # noqa: E402
+
+
+def _minimal_yaml() -> str:
+    return """
+job:
+  name_prefix: mermaidseg-test
+  image: mermaid-segmentation-jobs:training-smoke
+  entrypoint: scripts/sagemaker_train_entrypoint.py
+  instance_type: ml.g5.2xlarge
+  volume_gb: 200
+  max_runtime_hours: 24
+"""
+
+
+class ExpandImageTest(unittest.TestCase):
+    def test_short_form_expands(self):
+        result = lt.expand_image_uri("mermaid-segmentation-jobs:training-latest")
+        self.assertEqual(
+            result,
+            "554812291621.dkr.ecr.us-east-1.amazonaws.com"
+            "/mermaid-segmentation-jobs:training-latest",
+        )
+
+    def test_full_uri_passes_through(self):
+        full = "111111111111.dkr.ecr.us-east-1.amazonaws.com/other:tag"
+        self.assertEqual(lt.expand_image_uri(full), full)
+
+    def test_short_form_rejects_unknown_repo(self):
+        with self.assertRaises(ValueError):
+            lt.expand_image_uri("mermaid-classifier-jobs:training-latest")
+
+
+class BuildEstimatorKwargsTest(unittest.TestCase):
+    @patch("launch_training.datetime")
+    def test_kwargs_match_expectation(self, mock_dt):
+        mock_dt.now.return_value.strftime.return_value = "20260525T120000Z"
+        from mermaidseg.sagemaker.launcher_config import parse_run_config
+
+        cfg = parse_run_config(_minimal_yaml(), kind="training", strict=False)
+        kwargs = lt.build_estimator_kwargs(
+            cfg=cfg,
+            run_id="mermaidseg-test-20260525T120000Z",
+            staging_bucket="dev-datamermaid-sm-data",
+            mlflow_uri="arn:aws:sagemaker:us-east-1:554812291621:mlflow-app/app-EJVJ6AVFDWW2",
+            sm_session=MagicMock(),
+            role=lt.EXEC_ROLE,
+        )
+        self.assertEqual(kwargs["instance_type"], "ml.g5.2xlarge")
+        self.assertEqual(kwargs["volume_size"], 200)
+        self.assertEqual(
+            kwargs["role"],
+            "arn:aws:iam::554812291621:role/dev-sm-execution-role",
+        )
+        self.assertEqual(
+            kwargs["image_uri"],
+            "554812291621.dkr.ecr.us-east-1.amazonaws.com/mermaid-segmentation-jobs:training-smoke",
+        )
+        self.assertEqual(
+            kwargs["environment"]["MLFLOW_TRACKING_URI"],
+            "arn:aws:sagemaker:us-east-1:554812291621:mlflow-app/app-EJVJ6AVFDWW2",
+        )
+
+
+class CliArgsTest(unittest.TestCase):
+    def test_no_wait_flag_recognized(self):
+        """--no-wait must parse without error alongside required args."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--run-config", required=True, type=Path)
+        parser.add_argument("--config-dir", required=True, type=Path)
+        parser.add_argument("--mlflow-tracking-uri", required=True)
+        parser.add_argument("--dry-run", action="store_true")
+        parser.add_argument("--no-wait", action="store_true")
+        args = parser.parse_args(
+            [
+                "--run-config",
+                "sagemaker/runs/example-training.yaml",
+                "--config-dir",
+                "sagemaker/configs/example/",
+                "--mlflow-tracking-uri",
+                "arn:aws:sagemaker:us-east-1:554812291621:mlflow-app/app-X",
+                "--no-wait",
+            ]
+        )
+        self.assertTrue(args.no_wait)
+        self.assertFalse(args.dry_run)

--- a/tests/sagemaker_launcher/test_launcher_config.py
+++ b/tests/sagemaker_launcher/test_launcher_config.py
@@ -1,0 +1,99 @@
+"""Tests for mermaidseg.sagemaker.launcher_config."""
+
+from __future__ import annotations
+
+import unittest
+
+import yaml
+from pydantic import ValidationError
+
+from mermaidseg.sagemaker.launcher_config import (
+    JobConfig,
+    ShardConfig,
+    parse_run_config,
+)
+
+
+class JobConfigTest(unittest.TestCase):
+    def test_required_fields_minimal(self):
+        cfg = JobConfig(
+            name_prefix="my-run",
+            image="mermaid-segmentation-jobs:training-latest",
+            entrypoint="scripts/sagemaker_train_entrypoint.py",
+            instance_type="ml.g5.2xlarge",
+            volume_gb=200,
+            max_runtime_hours=24,
+        )
+        self.assertEqual(cfg.instance_count, 1)
+        self.assertFalse(cfg.use_spot)
+        self.assertEqual(cfg.env, {})
+        self.assertEqual(cfg.tags, {})
+
+    def test_missing_required_field_raises(self):
+        with self.assertRaises(ValidationError) as ctx:
+            JobConfig(
+                name_prefix="x", entrypoint="x", instance_type="x", volume_gb=1, max_runtime_hours=1
+            )
+        self.assertIn("image", str(ctx.exception))
+
+
+class ShardConfigTest(unittest.TestCase):
+    def test_workers_must_be_positive(self):
+        with self.assertRaises(ValidationError):
+            ShardConfig(items_from="x.csv", workers=0, per_worker_arg="--ids")
+
+
+class ParseRunConfigTest(unittest.TestCase):
+    def test_training_only(self):
+        y = yaml.safe_dump(
+            {
+                "job": {
+                    "name_prefix": "x",
+                    "image": "y",
+                    "entrypoint": "z",
+                    "instance_type": "ml.g5.2xlarge",
+                    "volume_gb": 200,
+                    "max_runtime_hours": 24,
+                },
+                "training": {"hyperparameters": {"k": "v"}},
+            }
+        )
+        cfg = parse_run_config(y, kind="training")
+        self.assertIsNotNone(cfg.training)
+        self.assertIsNone(cfg.processing)
+
+    def test_unknown_top_level_key_raises_in_strict(self):
+        y = yaml.safe_dump(
+            {
+                "job": {
+                    "name_prefix": "x",
+                    "image": "y",
+                    "entrypoint": "z",
+                    "instance_type": "a",
+                    "volume_gb": 1,
+                    "max_runtime_hours": 1,
+                },
+                "garbage": {"foo": "bar"},
+            }
+        )
+        with self.assertRaises(ValidationError):
+            parse_run_config(y, kind="training", strict=True)
+
+    def test_unknown_top_level_key_ignored_in_loose(self):
+        y = yaml.safe_dump(
+            {
+                "job": {
+                    "name_prefix": "x",
+                    "image": "y",
+                    "entrypoint": "z",
+                    "instance_type": "a",
+                    "volume_gb": 1,
+                    "max_runtime_hours": 1,
+                },
+                "config": {"model_name": "LinearDINOv3"},  # seg-specific block,
+                # consumed by the entrypoint
+                # not the launcher.
+            }
+        )
+        cfg = parse_run_config(y, kind="training", strict=False)
+        self.assertIsNotNone(cfg.job)

--- a/uv.lock
+++ b/uv.lock
@@ -224,6 +224,12 @@ wheels = [
 ]
 
 [[package]]
+name = "antlr4-python3-runtime"
+version = "4.9.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034, upload-time = "2021-11-06T17:52:23.524Z" }
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -339,11 +345,11 @@ wheels = [
 
 [[package]]
 name = "attrs"
-version = "26.1.0"
+version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
 ]
 
 [[package]]
@@ -1515,6 +1521,18 @@ wheels = [
 ]
 
 [[package]]
+name = "google-pasta"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/4a/0bd53b36ff0323d10d5f24ebd67af2de10a1117f5cf4d7add90df92756f1/google-pasta-0.2.0.tar.gz", hash = "sha256:c9f2c8dfc8f96d0d5808299920721be30c9eec37f2389f28904f454565c8a16e", size = 40430, upload-time = "2020-03-13T18:57:50.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/de/c648ef6835192e6e2cc03f40b19eeda4382c49b5bafb43d88b931c4c74ac/google_pasta-0.2.0-py3-none-any.whl", hash = "sha256:b32482794a366b5366a32c92a9a9201b107821889935a02b3e51f6b432ea84ed", size = 57471, upload-time = "2020-03-13T18:57:48.872Z" },
+]
+
+[[package]]
 name = "gradio"
 version = "6.17.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1951,14 +1969,14 @@ wheels = [
 
 [[package]]
 name = "importlib-metadata"
-version = "8.7.1"
+version = "6.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/eb/58c2ab27ee628ad801f56d4017fe62afab0293116f6d0b08f1d5bd46e06f/importlib_metadata-6.11.0.tar.gz", hash = "sha256:1231cf92d825c9e03cfc4da076a16de6422c863558229ea0b22b675657463443", size = 54593, upload-time = "2023-12-03T17:33:10.693Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+    { url = "https://files.pythonhosted.org/packages/59/9b/ecce94952ab5ea74c31dcf9ccf78ccd484eebebef06019bf8cb579ab4519/importlib_metadata-6.11.0-py3-none-any.whl", hash = "sha256:f0afba6205ad8f8947c7d338b5342d5db2afbfd82f9cbef7879a9539cc12eb9b", size = 23427, upload-time = "2023-12-03T17:33:08.965Z" },
 ]
 
 [[package]]
@@ -2766,6 +2784,9 @@ notebooks = [
     { name = "jupyter" },
     { name = "wandb" },
 ]
+sagemaker = [
+    { name = "sagemaker" },
+]
 scraping = [
     { name = "selenium" },
     { name = "webdriver-manager" },
@@ -2820,6 +2841,7 @@ requires-dist = [
     { name = "requests-auth-aws-sigv4", specifier = ">=0.7" },
     { name = "s3fs" },
     { name = "safetensors", specifier = ">=0.4.0" },
+    { name = "sagemaker", marker = "extra == 'sagemaker'", specifier = ">=2.0,<3.0" },
     { name = "sagemaker-mlflow", specifier = ">=0.2.0" },
     { name = "seaborn", specifier = ">=0.13.2" },
     { name = "segmentation-models-pytorch" },
@@ -2831,7 +2853,7 @@ requires-dist = [
     { name = "wandb", marker = "extra == 'notebooks'", specifier = ">=0.25.0" },
     { name = "webdriver-manager", marker = "extra == 'scraping'" },
 ]
-provides-extras = ["notebooks", "scraping", "test-live", "demo"]
+provides-extras = ["notebooks", "sagemaker", "scraping", "test-live", "demo"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2937,6 +2959,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1b/77/73af163432f3c66e2d213045250972e504a6683c76f63dd1abfba441a16a/mlflow_tracing-3.11.1.tar.gz", hash = "sha256:cb63cee16385d081467ec5bee4807fe1af59ddfdf04be4c79e7a7813b1002193", size = 1314550, upload-time = "2026-04-07T14:26:32.785Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/ab/d980c84e7df4224ab8db2457afbe135b430f371ca081a37cf89f8ef18ca1/mlflow_tracing-3.11.1-py3-none-any.whl", hash = "sha256:fa82df64dacf8293b714ae666440fe7c1902c6470c024df389bb91e9de3106d9", size = 1575790, upload-time = "2026-04-07T14:26:30.804Z" },
+]
+
+[[package]]
+name = "mock"
+version = "4.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/be/3ea39a8fd4ed3f9a25aae18a1bff2df7a610bca93c8ede7475e32d8b73a0/mock-4.0.3.tar.gz", hash = "sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc", size = 72316, upload-time = "2020-12-10T07:33:13.043Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/03/b7e605db4a57c0f6fba744b11ef3ddf4ddebcada35022927a2b5fc623fdf/mock-4.0.3-py3-none-any.whl", hash = "sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62", size = 28536, upload-time = "2020-12-10T07:33:11.564Z" },
 ]
 
 [[package]]
@@ -3392,6 +3423,19 @@ wheels = [
 ]
 
 [[package]]
+name = "omegaconf"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/3d/e4b57b8d9008c6ebe0d5eff901f91d5700cf7bdb8c8863df817463a7fd5e/omegaconf-2.3.1.tar.gz", hash = "sha256:e5e7de64aeebeddaf8e6d3f7a783b32ac2a01c0fbd9c878012caecb891a1f42a", size = 3298472, upload-time = "2026-06-11T05:05:12.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/0e/152509871bf30df6fc38569f52a2db9b55dd41aae957adae50a053ac7778/omegaconf-2.3.1-py3-none-any.whl", hash = "sha256:3d701d14e9a8828f1edd28bb70b725908b34277cdd72cf7d6a83f94dadc6b6a0", size = 79502, upload-time = "2026-06-11T05:05:09.954Z" },
+]
+
+[[package]]
 name = "opencv-python-headless"
 version = "4.11.0.86"
 source = { registry = "https://pypi.org/simple" }
@@ -3563,11 +3607,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.2"
+version = "24.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950, upload-time = "2024-11-08T09:47:47.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451, upload-time = "2024-11-08T09:47:44.722Z" },
 ]
 
 [[package]]
@@ -3698,6 +3742,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/58/1e3f382eef9e50a2a115486b0c178d22bb97d2fbb85421ccbe5d3a783530/parsy-2.2.tar.gz", hash = "sha256:e943147644a8cf0d82d1bcb5c5867dd517495254cea3e3eb058b1e421cb7561f", size = 47296, upload-time = "2025-09-12T11:39:26.783Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/fc/8cb9073bb1bee54eb49a1ae501a36402d01763812962ac811cdc1c81a9d7/parsy-2.2-py3-none-any.whl", hash = "sha256:5e981613d9d2d8b68012d1dd0afe928967bea2e4eefdb76c2f545af0dd02a9e7", size = 9538, upload-time = "2025-09-12T11:39:25.749Z" },
+]
+
+[[package]]
+name = "pathos"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+    { name = "multiprocess" },
+    { name = "pox" },
+    { name = "ppft" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/f9/180b44bda6b68d21b9547037b2a1609523dc874b51242d80c167d0914ad2/pathos-0.3.1.tar.gz", hash = "sha256:c9a088021493c5cb627d4459bba6c0533c684199e271a5dc297d62be23d74019", size = 166067, upload-time = "2023-07-23T11:18:52.835Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/08/ac94fa6f9eefe32963b8a54e573dab0dbc0d3df24fd34924bd9ce7eab7c4/pathos-0.3.1-py3-none-any.whl", hash = "sha256:b1c7145e2adcc19c7e9cac48f110ea5a63e300c1cc10c2947d4857dc97a47b46", size = 82100, upload-time = "2023-07-23T11:18:50.875Z" },
 ]
 
 [[package]]
@@ -3857,6 +3916,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pox"
+version = "0.3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/58/4385741dea1d74fe9dfed7ff42975266634ef8000f2c8e96717079c916b1/pox-0.3.7.tar.gz", hash = "sha256:0652f6f2103fe6d4ba638beb6fa8d3e8a68fd44bcb63315c614118515bcc3afb", size = 119442, upload-time = "2026-01-19T02:09:12.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/ac/4d5f104edf2aae2fec85567ec1d1969010de8124c5c45514f25e14900b65/pox-0.3.7-py3-none-any.whl", hash = "sha256:82a495249d13371314c1a5b5626a115e067ef5215d49530bf5efa37fbc25b56a", size = 29402, upload-time = "2026-01-19T02:09:11.024Z" },
+]
+
+[[package]]
+name = "ppft"
+version = "1.7.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/d2/281aa3466e948283d51b83238fb456f65e14f8ade5f8627822578cd2708f/ppft-1.7.8.tar.gz", hash = "sha256:5f696d4f397ae9b0af39b1faffb31957c51dfbc5a3815856472d4f4e872937ee", size = 136349, upload-time = "2026-01-19T03:03:13.439Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/e1/d1b380af6443e7c33aeb40617ebdc17c39dc30095235643cc518e3908203/ppft-1.7.8-py3-none-any.whl", hash = "sha256:d3e0e395215b14afc3dd5adfc032ccecfda2d4ed50dc7ded076cd1d215442843", size = 56759, upload-time = "2026-01-19T03:03:11.896Z" },
 ]
 
 [[package]]
@@ -4757,15 +4834,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "15.0.0"
+version = "14.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
 ]
 
 [[package]]
@@ -4961,6 +5038,62 @@ wheels = [
 ]
 
 [[package]]
+name = "sagemaker"
+version = "2.257.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "boto3" },
+    { name = "cloudpickle" },
+    { name = "docker" },
+    { name = "fastapi" },
+    { name = "google-pasta" },
+    { name = "graphene" },
+    { name = "importlib-metadata" },
+    { name = "jsonschema" },
+    { name = "numpy" },
+    { name = "omegaconf" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pathos" },
+    { name = "platformdirs" },
+    { name = "protobuf" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sagemaker-core" },
+    { name = "schema" },
+    { name = "smdebug-rulesconfig" },
+    { name = "tblib" },
+    { name = "tqdm" },
+    { name = "urllib3" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/ba/ace1532bdee0604de3ef2ec33b698d64ac364e73fd079fb8d4d3b204a70a/sagemaker-2.257.3.tar.gz", hash = "sha256:a72f5f64141d078a5632b20f0a653969e1df4e0920243b0398d3c67940696e7a", size = 1241976, upload-time = "2026-05-04T21:33:30.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/4c/7d95ae22a650761596c73b462ec2267ccbb6f2b30e7ef2a65c97b6d5fc1b/sagemaker-2.257.3-py3-none-any.whl", hash = "sha256:b13be3f25d705082da02c44561362e2f762228ccb120eac5eccbd33ec732d355", size = 1703995, upload-time = "2026-05-04T21:33:27.711Z" },
+]
+
+[[package]]
+name = "sagemaker-core"
+version = "1.0.78"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "importlib-metadata" },
+    { name = "jsonschema" },
+    { name = "mock" },
+    { name = "platformdirs" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/30/6d2342e1f9449546bc32caf8a6ebcdbdc3fde384196e0a54277cf1303468/sagemaker_core-1.0.78.tar.gz", hash = "sha256:e71582fd5da1c7ade07aee1155fe0438ee873f04ef064b994f7a7fc17dd9ee3c", size = 429547, upload-time = "2026-04-20T10:55:09.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/79/ad3171ecadb0217e18285026c3b3961c86eb73e92117c1a645a8689c6fa1/sagemaker_core-1.0.78-py3-none-any.whl", hash = "sha256:50e15959bc81ddafc81137408e4b1db9a481382eea4d3865459b63e18c182a9f", size = 444643, upload-time = "2026-04-20T10:55:07.761Z" },
+]
+
+[[package]]
 name = "sagemaker-mlflow"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4971,6 +5104,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/00/79841c7743734c7aaea2258755b3c29729143d7b6f460d6d9568ad1d09de/sagemaker_mlflow-0.3.0.tar.gz", hash = "sha256:f1657bd1351c7312450b2642782298b8f40c2842fabc45649b9f2f15f7b4456e", size = 18137, upload-time = "2026-04-21T20:31:23.929Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/8f/e2e440d6c4fe1dc7848887c693bb6d61d18f8837cf7bf0fa251ae697b0a9/sagemaker_mlflow-0.3.0-py3-none-any.whl", hash = "sha256:19581079984ebec02abb148d46bcbe4d10c1a3d6936d7cd39d24257d27a4fc76", size = 24682, upload-time = "2026-04-21T20:31:22.69Z" },
+]
+
+[[package]]
+name = "schema"
+version = "0.7.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/2e/8da627b65577a8f130fe9dfa88ce94fcb24b1f8b59e0fc763ee61abef8b8/schema-0.7.8.tar.gz", hash = "sha256:e86cc08edd6fe6e2522648f4e47e3a31920a76e82cce8937535422e310862ab5", size = 45540, upload-time = "2025-10-11T13:15:40.281Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/75/aad85817266ac5285c93391711d231ca63e9ae7d42cd3ca37549e24ebe52/schema-0.7.8-py2.py3-none-any.whl", hash = "sha256:00bd977fadc7d9521bf289850cd8a8aa5f4948f575476b8daaa5c1b57af2dce1", size = 19108, upload-time = "2025-10-11T17:13:07.323Z" },
 ]
 
 [[package]]
@@ -5282,6 +5424,15 @@ wheels = [
 ]
 
 [[package]]
+name = "smdebug-rulesconfig"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/7d/8ad6a2098e03c1f811d1277a2cedb81265828f144f6d323b83a2392e8bb9/smdebug_rulesconfig-1.0.1.tar.gz", hash = "sha256:7a19e6eb2e6bcfefbc07e4a86ef7a88f32495001a038bf28c7d8e77ab793fcd6", size = 12060, upload-time = "2020-12-18T23:54:52.357Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/a1/45a13a05198bbe9527bab2c5e5daa8bd02678aa825eec14783e767bfa7d1/smdebug_rulesconfig-1.0.1-py2.py3-none-any.whl", hash = "sha256:104da3e6931ecf879dfc687ca4bbb3bee5ea2bc27f4478e9dbb3ee3655f1ae61", size = 20282, upload-time = "2020-12-18T23:54:51.267Z" },
+]
+
+[[package]]
 name = "smmap"
 version = "5.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -5481,6 +5632,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tblib"
+version = "3.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8a/14c15ae154895cc131174f858c707790d416c444fc69f93918adfd8c4c0b/tblib-3.2.2.tar.gz", hash = "sha256:e9a652692d91bf4f743d4a15bc174c0b76afc750fe8c7b6d195cc1c1d6d2ccec", size = 35046, upload-time = "2025-11-12T12:21:16.572Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl", hash = "sha256:26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76", size = 12893, upload-time = "2025-11-12T12:21:14.407Z" },
 ]
 
 [[package]]

--- a/wiki/SageMaker-Jobs.md
+++ b/wiki/SageMaker-Jobs.md
@@ -1,0 +1,154 @@
+# Running code in SageMaker jobs
+
+How to run `mermaid-segmentation` code as SageMaker **TrainingJob**s and **ProcessingJob**s in the
+dev account. One Docker image backs both; the launcher selects the in-container entrypoint.
+
+The launcher convention (role ARN, bucket, schema, ECR tagging) is defined in
+`mermaid-api/iac/sagemaker-launcher-convention.md`. This page is the seg-specific runbook on top of
+that. Dataset-specific tasks (e.g. CoralNet ETL) are documented on their own pages.
+
+## Prerequisites
+
+- AWS SSO with the `SageMaker` Identity Center permission set on the project's dev account.
+- Docker installed locally.
+- `pip install -e .` succeeds and the `sagemaker` extra is installed: `uv sync --extra sagemaker`.
+- An MLflow App provisioned in the dev account; its ARN is your `MLFLOW_TRACKING_URI` (set in `.env`).
+
+### Preflight
+
+Account-specific values (`SM_ROLE_ARN`, `MLFLOW_TRACKING_URI`, …) go in **`.env`** (gitignored,
+loaded by direnv — see `.env.example`); the Makefile embeds no ARNs. Run before your first job (or
+after credential changes):
+
+```bash
+uv sync --extra sagemaker
+aws sso login --profile wcs-sso
+export MERMAID_AWS_MODE=launcher && direnv reload
+make sm-check
+```
+
+`sm-check` validates SDK version, region, credentials, execution-role trust
+(`sagemaker.amazonaws.com`), and warns about staging-bucket IAM and `HF_TOKEN`.
+
+## One-time: build and push the image
+
+ECR push requires the **`wcs-launcher`** profile (the launcher role); the read-only SSO role cannot
+push.
+
+```bash
+export AWS_PROFILE=wcs-launcher
+ACCT=<your-aws-account-id>
+IMG=$ACCT.dkr.ecr.us-east-1.amazonaws.com/mermaid-segmentation-jobs
+
+aws ecr get-login-password --region us-east-1 \
+    | docker login --username AWS --password-stdin $ACCT.dkr.ecr.us-east-1.amazonaws.com
+
+docker buildx build --platform linux/amd64 -t $IMG:training-latest -f docker/jobs/Dockerfile .
+docker push $IMG:training-latest
+
+# Same image, tagged for processing use:
+docker tag $IMG:training-latest $IMG:processing-latest
+docker push $IMG:processing-latest
+```
+
+Smoke-test locally before pushing:
+
+```bash
+bash docker/jobs/local_smoke.sh training
+bash docker/jobs/local_smoke.sh processing
+```
+
+## Run a training job
+
+```bash
+export AWS_PROFILE=wcs-launcher
+uv run --extra sagemaker python scripts/launch_training.py \
+    --run-config sagemaker/runs/example-training.yaml \
+    --config-dir sagemaker/configs/example/ \
+    --mlflow-tracking-uri $MLFLOW_TRACKING_URI   # from .env
+```
+
+Outputs:
+- Run ID and CloudWatch URL printed at submission.
+- An MLflow run under the `--run-name` from the YAML's `config.overrides`.
+- Final model artifact at `s3://dev-datamermaid-sm-data/runs/<run-id>/output/`.
+
+A run YAML's `config:` block names the model/training/data/logger configs and any `overrides:`
+(forwarded to `scripts/train.py` as CLI flags). See `sagemaker/configs/example/` for the shape.
+
+## Run a processing job
+
+Processing jobs share the training image but route to different code via `--task`. The entrypoint is
+`scripts/sagemaker_processing_entrypoint.py`.
+
+```bash
+export AWS_PROFILE=wcs-launcher
+uv run --extra sagemaker python scripts/launch_processing.py \
+    --run-config sagemaker/runs/<your-run>.yaml \
+    --config-dir sagemaker/configs/<your-config-dir>/
+```
+
+Built-in tasks are `eval` and `inference`. Dataset/ETL tasks are registered by their owning modules
+and documented on their own pages.
+
+### Adding a new processing task
+
+1. Add the task name to `choices=` in `scripts/sagemaker_processing_entrypoint.py`.
+2. Add an `elif args.task == "<name>":` block that imports from `mermaidseg/` and calls its
+   `main(extra)`.
+3. If the implementation lives under `scripts/` rather than `mermaidseg/`, move it to a package path
+   under `mermaidseg/` and register a console script in `pyproject.toml` so the in-container import
+   resolves.
+
+### Credentials in run YAMLs
+
+Any `${VAR}` in a run YAML `env:` block is expanded from the shell environment at launch via
+`os.path.expandvars()`. Set sensitive values in `.env` and reference them as `${MY_VAR}` — they are
+never committed.
+
+### Sharding
+
+For a task that fans out over a list of items, add a `shard:` block to the run YAML:
+
+```yaml
+processing:
+  container_args:
+    - --task=<task>
+  shard:
+    items_from: items.csv      # CSV in --config-dir; must have a header row
+    items_column: id           # which column to read
+    workers: 5                 # number of parallel ProcessingJobs
+    per_worker_arg: --ids      # CLI arg each worker receives its slice as
+```
+
+The launcher splits `items_from` across `workers` jobs and submits them in parallel. Each job's logs
+land in `/aws/sagemaker/ProcessingJobs` under stream `<job-name>-N/algo-1`.
+
+## Instance sizing
+
+| Instance | GPU | $/hr | Use case |
+|---|---|---|---|
+| `ml.g5.xlarge` | A10G (24GB) | ~$1.41 | Eval / inference; small training runs |
+| `ml.g5.2xlarge` | A10G | ~$1.52 | Standard training run (DINOv3-base, batch 4-8) |
+| `ml.g5.4xlarge` | A10G | ~$2.03 | Larger batch, more CPU for data loading |
+| `ml.p3.2xlarge` | V100 (16GB) | ~$3.83 | When A10G's 24GB isn't enough |
+
+CPU-only processing jobs (ETL, resize) typically use `ml.m5.*` — size by the task.
+
+## Debug a failed job
+
+CloudWatch log group: `/aws/sagemaker/TrainingJobs` (or `/ProcessingJobs`).
+
+```bash
+export AWS_PROFILE=wcs-launcher
+aws logs tail /aws/sagemaker/TrainingJobs --log-stream-name-prefix <run-id>/ --follow
+```
+
+Or reproduce locally:
+
+```bash
+docker run --rm -it \
+    -v $(pwd)/sagemaker/configs/example:/opt/ml/input/data/config:ro \
+    -e CONTAINER_ENTRYPOINT_SCRIPT=scripts/sagemaker_train_entrypoint.py \
+    mermaid-segmentation-jobs:training-smoke-local
+```


### PR DESCRIPTION
Part **1/4** of splitting draft #155 into reviewable, issue-scoped PRs. Closes #131.

Generic SageMaker TrainingJob/ProcessingJob launcher + supporting infra:
- `mermaidseg/sagemaker/` launch config model
- `scripts/launch_{training,processing}.py`, `check_sagemaker_env.py`, `sagemaker_{train,processing}_entrypoint.py`
- `docker/jobs/` GPU image + build/push recipe (ECR push via the `wcs-launcher` profile)
- `wiki/SageMaker-Jobs.md` runbook; generic `sm-*` Makefile targets
- `tests/sagemaker_launcher/` — **16 passing**

Processing entrypoint exposes `eval`/`inference` only; `coralnet-*` tasks land in PR 2/3. `pyproject` adds only the `sagemaker` extra.

**Stack (merge in order):** this (base `main`) → ETL/scraper → resize/manifest. The baseline PR also branches off this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)