### PR TITLE
feat(coralnet): resized training manifest + dataset consumption (#146, #154)

### DIFF
--- a/mermaidseg/datasets/coralnet/coralnet_dataset.py
+++ b/mermaidseg/datasets/coralnet/coralnet_dataset.py
@@ -16,12 +16,10 @@ filename for backward compatibility; pin a specific build via
 
 from __future__ import annotations
 
-import json
 import os
 from typing import Any
 
 import boto3
-import fsspec
 import numpy as np
 import pandas as pd
 from numpy.typing import NDArray
@@ -33,7 +31,8 @@ _LEGACY_ANNOTATIONS_PATH = "coralnet_annotations_30112025.parquet"
 
 
 def _resolve_default_annotations_path() -> str:
-    """Resolve the default ``annotations_path`` from env vars, falling back to the legacy file.
+    """Resolve the default ``annotations_path`` from env vars, falling back to the
+    legacy file.
 
     Precedence:
         1. ``MERMAID_CORALNET_ANNOTATIONS_PATH`` — full S3 key as published by the ETL.
@@ -53,8 +52,8 @@ def _resolve_default_annotations_path() -> str:
 
 
 class CoralNetDataset(BaseCoralDataset):
-    """A PyTorch Dataset for loading CoralNet annotated coral reef images from a Parquet file stored
-    on S3.
+    """A PyTorch Dataset for loading CoralNet annotated coral reef images from a Parquet
+    file stored on S3.
 
     Each item returned is a tuple ``(image, source_labels)`` where
     ``source_labels`` is an integer mask in CoralNet's own provider-ID label
@@ -78,6 +77,10 @@ class CoralNetDataset(BaseCoralDataset):
     """
 
     SOURCE_NAME = "coralnet"
+
+    # Columns every CoralNet annotations parquet must provide. ``source_label_name`` is derived
+    # from ``coralnet_id``; ``image_s3_key`` is optional (present only in the resized parquet).
+    REQUIRED_COLUMNS: tuple[str, ...] = ("source_id", "image_id", "row", "col", "coralnet_id")
 
     annotations_path: str
     source_ids: list[int | str]
@@ -133,42 +136,40 @@ class CoralNetDataset(BaseCoralDataset):
         """
         annotations_path = f"s3://{self.source_bucket}/{self.annotations_path}"
         df_annotations = pd.read_parquet(annotations_path)
-        id2name_path = (
-            "s3://dev-datamermaid-sm-sources/coralnet-public-images/temporary/coralnet_id2name.json"
-        )
-
-        with fsspec.open(id2name_path, "r") as f:
-            coralnet_id2name = json.load(f)
-
-        df_annotations["coralnet_name"] = df_annotations["coralnet_id"].map(
-            lambda x: coralnet_id2name.get(str(x))
-        )
-        df_annotations["source_label_name"] = (
-            df_annotations["coralnet_name"].astype(str).str.lower()
-        )
-
-        df_annotations = df_annotations[
-            [
-                "source_id",
-                "image_id",
-                "row",
-                "col",
-                "coralnet_id",
-                "coralnet_name",
-                "source_label_name",
-            ]
-        ]
+        missing = set(self.REQUIRED_COLUMNS) - set(df_annotations.columns)
+        if missing:
+            raise ValueError(
+                f"CoralNet annotations parquet at {annotations_path} is missing required "
+                f"columns: {sorted(missing)}"
+            )
+        df_annotations["source_label_name"] = df_annotations["coralnet_id"].astype(str)
+        columns = ["source_id", "image_id", "row", "col", "coralnet_id", "source_label_name"]
+        # The resized training parquet carries a per-image resolved S3 key (resized or original)
+        # with row/col already scaled to that image. The legacy parquet omits it, in which case
+        # read_image falls back to constructing the original key.
+        if "image_s3_key" in df_annotations.columns:
+            columns.append("image_s3_key")
+        df_annotations = df_annotations[columns]
 
         df_images = self._derive_df_images_from_annotations(df_annotations)
         return df_annotations, df_images
 
     def _derive_df_images_from_annotations(self, df_annotations: pd.DataFrame) -> pd.DataFrame:
+        columns = ["source_id", "image_id"]
+        if "image_s3_key" in df_annotations.columns:
+            columns.append("image_s3_key")
         return (
-            df_annotations[["source_id", "image_id"]]
+            df_annotations[columns]
             .drop_duplicates(subset=["source_id", "image_id"])
             .reset_index(drop=True)
         )
 
-    def read_image(self, image_id: str, source_id: str, **row_kwargs: Any) -> NDArray[Any]:
-        key = f"{self.source_s3_prefix}/s{source_id}/images/{image_id}.jpg"
+    def read_image(
+        self,
+        image_id: str,
+        source_id: str,
+        image_s3_key: str | None = None,
+        **row_kwargs: Any,
+    ) -> NDArray[Any]:
+        key = image_s3_key or f"{self.source_s3_prefix}/s{source_id}/images/{image_id}.jpg"
         return np.array(get_image_s3(s3=self.s3, bucket=self.source_bucket, key=key).convert("RGB"))

--- a/mermaidseg/datasets/coralnet/preprocessing/manifest.py
+++ b/mermaidseg/datasets/coralnet/preprocessing/manifest.py
@@ -13,10 +13,11 @@ logger = logging.getLogger(__name__)
 def combine_checkpoints(checkpoints: Sequence[ibis.Table]) -> ibis.Table:
     """Merge resize checkpoints from successive runs into one status table.
 
-    The row with the most recent ``resize_timestamp`` wins on (source_id, image_id) conflicts, so a
-    rerun that reprocessed previously skipped/failed items overrides the earlier status. Rows with
-    no timestamp (failed/skipped) lose to any timestamped row; among themselves, the later
-    checkpoint in the input sequence wins. All checkpoints must share the same schema.
+    The row with the most recent ``resize_timestamp`` wins on (source_id, image_id)
+    conflicts, so a rerun that reprocessed previously skipped/failed items overrides the
+    earlier status. Rows with no timestamp (failed/skipped) lose to any timestamped row;
+    among themselves, the later checkpoint in the input sequence wins. All checkpoints
+    must share the same schema.
     """
     if not checkpoints:
         raise ValueError("combine_checkpoints requires at least one checkpoint")
@@ -106,4 +107,121 @@ def build_manifest(
             status=ibis._.status,
         )
         .order_by(["source_id", "image_id"])
+    )
+
+
+def build_training_manifest(
+    annotations: ibis.Table,
+    images: ibis.Table,
+    checkpoint: ibis.Table,
+    output_prefix: str,
+    threshold: int = 2048,
+) -> ibis.Table:
+    """Build the annotation-level training parquet consumed by ``CoralNetDataset``.
+
+    Resolves the S3 key of the image to actually load (resized when the image was resized,
+    original otherwise) and rescales each point annotation's ``row``/``col`` to the loaded
+    image's dimensions, so the dataset needs no runtime scaling. Images that ``needs_resize``
+    but whose resize did not complete are excluded entirely (their annotations are dropped).
+
+    Args:
+        annotations: Annotation rows with [source_id, image_id, row, col, coralnet_id].
+        images: Image metadata with [source_id, image_id, s3_key, width, height, needs_resize, ...].
+        checkpoint: Resize checkpoint/manifest with [source_id, image_id, status, ...].
+        output_prefix: S3 prefix under which resized images live (e.g. ``"dev/images"``).
+        threshold: Resize threshold (longest edge in pixels) used when the corpus was resized.
+
+    Returns:
+        Annotation-level table with columns:
+        [source_id, image_id, row, col, coralnet_id, source_label_name, image_s3_key,
+         load_width, load_height, uses_resized_image]. ``row``/``col`` are already scaled
+        to (load_height, load_width).
+    """
+    joined = images.left_join(checkpoint, ["source_id", "image_id"])
+
+    # Treat a resize as usable only when the image needed resizing AND its checkpoint row
+    # completed; images absent from the checkpoint get a null status (-> not completed).
+    use_resized = joined.needs_resize & (joined.status.fill_null("") == "completed")  # noqa: PD004 — ibis API
+
+    resized_key = (
+        ibis.literal(f"{output_prefix}/resized/s")
+        + joined.source_id.cast("string")
+        + "/images/"
+        + joined.image_id
+        + ".jpg"
+    )
+
+    # Scale the longest edge to the threshold, flooring like the resize worker's int().
+    longest = ibis.greatest(joined.width, joined.height)
+    scale = ibis.literal(threshold).cast("float64") / longest.cast("float64")
+    load_width = ibis.ifelse(
+        use_resized, (joined.width.cast("float64") * scale).floor().cast("int64"), joined.width
+    )
+    load_height = ibis.ifelse(
+        use_resized, (joined.height.cast("float64") * scale).floor().cast("int64"), joined.height
+    )
+
+    image_manifest = (
+        joined.mutate(
+            image_s3_key=ibis.ifelse(use_resized, resized_key, joined.s3_key),
+            load_width=load_width,
+            load_height=load_height,
+            uses_resized_image=use_resized,
+        )
+        # Keep sub-threshold or completed-resize images, and only those with known original
+        # dimensions — null dims (e.g. header_status="not_found") can't be scaled or validated,
+        # and DuckDB's greatest(NULL, 0) would silently collapse their coords to (0, 0).
+        .filter(
+            ((~joined.needs_resize) | use_resized)  # noqa: PD004 — ibis API
+            & joined.width.notnull()
+            & joined.height.notnull()
+            & (joined.width > 0)
+            & (joined.height > 0)
+        )
+        .select(
+            "source_id",
+            "image_id",
+            "image_s3_key",
+            "load_width",
+            "load_height",
+            "uses_resized_image",
+            orig_width=ibis._.width,
+            orig_height=ibis._.height,
+        )
+    )
+
+    # Inner join drops annotations of excluded images.
+    out = annotations.inner_join(image_manifest, ["source_id", "image_id"])
+    scale_x = out.load_width.cast("float64") / out.orig_width.cast("float64")
+    scale_y = out.load_height.cast("float64") / out.orig_height.cast("float64")
+    col_scaled = ibis.least(
+        (out.col.cast("float64") * scale_x).floor().cast("int64"), out.load_width - 1
+    )
+    row_scaled = ibis.least(
+        (out.row.cast("float64") * scale_y).floor().cast("int64"), out.load_height - 1
+    )
+
+    # row/col and load dims are bounded by the resize threshold (<= 2048), so int16 stores them
+    # losslessly at a quarter of int64 — they dominate the file size at annotation scale.
+    return (
+        out.mutate(
+            row=ibis.greatest(row_scaled, ibis.literal(0)).cast("int16"),
+            col=ibis.greatest(col_scaled, ibis.literal(0)).cast("int16"),
+            load_width=out.load_width.cast("int16"),
+            load_height=out.load_height.cast("int16"),
+            source_label_name=out.coralnet_id.cast("string"),
+        )
+        .select(
+            "source_id",
+            "image_id",
+            "row",
+            "col",
+            "coralnet_id",
+            "source_label_name",
+            "image_s3_key",
+            "load_width",
+            "load_height",
+            "uses_resized_image",
+        )
+        .order_by(["source_id", "image_id", "row", "col"])
     )

--- a/mermaidseg/datasets/coralnet/preprocessing/resize.py
+++ b/mermaidseg/datasets/coralnet/preprocessing/resize.py
@@ -1,5 +1,5 @@
-"""Image resizing preprocessing pipeline: scan for missing resized images, then resize and
-upload."""
+"""Image resizing preprocessing pipeline: scan for missing resized images, then resize
+and upload."""
 
 from __future__ import annotations
 
@@ -35,8 +35,8 @@ DEFAULT_CHECKPOINT_EVERY = 1000
 def make_resize_s3_client(*, max_pool_connections: int = 10) -> Any:
     """Build an S3 client sized for concurrent resize/scan workers.
 
-    boto3 clients are thread-safe, so the orchestrator builds one client with ``max_pool_connections
-    >= workers`` and shares it across all worker threads.
+    boto3 clients are thread-safe, so the orchestrator builds one client with
+    ``max_pool_connections >= workers`` and shares it across all worker threads.
     """
     config = Config(
         retries={"max_attempts": 10, "mode": "adaptive"},
@@ -120,8 +120,8 @@ def _resized_s3_key_for(prefix: str, source_id: int, image_id: str, threshold: i
 def _list_existing_resized_keys(s3_client: Any, bucket: str, output_prefix: str) -> set[str]:
     """Return every object key under ``<output_prefix>/resized/`` via paginated LIST.
 
-    One LIST request covers 1000 objects, so this replaces hundreds of thousands of per-image
-    ``head_object`` calls with a few hundred sequential pages.
+    One LIST request covers 1000 objects, so this replaces hundreds of thousands of per-
+    image ``head_object`` calls with a few hundred sequential pages.
     """
     resized_prefix = f"{output_prefix}/resized/"
     paginator = s3_client.get_paginator("list_objects_v2")
@@ -444,13 +444,15 @@ def resize_and_upload_image(
 def _summarise_checkpoint(checkpoint_df: pd.DataFrame) -> tuple[int, int, int, int]:
     """Count (resized, skipped, failed, corrupted) from checkpoint statuses alone.
 
-    Counts come from the checkpoint, never from todo-list arithmetic — on a resume the todo can be
-    smaller than the checkpoint, which previously produced negative "skipped" counts.
+    Counts come from the checkpoint, never from todo-list arithmetic — on a resume the
+    todo can be smaller than the checkpoint, which previously produced negative
+    "skipped" counts.
     """
     num_resized = int((checkpoint_df["status"] == "completed").sum())
     num_failed = int((checkpoint_df["status"] == "failed").sum())
     is_skipped = checkpoint_df["status"] == "skipped"
-    is_corrupted = checkpoint_df["skip_reason"].str.startswith("corrupted_").fillna(False)
+    skip_reason = checkpoint_df.get("skip_reason", pd.Series("", index=checkpoint_df.index))
+    is_corrupted = skip_reason.str.startswith("corrupted_").fillna(False)
     num_corrupted = int((is_skipped & is_corrupted).sum())
     num_skipped = int((is_skipped & ~is_corrupted).sum())
     return num_resized, num_skipped, num_failed, num_corrupted
@@ -507,6 +509,18 @@ def resize_and_upload_all_images(
         df_todo[["source_id", "image_id", "original_s3_key", "output_s3_key"]],
         on=["source_id", "image_id"],
     )
+
+    # A non-empty checkpoint that shares zero (source_id, image_id) with the todo is never
+    # intentional — it means the checkpoint came from a different ETL run than the one that
+    # produced df_todo. Left unguarded this silently processes nothing and reports success
+    # (the "Resizing images: 0it" bug). Fail loudly so the stale checkpoint gets noticed.
+    if df_work.empty:
+        raise ValueError(
+            f"Checkpoint at {checkpoint_path} has {len(df_pending)} pending items but none "
+            f"intersect the {len(df_todo)} todo items — checkpoint is from a different ETL run. "
+            "Delete the stale checkpoint or pull the one matching this run."
+        )
+    logger.info("Merged %d pending checkpoint items → %d workable", len(df_pending), len(df_work))
 
     # Map (source_id, image_id) -> positional row index for O(1) in-memory status updates.
     row_index: dict[tuple[int, str], int] = {
@@ -566,3 +580,198 @@ def resize_and_upload_all_images(
     )
 
     return num_resized, num_skipped, num_failed, num_corrupted
+
+
+def _default_worker_count() -> int:
+    env = os.environ.get("MERMAID_CORALNET_RESIZE_WORKERS")
+    if env:
+        return max(1, int(env))
+    cpu = os.cpu_count() or 4
+    return min(64, max(32, cpu * 4))
+
+
+def _sync_checkpoint_to_s3(local_path: Path, bucket: str, s3_key: str) -> None:
+    import boto3
+
+    boto3.client("s3").upload_file(str(local_path), bucket, s3_key)
+    logger.info("Checkpoint synced to s3://%s/%s", bucket, s3_key)
+
+
+def _sync_checkpoint_from_s3(local_path: Path, bucket: str, s3_key: str) -> bool:
+    import boto3
+
+    s3 = boto3.client("s3")
+    try:
+        s3.head_object(Bucket=bucket, Key=s3_key)
+    except Exception:  # noqa: BLE001
+        return False
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    s3.download_file(bucket, s3_key, str(local_path))
+    logger.info("Checkpoint downloaded from s3://%s/%s", bucket, s3_key)
+    return True
+
+
+_DEFAULT_CHECKPOINT_S3_KEY = "etl-outputs/coralnet/{run}/resize_checkpoint_{run}.parquet"
+
+
+def _resolve_checkpoint_s3_keys(
+    run: str,
+    checkpoint_s3_key: str | None,
+    pull_checkpoint_s3_key: str | None,
+) -> tuple[str, str]:
+    """Resolve the (pull, push) checkpoint S3 keys.
+
+    Pull and push are deliberately independent: a job may seed from a prior run's checkpoint
+    (``pull_checkpoint_s3_key``) while writing its own results under the current run's path. When
+    only the push key is overridden, pull falls back to it; when neither is given, both derive from
+    the run version. Conflating the two is the wrong-path bug — a May-seeded job overwriting May's
+    checkpoint — so this returns them as a pair.
+
+    Returns:
+        (pull_key, push_key)
+    """
+    push_key = checkpoint_s3_key or _DEFAULT_CHECKPOINT_S3_KEY.format(run=run)
+    pull_key = pull_checkpoint_s3_key or push_key
+    return pull_key, push_key
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the CoralNet resize pipeline (SageMaker processing task)."""
+    import argparse
+
+    import pandas as pd
+
+    parser = argparse.ArgumentParser(description="Resize CoralNet images flagged needs_resize.")
+    parser.add_argument("--bucket", default="dev-datamermaid-sm-sources")
+    parser.add_argument("--run", default=None, help="ETL version tag (e.g. 20260624_nogit)")
+    parser.add_argument("--images-uri", default=None, help="Override S3/local images parquet URI")
+    parser.add_argument("--output-prefix", default="dev/images")
+    parser.add_argument("--threshold", type=int, default=2048)
+    parser.add_argument("--workers-scan", type=int, default=None)
+    parser.add_argument("--workers-resize", type=int, default=None)
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        default=Path("outputs/resize_checkpoint.parquet"),
+    )
+    parser.add_argument(
+        "--checkpoint-s3-key", default=None, help="S3 key for push (default: derived from --run)"
+    )
+    parser.add_argument(
+        "--pull-checkpoint-s3-key",
+        default=None,
+        help="S3 key to pull from (default: same as --checkpoint-s3-key)",
+    )
+    parser.add_argument("--pull-checkpoint", action="store_true")
+    parser.add_argument("--push-checkpoint", action="store_true")
+    parser.add_argument("--skip-scan", action="store_true")
+    parser.add_argument("--checkpoint-every", type=int, default=DEFAULT_CHECKPOINT_EVERY)
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    workers_default = _default_worker_count()
+    workers_scan = args.workers_scan or workers_default
+    workers_resize = args.workers_resize or workers_default
+    run = args.run or "unknown"
+    pull_s3_key, checkpoint_s3_key = _resolve_checkpoint_s3_keys(
+        run=run,
+        checkpoint_s3_key=args.checkpoint_s3_key,
+        pull_checkpoint_s3_key=args.pull_checkpoint_s3_key,
+    )
+
+    if args.pull_checkpoint:
+        _sync_checkpoint_from_s3(args.checkpoint, args.bucket, pull_s3_key)
+
+    if args.checkpoint.exists():
+        df_cp = read_checkpoint(args.checkpoint)
+        counts = df_cp["status"].value_counts().to_dict()
+        logger.info(
+            "Checkpoint: completed=%s pending=%s failed=%s",
+            counts.get("completed", 0),
+            counts.get("pending", 0),
+            counts.get("failed", 0),
+        )
+
+    if args.images_uri:
+        images_uri = args.images_uri
+    elif args.run:
+        images_uri = f"s3://{args.bucket}/etl-outputs/coralnet/{run}/coralnet_images_{run}.parquet"
+    else:
+        logger.error("Provide --images-uri or --run")
+        return 2
+
+    logger.info("Loading images parquet: %s", images_uri)
+    storage_options = None
+    if images_uri.startswith("s3://"):
+        storage_options = {
+            "config_kwargs": {"max_pool_connections": max(workers_scan, workers_resize) + 4}
+        }
+    df = pd.read_parquet(images_uri, storage_options=storage_options)
+    df_work = df.loc[df["needs_resize"]].copy()
+    logger.info(
+        "needs_resize=True: %s / %s total rows across %s sources",
+        f"{len(df_work):,}",
+        f"{len(df):,}",
+        df_work["source_id"].nunique(),
+    )
+
+    if args.skip_scan:
+        if not args.checkpoint.exists():
+            logger.error("--skip-scan requires an existing checkpoint at %s", args.checkpoint)
+            return 1
+        df_todo = build_todo_from_checkpoint(
+            df_images=df_work,
+            checkpoint_path=args.checkpoint,
+            output_prefix=args.output_prefix,
+            threshold=args.threshold,
+        )
+        logger.info("Skip-scan resume: %s pending images", f"{len(df_todo):,}")
+    else:
+        df_todo = scan_for_missing_resized_images(
+            df_images=df_work,
+            bucket=args.bucket,
+            output_prefix=args.output_prefix,
+            threshold=args.threshold,
+            workers=workers_scan,
+            s3_client=None,
+        )
+        logger.info("Scan complete: %s images to resize", f"{len(df_todo):,}")
+
+    if df_todo.empty:
+        logger.info("Nothing to do — all resized images already exist.")
+        if args.push_checkpoint and args.checkpoint.exists():
+            _sync_checkpoint_to_s3(args.checkpoint, args.bucket, checkpoint_s3_key)
+        return 0
+
+    args.checkpoint.parent.mkdir(parents=True, exist_ok=True)
+    num_resized, num_skipped, num_failed, num_corrupted = resize_and_upload_all_images(
+        df_todo=df_todo,
+        bucket=args.bucket,
+        output_prefix=args.output_prefix,
+        checkpoint_path=args.checkpoint,
+        threshold=args.threshold,
+        workers=workers_resize,
+        s3_client=None,
+        checkpoint_every=args.checkpoint_every,
+    )
+    logger.info(
+        "Done: resized=%s skipped=%s corrupted=%s failed=%s",
+        num_resized,
+        num_skipped,
+        num_corrupted,
+        num_failed,
+    )
+
+    if args.push_checkpoint:
+        _sync_checkpoint_to_s3(args.checkpoint, args.bucket, checkpoint_s3_key)
+
+    return 1 if num_failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
 coralnet-etl = "mermaidseg.datasets.coralnet.etl.__main__:main"
 coralnet-remediate = "mermaidseg.datasets.coralnet.scraper.remediate_incomplete:main"
 coralnet-refresh = "mermaidseg.datasets.coralnet.scraper.refresh_image_lists:main"
+coralnet-resize = "mermaidseg.datasets.coralnet.preprocessing.resize:main"
 
 [project.optional-dependencies]
 notebooks = [

--- a/scripts/build_coralnet_training_manifest.py
+++ b/scripts/build_coralnet_training_manifest.py
@@ -1,0 +1,134 @@
+"""Build the CoralNet annotation-level training parquet (resized + original-below-
+threshold).
+
+Resolves each image to the key actually loaded at train time — the resized key when a resized
+object exists on S3, the original ``s3_key`` for sub-threshold images — and scales each point
+annotation's row/col to the loaded image's dimensions, so ``CoralNetDataset`` needs no runtime
+scaling.
+
+Resize-existence is read from the S3 LIST of ``<output_prefix>/resized/`` objects, NOT from the
+resize checkpoint: historical checkpoints under-record completed resizes (uploads succeeded but the
+status was never flushed), so the checkpoint would wrongly drop hundreds of thousands of images
+that are genuinely resized on S3. The S3 object listing is the same source of truth the resize scan
+trusts.
+
+Usage:
+    uv run python scripts/build_coralnet_training_manifest.py --run 20260623_nogit
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+
+import boto3
+import ibis
+import pandas as pd
+
+from mermaidseg.datasets.coralnet.preprocessing.manifest import build_training_manifest
+from mermaidseg.datasets.coralnet.preprocessing.resize import _list_existing_resized_keys
+
+logger = logging.getLogger("build_training_manifest")
+
+# Matches resize._resized_s3_key_for: <prefix>/resized/s<source_id>/images/<image_id>.jpg
+_KEY_RE = re.compile(r"/resized/s(\d+)/images/(.+)\.jpg$")
+
+
+def _resized_existence_table(s3_client, bucket: str, output_prefix: str) -> pd.DataFrame:
+    """A (source_id, image_id, status='completed') row for every resized object on
+    S3."""
+    keys = _list_existing_resized_keys(s3_client, bucket, output_prefix)
+    rows = []
+    for k in keys:
+        m = _KEY_RE.search(k)
+        if m:
+            rows.append((int(m.group(1)), m.group(2)))
+    df = pd.DataFrame(rows, columns=["source_id", "image_id"])
+    df["status"] = "completed"
+    return df
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bucket", default="dev-datamermaid-sm-sources")
+    parser.add_argument("--run", required=True, help="ETL version tag, e.g. 20260623_nogit")
+    parser.add_argument("--output-prefix", default="dev/images", help="Prefix holding /resized/")
+    parser.add_argument("--threshold", type=int, default=2048)
+    parser.add_argument("--profile", default="mermaid-core", help="AWS profile (empty for default)")
+    parser.add_argument("--out-key", default=None, help="Override output S3 key")
+    parser.add_argument("--dry-run", action="store_true", help="Compute + report, but don't write")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+
+    session = boto3.Session(profile_name=args.profile) if args.profile else boto3.Session()
+    s3 = session.client("s3")
+    storage_options = {"profile": args.profile} if args.profile else None
+
+    base = f"s3://{args.bucket}/etl-outputs/coralnet/{args.run}"
+    ann = pd.read_parquet(
+        f"{base}/coralnet_annotations_{args.run}.parquet", storage_options=storage_options
+    )
+    img = pd.read_parquet(
+        f"{base}/coralnet_images_{args.run}.parquet", storage_options=storage_options
+    )
+    logger.info("Loaded annotations=%s images=%s", f"{len(ann):,}", f"{len(img):,}")
+
+    n_needs = int(img["needs_resize"].sum())
+    n_sub = int((~img["needs_resize"]).sum())
+    n_nulldim = int((img["width"].isna() | img["height"].isna()).sum())
+    logger.info(
+        "Images: needs_resize=%s sub_threshold=%s null_dims=%s",
+        f"{n_needs:,}",
+        f"{n_sub:,}",
+        f"{n_nulldim:,}",
+    )
+
+    logger.info(
+        "Listing resized objects under s3://%s/%s/resized/ ...", args.bucket, args.output_prefix
+    )
+    ckpt = _resized_existence_table(s3, args.bucket, args.output_prefix)
+    logger.info("Resized objects on S3: %s", f"{len(ckpt):,}")
+
+    manifest = build_training_manifest(
+        annotations=ibis.memtable(ann),
+        images=ibis.memtable(img),
+        checkpoint=ibis.memtable(ckpt),
+        output_prefix=args.output_prefix,
+        threshold=args.threshold,
+    ).to_pandas()
+
+    # --- data-quality numbers ---
+    n_rows = len(manifest)
+    imgs = manifest.drop_duplicates(["source_id", "image_id"])
+    n_imgs = len(imgs)
+    n_resized = int(imgs["uses_resized_image"].sum())
+    n_original = n_imgs - n_resized
+    ann_imgs = ann.drop_duplicates(["source_id", "image_id"])
+    dropped_imgs = len(ann_imgs) - n_imgs
+    dropped_rows = len(ann) - n_rows
+    logger.info("=== Training manifest ===")
+    logger.info("Annotation rows:        %s  (dropped %s)", f"{n_rows:,}", f"{dropped_rows:,}")
+    logger.info("Distinct images:        %s  (dropped %s)", f"{n_imgs:,}", f"{dropped_imgs:,}")
+    logger.info("  using RESIZED key:    %s", f"{n_resized:,}")
+    logger.info("  using ORIGINAL key:   %s", f"{n_original:,}")
+
+    if args.dry_run:
+        logger.info("--dry-run: not writing")
+        return 0
+
+    out_key = (
+        args.out_key
+        or f"etl-outputs/coralnet/{args.run}/coralnet_training_manifest_{args.run}.parquet"
+    )
+    out_uri = f"s3://{args.bucket}/{out_key}"
+    manifest.to_parquet(out_uri, storage_options=storage_options, index=False)
+    logger.info("Wrote %s rows -> %s", f"{n_rows:,}", out_uri)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sagemaker_processing_entrypoint.py
+++ b/scripts/sagemaker_processing_entrypoint.py
@@ -29,7 +29,7 @@ def main():
     parser.add_argument(
         "--task",
         required=True,
-        choices=["eval", "inference", "coralnet-etl", "coralnet-refresh"],
+        choices=["eval", "inference", "coralnet-etl", "coralnet-refresh", "coralnet-resize"],
         help="Which processing routine to run.",
     )
     # Pass-through args specific to each task.
@@ -51,6 +51,10 @@ def main():
         from mermaidseg.datasets.coralnet.scraper.refresh_image_lists import main as refresh_main
 
         sys.exit(refresh_main(extra))
+    elif args.task == "coralnet-resize":
+        from mermaidseg.datasets.coralnet.preprocessing.resize import main as resize_main
+
+        sys.exit(resize_main(extra))
     else:
         raise SystemExit(f"Unknown task: {args.task}")
 

--- a/tests/datasets/coralnet/test_coralnet_dataset_resized.py
+++ b/tests/datasets/coralnet/test_coralnet_dataset_resized.py
@@ -1,0 +1,133 @@
+"""CoralNetDataset consuming the resized training parquet (per-image image_s3_key).
+
+These tests are hermetic: parquet reads, the boto3 client, and S3 image fetches are all
+stubbed, so nothing touches AWS.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+from PIL import Image
+
+import mermaidseg.datasets.coralnet.coralnet_dataset as cnd
+from mermaidseg.datasets.coralnet.coralnet_dataset import CoralNetDataset
+
+
+def _make_dataset(monkeypatch, df_annotations, captured_keys, image_provider, **base_kwargs):
+    """Build a CoralNetDataset offline.
+
+    ``df_annotations`` is returned in place of any S3 parquet read. ``image_provider``
+    maps a requested S3 key to a PIL image; every requested key is appended to
+    ``captured_keys``.
+    """
+    monkeypatch.setattr(pd, "read_parquet", lambda *a, **k: df_annotations.copy())
+    monkeypatch.setattr(cnd.boto3, "client", lambda *a, **k: MagicMock())
+
+    def fake_get_image_s3(s3, bucket, key, **kwargs):
+        captured_keys.append(key)
+        return image_provider(key)
+
+    monkeypatch.setattr(cnd, "get_image_s3", fake_get_image_s3)
+    return CoralNetDataset(**base_kwargs)
+
+
+def _resized_parquet_df():
+    """One image, two points, with a resolved resized image_s3_key (new-parquet
+    shape)."""
+    return pd.DataFrame(
+        {
+            "source_id": [1, 1],
+            "image_id": ["img1", "img1"],
+            "row": [10, 5],
+            "col": [20, 7],
+            "coralnet_id": [82, 82],
+            "source_label_name": ["82", "82"],
+            "image_s3_key": ["dev/images/resized/s1/images/img1.jpg"] * 2,
+        }
+    )
+
+
+def test_read_image_prefers_resolved_key(monkeypatch):
+    """When the parquet carries image_s3_key, read_image loads exactly that key."""
+    keys: list[str] = []
+    ds = _make_dataset(
+        monkeypatch,
+        _resized_parquet_df(),
+        keys,
+        lambda key: Image.new("RGB", (50, 30)),
+    )
+    # df_images must carry the resolved key through to read_image.
+    assert "image_s3_key" in ds.df_images.columns
+    ds.read_image(
+        image_id="img1", source_id="1", image_s3_key="dev/images/resized/s1/images/img1.jpg"
+    )
+    assert keys[-1] == "dev/images/resized/s1/images/img1.jpg"
+
+
+def test_read_image_falls_back_to_constructed_key(monkeypatch):
+    """Legacy parquet (no image_s3_key) -> read_image constructs the original key."""
+    legacy = _resized_parquet_df().drop(columns=["image_s3_key"])
+    keys: list[str] = []
+    ds = _make_dataset(monkeypatch, legacy, keys, lambda key: Image.new("RGB", (50, 30)))
+    assert "image_s3_key" not in ds.df_images.columns
+    ds.read_image(image_id="img1", source_id="1")
+    assert keys[-1] == "coralnet-public-images/s1/images/img1.jpg"
+
+
+def test_getitem_places_label_at_point_with_correct_orientation(monkeypatch):
+    """End-to-end alignment: the (row, col) from the parquet lands at mask[row, col] on
+    the loaded image, with row indexing height and col indexing width (guards a row/col
+    transpose).
+
+    Uses a single point and a non-square image so a transpose would move the label.
+    """
+    df = pd.DataFrame(
+        {
+            "source_id": [1],
+            "image_id": ["img1"],
+            "row": [10],
+            "col": [20],
+            "coralnet_id": [82],
+            "source_label_name": ["82"],
+            "image_s3_key": ["dev/images/resized/s1/images/img1.jpg"],
+        }
+    )
+    keys: list[str] = []
+    # PIL size is (width, height) -> numpy array shape (30, 50, 3): H=30, W=50.
+    ds = _make_dataset(monkeypatch, df, keys, lambda key: Image.new("RGB", (50, 30)), padding=None)
+
+    image, mask = ds[0]
+
+    assert keys == ["dev/images/resized/s1/images/img1.jpg"]
+    assert image.shape == (30, 50, 3)
+    assert mask.shape == (30, 50)  # (height, width) — matches the loaded image
+    # Single foreground class -> local id 1, placed exactly at (row=10, col=20).
+    assert mask[10, 20] == 1
+    assert int((mask != 0).sum()) == 1  # nothing else set; no transpose to (20, 10)
+
+
+def test_missing_required_column_raises(monkeypatch):
+    """A parquet missing a required column fails fast with a clear error, not a pandas
+    KeyError."""
+    bad = _resized_parquet_df().drop(columns=["coralnet_id"])
+    with pytest.raises(ValueError, match="missing required columns.*coralnet_id"):
+        _make_dataset(monkeypatch, bad, [], lambda key: Image.new("RGB", (8, 8)))
+
+
+def test_collate_fn_skips_failed_loads(monkeypatch):
+    """A (None, None) failed-load item is dropped; the surviving sample is stacked."""
+    import torch
+
+    keys: list[str] = []
+    ds = _make_dataset(
+        monkeypatch, _resized_parquet_df(), keys, lambda key: Image.new("RGB", (8, 8))
+    )
+    good_img = np.zeros((3, 8, 8), dtype=np.float32)
+    good_mask = np.zeros((8, 8), dtype=np.int64)
+    images, masks = ds.collate_fn([(None, None), (good_img, good_mask)])
+    assert isinstance(images, torch.Tensor)
+    assert images.shape[0] == 1 and masks.shape[0] == 1

--- a/tests/datasets/coralnet/test_preprocessing.py
+++ b/tests/datasets/coralnet/test_preprocessing.py
@@ -17,10 +17,13 @@ from mermaidseg.datasets.coralnet.preprocessing.inspect import (
 )
 from mermaidseg.datasets.coralnet.preprocessing.manifest import (
     build_manifest,
+    build_training_manifest,
     combine_checkpoints,
 )
 from mermaidseg.datasets.coralnet.preprocessing.resize import (
     _resized_s3_key_for,
+    _resolve_checkpoint_s3_keys,
+    _summarise_checkpoint,
     get_pending_items,
     read_checkpoint,
     resize_and_upload_all_images,
@@ -83,7 +86,8 @@ def test_resize_image_square():
 
 
 def test_resize_converts_rgba_to_rgb_jpeg():
-    """RGBA images are converted to RGB so they can be JPEG-encoded (not RGBA-as-JPEG error)."""
+    """RGBA images are converted to RGB so they can be JPEG-encoded (not RGBA-as-JPEG
+    error)."""
     img = Image.new("RGBA", (3000, 2000), color=(255, 0, 0, 128))
     img_bytes = BytesIO()
     img.save(img_bytes, format="PNG")
@@ -100,7 +104,8 @@ def test_resize_converts_rgba_to_rgb_jpeg():
 
 
 def test_resize_converts_rgba_below_threshold():
-    """A small RGBA image is still re-encoded to RGB JPEG, not passed through as raw bytes."""
+    """A small RGBA image is still re-encoded to RGB JPEG, not passed through as raw
+    bytes."""
     img = Image.new("RGBA", (800, 400), color=(0, 255, 0, 64))
     img_bytes = BytesIO()
     img.save(img_bytes, format="PNG")
@@ -117,7 +122,8 @@ def test_resize_converts_rgba_below_threshold():
 
 
 def test_scan_for_missing_resized_images_builds_todo_list():
-    """Scan lists the resized prefix once and diffs in memory — no per-image head_object."""
+    """Scan lists the resized prefix once and diffs in memory — no per-image
+    head_object."""
     df_images = pd.DataFrame(
         {
             "source_id": [1, 1, 2],
@@ -212,7 +218,8 @@ def test_checkpoint_pending_items_extracted():
 
 
 def test_resize_and_upload_image_returns_completed_result():
-    """Worker downloads/resizes/uploads and RETURNS a checkpoint row; it does no checkpoint I/O."""
+    """Worker downloads/resizes/uploads and RETURNS a checkpoint row; it does no
+    checkpoint I/O."""
     # Create mock S3 client
     mock_s3 = Mock()
 
@@ -264,7 +271,8 @@ def test_resize_and_upload_image_returns_completed_result():
 
 
 def _checkpoint_table(df: pd.DataFrame) -> ibis.Table:
-    """Memtable with the dtypes the checkpoint parquet schema guarantees in production."""
+    """Memtable with the dtypes the checkpoint parquet schema guarantees in
+    production."""
     return ibis.memtable(
         df.astype(
             {
@@ -312,7 +320,8 @@ def test_combine_checkpoints_later_run_wins():
 
 
 def test_combine_checkpoints_most_recent_timestamp_wins_regardless_of_order():
-    """The freshest resize_timestamp wins even when checkpoints are passed out of order."""
+    """The freshest resize_timestamp wins even when checkpoints are passed out of
+    order."""
     ckpt_newer = pd.DataFrame(
         {
             "source_id": [1],
@@ -354,7 +363,8 @@ def test_combine_checkpoints_empty_raises():
 
 
 def test_combine_checkpoints_single_input_dedups():
-    """A single checkpoint passes through, still deduped by latest timestamp per image."""
+    """A single checkpoint passes through, still deduped by latest timestamp per
+    image."""
     ckpt = pd.DataFrame(
         {
             "source_id": [1, 1],
@@ -424,8 +434,8 @@ def test_manifest_schema_is_correct():
 
 
 def test_manifest_dimensions_and_keys_match_resize():
-    """Below threshold keeps original dims; above threshold floors like the resize worker, and
-    output_s3_key matches _resized_s3_key_for."""
+    """Below threshold keeps original dims; above threshold floors like the resize
+    worker, and output_s3_key matches _resized_s3_key_for."""
     threshold = 2048
     df_images = pd.DataFrame(
         {
@@ -471,6 +481,161 @@ def test_manifest_dimensions_and_keys_match_resize():
     )
 
 
+def test_training_manifest_scales_coords_and_excludes():
+    """Sub-threshold coords unchanged + original key; resized coords floored to load
+    dims + resized key; needs_resize-but-not-completed images (failed / absent from
+    checkpoint) excluded."""
+    images = pd.DataFrame(
+        {
+            "source_id": [1, 1, 1, 1, 1],
+            "image_id": ["sub", "big", "fail", "missing", "nodims"],
+            "s3_key": [
+                "coralnet-public-images/s1/images/sub.jpg",
+                "coralnet-public-images/s1/images/big.jpg",
+                "coralnet-public-images/s1/images/fail.jpg",
+                "coralnet-public-images/s1/images/missing.jpg",
+                "coralnet-public-images/s1/images/nodims.jpg",
+            ],
+            # "nodims" has unknown dimensions (e.g. header_status="not_found").
+            "width": [1000, 4000, 5000, 6000, None],
+            "height": [800, 2000, 3000, 3000, None],
+            "needs_resize": [False, True, True, True, False],
+        }
+    )
+    # "missing" needs_resize but has no checkpoint row at all -> must be excluded.
+    checkpoint = pd.DataFrame(
+        {
+            "source_id": [1, 1],
+            "image_id": ["big", "fail"],
+            "status": ["completed", "failed"],
+            "resize_timestamp": [datetime.now(), None],
+            "error_message": [None, "decode failed"],
+        }
+    )
+    annotations = pd.DataFrame(
+        {
+            "source_id": [1, 1, 1, 1, 1, 1],
+            "image_id": ["sub", "big", "big", "fail", "missing", "nodims"],
+            "row": [400, 1000, 1999, 10, 10, 10],
+            "col": [500, 2000, 3999, 10, 10, 10],
+            "coralnet_id": [82, 91, 91, 7, 7, 7],
+        }
+    )
+
+    out = build_training_manifest(
+        annotations=ibis.memtable(annotations),
+        images=ibis.memtable(images),
+        checkpoint=ibis.memtable(checkpoint),
+        output_prefix="dev/images",
+        threshold=2048,
+    ).to_pandas()
+
+    # Only sub-threshold + completed-resize images with known dims survive
+    # ("fail"/"missing" excluded for incomplete resize, "nodims" for null dimensions).
+    assert set(out["image_id"]) == {"sub", "big"}
+
+    # Every surviving point is in bounds (no nulls, no out-of-range from null-dim collapse).
+    assert out["load_width"].notna().all() and out["load_height"].notna().all()
+    assert (out["row"] >= 0).all() and (out["row"] < out["load_height"]).all()
+    assert (out["col"] >= 0).all() and (out["col"] < out["load_width"]).all()
+
+    # Coords/dims are stored as int16 (bounded by the 2048 resize threshold) to keep the file small.
+    for c in ("row", "col", "load_width", "load_height"):
+        assert out[c].dtype == "int16", (c, out[c].dtype)
+
+    # Sub-threshold image: original key, coords unchanged, source_label_name = str(coralnet_id).
+    sub = out[out["image_id"] == "sub"].iloc[0]
+    assert sub["image_s3_key"] == "coralnet-public-images/s1/images/sub.jpg"
+    assert (int(sub["row"]), int(sub["col"])) == (400, 500)
+    assert bool(sub["uses_resized_image"]) is False
+    assert sub["source_label_name"] == "82"
+
+    # Resized image: resized key, dims floored to threshold (4000 -> 2048, 2000 -> 1024).
+    big = out[out["image_id"] == "big"]
+    assert (big["image_s3_key"] == "dev/images/resized/s1/images/big.jpg").all()
+    assert big["uses_resized_image"].all()
+    assert (big["load_width"] == 2048).all() and (big["load_height"] == 1024).all()
+    coords = set(zip(big["row"].astype(int), big["col"].astype(int), strict=True))
+    # (1000,2000) -> (floor(1000*1024/2000), floor(2000*2048/4000)) = (512, 1024)
+    assert (512, 1024) in coords
+    # (1999,3999) -> (floor(1999*1024/2000), floor(3999*2048/4000)) = (1023, 2047), within bounds
+    assert (1023, 2047) in coords
+
+
+def _build_one_image_manifest(orig_w, orig_h, row, col, *, threshold=2048):
+    """Run build_training_manifest for a single image+point; return (out_df,
+    needs_resize)."""
+    needs = max(orig_w, orig_h) > threshold
+    images = pd.DataFrame(
+        {
+            "source_id": [1],
+            "image_id": ["x"],
+            "s3_key": ["coralnet-public-images/s1/images/x.jpg"],
+            "width": [orig_w],
+            "height": [orig_h],
+            "needs_resize": [needs],
+        }
+    )
+    checkpoint = pd.DataFrame(
+        {
+            "source_id": [1],
+            "image_id": ["x"],
+            "status": ["completed"],
+            "resize_timestamp": [datetime.now()],
+            "error_message": [None],
+        }
+    )
+    annotations = pd.DataFrame(
+        {"source_id": [1], "image_id": ["x"], "row": [row], "col": [col], "coralnet_id": [82]}
+    )
+    out = build_training_manifest(
+        annotations=ibis.memtable(annotations),
+        images=ibis.memtable(images),
+        checkpoint=ibis.memtable(checkpoint),
+        output_prefix="dev/images",
+        threshold=threshold,
+    ).to_pandas()
+    return out, needs
+
+
+@pytest.mark.parametrize(
+    "orig_w,orig_h",
+    [
+        (4000, 2000),  # landscape, resized
+        (2000, 4000),  # portrait, resized
+        (3000, 3000),  # square, resized (non-power-of-2 ratio)
+        (2049, 2049),  # just over threshold
+        (800, 600),  # sub-threshold, not resized
+        (2048, 1000),  # longest == threshold, not resized
+    ],
+)
+def test_training_manifest_load_dims_and_coords_match_real_resize(orig_w, orig_h):
+    """Builder load dims + scaled coords agree with the actual PIL resize (oracle), and
+    a far-corner point stays in bounds after the floor+clip."""
+    threshold = 2048
+    r, c = orig_h - 1, orig_w - 1  # far corner stresses the clip
+    out, needs = _build_one_image_manifest(orig_w, orig_h, r, c, threshold=threshold)
+    assert len(out) == 1
+    rowd = out.iloc[0]
+
+    buf = BytesIO()
+    Image.new("RGB", (orig_w, orig_h)).save(buf, format="JPEG")
+    buf.seek(0)
+    resized = Image.open(resize_image_to_threshold(buf, threshold=threshold))
+    resized.load()
+
+    # Oracle: recorded load dims == dimensions the real resize produced.
+    assert int(rowd["load_width"]) == resized.width
+    assert int(rowd["load_height"]) == resized.height
+    assert bool(rowd["uses_resized_image"]) == needs
+
+    # Coords scale by load/orig (same factor the builder uses) and stay in bounds.
+    assert int(rowd["col"]) == min(int(c * resized.width / orig_w), resized.width - 1)
+    assert int(rowd["row"]) == min(int(r * resized.height / orig_h), resized.height - 1)
+    assert 0 <= int(rowd["row"]) < resized.height
+    assert 0 <= int(rowd["col"]) < resized.width
+
+
 # ============================================================================
 # Image inspection and robustness tests
 # ============================================================================
@@ -490,7 +655,8 @@ def test_inspect_image_valid_rgb(valid_rgb_jpeg_bytes):
 
 
 def test_inspect_image_rgba_png(rgba_png_bytes):
-    """Inspection passes for RGBA PNG; the resize step converts it to RGB before JPEG encoding."""
+    """Inspection passes for RGBA PNG; the resize step converts it to RGB before JPEG
+    encoding."""
     image_bytes = BytesIO(rgba_png_bytes)
     inspection = inspect_image(image_bytes)
 
@@ -501,7 +667,8 @@ def test_inspect_image_rgba_png(rgba_png_bytes):
 
 
 def test_inspect_image_grayscale(grayscale_jpeg_bytes):
-    """Inspection passes for grayscale JPEG; the resize step encodes single-channel L directly."""
+    """Inspection passes for grayscale JPEG; the resize step encodes single-channel L
+    directly."""
     image_bytes = BytesIO(grayscale_jpeg_bytes)
     inspection = inspect_image(image_bytes)
 
@@ -553,7 +720,8 @@ def test_inspect_image_none():
 
 
 def test_resize_converts_and_uploads_rgba_png(rgba_png_bytes):
-    """Worker converts an RGBA PNG to RGB JPEG, uploads it, and returns a completed result."""
+    """Worker converts an RGBA PNG to RGB JPEG, uploads it, and returns a completed
+    result."""
     mock_s3 = MagicMock()
 
     # Mock GET to return RGBA PNG bytes
@@ -650,8 +818,8 @@ def test_resize_mixed_batch(valid_rgb_jpeg_bytes, truncated_jpeg_bytes, tmp_path
 
 
 def test_resize_resumes_only_pending_items(valid_rgb_jpeg_bytes, tmp_path):
-    """An existing checkpoint with completed rows is resumed: completed images are not re-
-    downloaded."""
+    """An existing checkpoint with completed rows is resumed: completed images are not
+    re- downloaded."""
     mock_s3 = MagicMock()
     mock_s3.get_object.return_value = {"Body": BytesIO(valid_rgb_jpeg_bytes)}
     mock_s3.put_object = MagicMock()
@@ -711,8 +879,8 @@ def test_resize_resumes_only_pending_items(valid_rgb_jpeg_bytes, tmp_path):
 
 
 def test_resume_summary_counts_never_negative(valid_rgb_jpeg_bytes, tmp_path):
-    """Resuming with a todo smaller than the checkpoint reports counts from the checkpoint
-    itself."""
+    """Resuming with a todo smaller than the checkpoint reports counts from the
+    checkpoint itself."""
     mock_s3 = MagicMock()
     mock_s3.get_object.return_value = {"Body": BytesIO(valid_rgb_jpeg_bytes)}
 
@@ -761,10 +929,126 @@ def test_resume_summary_counts_never_negative(valid_rgb_jpeg_bytes, tmp_path):
     assert num_corrupted == 1  # 'c'
 
 
+def test_summarise_checkpoint_handles_old_schema_without_skip_reason():
+    """A pre-schema checkpoint (no skip_reason column) summarizes without KeyError.
+
+    Reproduces the May-checkpoint crash: that file predates the skip_reason column, and
+    summarizing it raised KeyError. The summary must treat absent skip_reason as "no corrupted
+    skips".
+    """
+    old_checkpoint = pd.DataFrame(
+        {
+            "source_id": [1, 1, 1, 1],
+            "image_id": ["a", "b", "c", "d"],
+            "status": ["completed", "completed", "skipped", "failed"],
+            "resize_timestamp": [datetime.now(), datetime.now(), None, None],
+            "error_message": [None, None, None, "boom"],
+        }
+    )
+    assert "skip_reason" not in old_checkpoint.columns
+
+    num_resized, num_skipped, num_failed, num_corrupted = _summarise_checkpoint(old_checkpoint)
+
+    assert num_resized == 2
+    assert num_skipped == 1  # the lone skip is counted as a plain skip, not corrupted
+    assert num_failed == 1
+    assert num_corrupted == 0
+
+
+def test_checkpoint_keys_default_pull_and_push_to_same_run_path():
+    """With no overrides, pull and push both derive from the run version."""
+    pull_key, push_key = _resolve_checkpoint_s3_keys(
+        run="20260623_nogit", checkpoint_s3_key=None, pull_checkpoint_s3_key=None
+    )
+    assert pull_key == push_key
+    assert "20260623_nogit" in push_key
+
+
+def test_checkpoint_keys_pull_from_old_run_push_to_new_run():
+    """Pulling a prior run's checkpoint must NOT redirect the push to that prior path.
+
+    Reproduces the wrong-path bug: one --checkpoint-s3-key served both pull and push, so a job
+    that seeded from May's checkpoint wrote its results back over May's path. Pull and push are
+    now independent.
+    """
+    pull_key, push_key = _resolve_checkpoint_s3_keys(
+        run="20260623_nogit",
+        checkpoint_s3_key=None,
+        pull_checkpoint_s3_key="etl-outputs/coralnet/20260526_807b611/resize_checkpoint_20260526_807b611.parquet",
+    )
+    assert "20260526_807b611" in pull_key  # pulls the old run
+    assert "20260623_nogit" in push_key  # but pushes under the new run
+    assert pull_key != push_key
+
+
+def test_checkpoint_keys_pull_falls_back_to_push_override():
+    """When only the push key is overridden, pull reuses it (single-key behavior
+    preserved)."""
+    pull_key, push_key = _resolve_checkpoint_s3_keys(
+        run="20260623_nogit",
+        checkpoint_s3_key="custom/path/checkpoint.parquet",
+        pull_checkpoint_s3_key=None,
+    )
+    assert pull_key == "custom/path/checkpoint.parquet"
+    assert push_key == "custom/path/checkpoint.parquet"
+
+
+def test_resize_raises_when_checkpoint_does_not_intersect_todo(tmp_path):
+    """A pre-existing checkpoint whose pending IDs don't match the todo must fail
+    loudly.
+
+    Reproduces the cross-version bug: a checkpoint from an earlier ETL run is on disk, but the new
+    run's todo has different image IDs. The pending/todo merge collapses to zero rows. The old code
+    silently processed nothing and reported success; it must now raise.
+    """
+    mock_s3 = MagicMock()
+
+    checkpoint_path = tmp_path / "checkpoint.parquet"
+
+    # Old run's checkpoint: pending images from a different ETL version.
+    write_checkpoint(
+        checkpoint_path,
+        pd.DataFrame(
+            {
+                "source_id": [1, 1],
+                "image_id": ["old_a", "old_b"],
+                "status": ["pending", "pending"],
+                "resize_timestamp": [None, None],
+                "error_message": [None, None],
+                "skip_reason": [None, None],
+            }
+        ),
+    )
+
+    # This run's todo: entirely different image IDs — zero overlap with the checkpoint.
+    todo_df = pd.DataFrame(
+        [
+            {
+                "source_id": 2,
+                "image_id": "new_c",
+                "original_s3_key": "coralnet-public-images/s2/images/new_c.jpg",
+                "output_s3_key": "etl-outputs/coralnet/resized/s2/images/new_c.jpg",
+            }
+        ]
+    )
+
+    with pytest.raises(ValueError, match="intersect"):
+        resize_and_upload_all_images(
+            df_todo=todo_df,
+            bucket="test-bucket",
+            output_prefix="etl-outputs/coralnet",
+            checkpoint_path=checkpoint_path,
+            threshold=2048,
+            workers=2,
+            s3_client=mock_s3,
+        )
+
+
 def test_resize_all_images_builds_one_pool_sized_client(
     monkeypatch, valid_rgb_jpeg_bytes, tmp_path
 ):
-    """With no client injected, the orchestrator builds ONE shared client with pool >= workers."""
+    """With no client injected, the orchestrator builds ONE shared client with pool >=
+    workers."""
     from mermaidseg.datasets.coralnet.preprocessing import resize as resize_module
 
     created_pools: list[int] = []

--- a/tests/sagemaker_launcher/test_processing_entrypoint.py
+++ b/tests/sagemaker_launcher/test_processing_entrypoint.py
@@ -1,0 +1,62 @@
+"""Tests for the in-container processing entrypoint
+(scripts/sagemaker_processing_entrypoint.py).
+
+The entrypoint dispatches on --task and forwards the remaining args to the matching
+routine. A task that isn't wired into the argparse choices fails the whole job at
+container start (the "invalid choice: 'coralnet-resize'" CloudWatch error), so these
+tests lock the dispatch table.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import sagemaker_processing_entrypoint as entrypoint  # type: ignore  # noqa: E402
+
+
+def test_dispatches_coralnet_resize_and_forwards_args(monkeypatch):
+    """--task=coralnet-resize routes to resize.main with the remaining args and exits its code."""
+    received: dict[str, object] = {}
+
+    def fake_resize_main(extra: list[str]) -> int:
+        received["extra"] = extra
+        return 0
+
+    monkeypatch.setattr("mermaidseg.datasets.coralnet.preprocessing.resize.main", fake_resize_main)
+    monkeypatch.setattr(sys, "argv", ["prog", "--task=coralnet-resize", "--run=foo", "--bucket=b"])
+
+    with pytest.raises(SystemExit) as exc:
+        entrypoint.main()
+
+    assert exc.value.code == 0
+    assert received["extra"] == ["--run=foo", "--bucket=b"]
+
+
+def test_resize_nonzero_exit_propagates(monkeypatch):
+    """A non-zero return from resize.main becomes the entrypoint's exit code (failed-job
+    signal)."""
+    monkeypatch.setattr("mermaidseg.datasets.coralnet.preprocessing.resize.main", lambda extra: 1)
+    monkeypatch.setattr(sys, "argv", ["prog", "--task=coralnet-resize", "--run=foo"])
+
+    with pytest.raises(SystemExit) as exc:
+        entrypoint.main()
+
+    assert exc.value.code == 1
+
+
+def test_unknown_task_is_rejected(monkeypatch):
+    """An unregistered task is rejected by argparse before any routine runs."""
+    monkeypatch.setattr(sys, "argv", ["prog", "--task=does-not-exist"])
+
+    with pytest.raises(SystemExit) as exc:
+        entrypoint.main()
+
+    # argparse exits with code 2 on invalid choice.
+    assert exc.value.code == 2


### PR DESCRIPTION
Part **3/4** of the #155 split. **Stacked on** `feat/coralnet-etl-scraper` (PR 2). Closes #146 and #154.

- resize fixes: merge-empty guard, pull/push checkpoint key split, SageMaker `main()`
- `build_training_manifest` + `scripts/build_coralnet_training_manifest.py` (resize-existence read from S3, authoritative)
- `coralnet_dataset.read_image` consumes a per-image `image_s3_key` (resized key for resized images, original for sub-threshold) — ported from #128
- entrypoint + `pyproject` gain `coralnet-resize`
- tests: **48 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)