### PR TITLE
feat(coralnet): ETL/scraper + resize manifest + dataset consumption (#130, #153, #146, #154)

### DIFF
--- a/mermaidseg/datasets/coralnet/coralnet_dataset.py
+++ b/mermaidseg/datasets/coralnet/coralnet_dataset.py
@@ -16,12 +16,10 @@ filename for backward compatibility; pin a specific build via
 
 from __future__ import annotations
 
-import json
 import os
 from typing import Any
 
 import boto3
-import fsspec
 import numpy as np
 import pandas as pd
 from numpy.typing import NDArray
@@ -33,7 +31,8 @@ _LEGACY_ANNOTATIONS_PATH = "coralnet_annotations_30112025.parquet"
 
 
 def _resolve_default_annotations_path() -> str:
-    """Resolve the default ``annotations_path`` from env vars, falling back to the legacy file.
+    """Resolve the default ``annotations_path`` from env vars, falling back to the
+    legacy file.
 
     Precedence:
         1. ``MERMAID_CORALNET_ANNOTATIONS_PATH`` — full S3 key as published by the ETL.
@@ -53,8 +52,8 @@ def _resolve_default_annotations_path() -> str:
 
 
 class CoralNetDataset(BaseCoralDataset):
-    """A PyTorch Dataset for loading CoralNet annotated coral reef images from a Parquet file stored
-    on S3.
+    """A PyTorch Dataset for loading CoralNet annotated coral reef images from a Parquet
+    file stored on S3.
 
     Each item returned is a tuple ``(image, source_labels)`` where
     ``source_labels`` is an integer mask in CoralNet's own provider-ID label
@@ -78,6 +77,10 @@ class CoralNetDataset(BaseCoralDataset):
     """
 
     SOURCE_NAME = "coralnet"
+
+    # Columns every CoralNet annotations parquet must provide. ``source_label_name`` is derived
+    # from ``coralnet_id``; ``image_s3_key`` is optional (present only in the resized parquet).
+    REQUIRED_COLUMNS: tuple[str, ...] = ("source_id", "image_id", "row", "col", "coralnet_id")
 
     annotations_path: str
     source_ids: list[int | str]
@@ -133,42 +136,40 @@ class CoralNetDataset(BaseCoralDataset):
         """
         annotations_path = f"s3://{self.source_bucket}/{self.annotations_path}"
         df_annotations = pd.read_parquet(annotations_path)
-        id2name_path = (
-            "s3://dev-datamermaid-sm-sources/coralnet-public-images/temporary/coralnet_id2name.json"
-        )
-
-        with fsspec.open(id2name_path, "r") as f:
-            coralnet_id2name = json.load(f)
-
-        df_annotations["coralnet_name"] = df_annotations["coralnet_id"].map(
-            lambda x: coralnet_id2name.get(str(x))
-        )
-        df_annotations["source_label_name"] = (
-            df_annotations["coralnet_name"].astype(str).str.lower()
-        )
-
-        df_annotations = df_annotations[
-            [
-                "source_id",
-                "image_id",
-                "row",
-                "col",
-                "coralnet_id",
-                "coralnet_name",
-                "source_label_name",
-            ]
-        ]
+        missing = set(self.REQUIRED_COLUMNS) - set(df_annotations.columns)
+        if missing:
+            raise ValueError(
+                f"CoralNet annotations parquet at {annotations_path} is missing required "
+                f"columns: {sorted(missing)}"
+            )
+        df_annotations["source_label_name"] = df_annotations["coralnet_id"].astype(str)
+        columns = ["source_id", "image_id", "row", "col", "coralnet_id", "source_label_name"]
+        # The resized training parquet carries a per-image resolved S3 key (resized or original)
+        # with row/col already scaled to that image. The legacy parquet omits it, in which case
+        # read_image falls back to constructing the original key.
+        if "image_s3_key" in df_annotations.columns:
+            columns.append("image_s3_key")
+        df_annotations = df_annotations[columns]
 
         df_images = self._derive_df_images_from_annotations(df_annotations)
         return df_annotations, df_images
 
     def _derive_df_images_from_annotations(self, df_annotations: pd.DataFrame) -> pd.DataFrame:
+        columns = ["source_id", "image_id"]
+        if "image_s3_key" in df_annotations.columns:
+            columns.append("image_s3_key")
         return (
-            df_annotations[["source_id", "image_id"]]
+            df_annotations[columns]
             .drop_duplicates(subset=["source_id", "image_id"])
             .reset_index(drop=True)
         )
 
-    def read_image(self, image_id: str, source_id: str, **row_kwargs: Any) -> NDArray[Any]:
-        key = f"{self.source_s3_prefix}/s{source_id}/images/{image_id}.jpg"
+    def read_image(
+        self,
+        image_id: str,
+        source_id: str,
+        image_s3_key: str | None = None,
+        **row_kwargs: Any,
+    ) -> NDArray[Any]:
+        key = image_s3_key or f"{self.source_s3_prefix}/s{source_id}/images/{image_id}.jpg"
         return np.array(get_image_s3(s3=self.s3, bucket=self.source_bucket, key=key).convert("RGB"))

--- a/mermaidseg/datasets/coralnet/etl/audit.py
+++ b/mermaidseg/datasets/coralnet/etl/audit.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -107,6 +108,7 @@ def _empty_record(source_id: int, audit_ts: datetime) -> dict[str, Any]:
         "metadata_csv_read_failed": False,
         "is_complete": False,
         "image_count_match": False,
+        "image_list_covers_annotations": False,
         "errors": [],
     }
 
@@ -205,13 +207,21 @@ def _audit_one_source(
         except Exception as e:  # noqa: BLE001
             record["errors"].append(f"Error reading {spec.filename}: {type(e).__name__}: {e}")
 
+    record["image_count_match"] = record["n_images_s3"] == record["n_images_csv"]
+    # image_list.csv is the only Name -> CoralNet image_id bridge the ETL has. When it lists fewer
+    # images than annotations.csv references, every uncovered annotated image is silently dropped
+    # downstream regardless of confirmed status. Gate on coverage so a truncated image_list can't
+    # masquerade as a usable source (see the 2026-06 image_list truncation incident).
+    record["image_list_covers_annotations"] = (
+        record["n_images_csv"] >= record["n_unique_images_annotated"]
+    )
     record["is_complete"] = bool(
         record["has_images_folder"]
         and record["has_annotations_csv"]
         and record["has_image_list_csv"]
         and record["n_annotations"] > 0
+        and record["image_list_covers_annotations"]
     )
-    record["image_count_match"] = record["n_images_s3"] == record["n_images_csv"]
     return record
 
 
@@ -225,9 +235,28 @@ def _get_thread_context() -> tuple[BaseClient, CsvReader]:
     return _thread_local.s3, _thread_local.csv_reader
 
 
+_CRED_REFRESH_INTERVAL_SECONDS = 3000  # refresh every ~50 min; SageMaker rotates at 60 min
+
+
+def _refresh_thread_credentials_if_due() -> None:
+    """Refresh per-thread ibis credentials based on wall time, not call count.
+
+    Called inside each worker invocation so the refresh happens on the worker thread
+    that owns the ibis connection. A time-based check avoids threading
+    credential_refresh_every into the worker args and handles variable per-source
+    latency correctly.
+    """
+    now = time.monotonic()
+    last = getattr(_thread_local, "last_cred_refresh", 0.0)
+    if now - last >= _CRED_REFRESH_INTERVAL_SECONDS:
+        refresh_thread_ibis_credentials_if_present(_thread_local)
+        _thread_local.last_cred_refresh = now
+
+
 def _audit_worker(args: tuple[int, str, str, datetime]) -> dict[str, Any]:
     source_id, bucket, prefix, audit_ts = args
     client, reader = _get_thread_context()
+    _refresh_thread_credentials_if_due()
     return _audit_one_source(client, reader, bucket, prefix, source_id, audit_ts)
 
 
@@ -246,7 +275,6 @@ def audit_sources(
     source_ids: list[int] | None = None,
     s3_client: BaseClient | None = None,
     csv_reader: CsvReader | None = None,
-    credential_refresh_every: int = 100,
 ) -> pd.DataFrame:
     """Audit every CoralNet source folder under ``s3://<bucket>/<prefix>/``.
 
@@ -262,9 +290,6 @@ def audit_sources(
         csv_reader: ``CsvReader`` callable. When None and ``s3_client`` is
             also None, the production ibis path is used; when ``s3_client``
             is given, falls back to a boto3-backed reader against it.
-        credential_refresh_every: Re-run the DuckDB ``CREATE OR REPLACE SECRET``
-            on every worker's ibis connection after this many completed
-            sources, to survive SageMaker IAM rotation.
     """
     bucket = bucket or get_bucket()
     prefix = prefix or get_prefix()
@@ -307,8 +332,6 @@ def audit_sources(
                     record = _empty_record(source_id, audit_ts)
                     record["errors"].append(f"Worker exception: {type(e).__name__}: {e}")
                 results.append(record)
-                if len(results) % credential_refresh_every == 0:
-                    refresh_thread_ibis_credentials_if_present(_thread_local)
     else:
         for source_id in tqdm(source_ids, desc="Auditing sources"):
             try:

--- a/mermaidseg/datasets/coralnet/etl/schemas.py
+++ b/mermaidseg/datasets/coralnet/etl/schemas.py
@@ -1,8 +1,9 @@
 """PyArrow schemas for the three CoralNet ETL output parquets.
 
 Single source of truth for column names, dtypes, and primary keys. The writer in
-:mod:`mermaidseg.datasets.coralnet.etl.io` casts every DataFrame to the declared schema before
-writing so byte output is deterministic and downstream readers can rely on the column types.
+:mod:`mermaidseg.datasets.coralnet.etl.io` casts every DataFrame to the declared schema
+before writing so byte output is deterministic and downstream readers can rely on the
+column types.
 """
 
 from __future__ import annotations
@@ -34,6 +35,7 @@ AUDIT_SCHEMA: pa.Schema = pa.schema(
         pa.field("metadata_csv_read_failed", pa.bool_(), nullable=False),
         pa.field("is_complete", pa.bool_(), nullable=False),
         pa.field("image_count_match", pa.bool_(), nullable=False),
+        pa.field("image_list_covers_annotations", pa.bool_(), nullable=False),
         pa.field("errors", pa.list_(pa.string()), nullable=True),
     ]
 )
@@ -82,9 +84,9 @@ class SchemaValidationError(ValueError):
 def validate(df, schema: pa.Schema) -> None:
     """Verify that ``df`` has every column the schema declares.
 
-    We don't check dtypes here — the writer in ``io.write_parquet_deterministic`` casts everything
-    to the declared types. This function exists to catch the common case where a column is silently
-    dropped or renamed in upstream code.
+    We don't check dtypes here — the writer in ``io.write_parquet_deterministic`` casts
+    everything to the declared types. This function exists to catch the common case
+    where a column is silently dropped or renamed in upstream code.
     """
     declared = {field.name for field in schema}
     actual = set(df.columns)

--- a/mermaidseg/datasets/coralnet/preprocessing/manifest.py
+++ b/mermaidseg/datasets/coralnet/preprocessing/manifest.py
@@ -13,10 +13,11 @@ logger = logging.getLogger(__name__)
 def combine_checkpoints(checkpoints: Sequence[ibis.Table]) -> ibis.Table:
     """Merge resize checkpoints from successive runs into one status table.
 
-    The row with the most recent ``resize_timestamp`` wins on (source_id, image_id) conflicts, so a
-    rerun that reprocessed previously skipped/failed items overrides the earlier status. Rows with
-    no timestamp (failed/skipped) lose to any timestamped row; among themselves, the later
-    checkpoint in the input sequence wins. All checkpoints must share the same schema.
+    The row with the most recent ``resize_timestamp`` wins on (source_id, image_id)
+    conflicts, so a rerun that reprocessed previously skipped/failed items overrides the
+    earlier status. Rows with no timestamp (failed/skipped) lose to any timestamped row;
+    among themselves, the later checkpoint in the input sequence wins. All checkpoints
+    must share the same schema.
     """
     if not checkpoints:
         raise ValueError("combine_checkpoints requires at least one checkpoint")
@@ -106,4 +107,121 @@ def build_manifest(
             status=ibis._.status,
         )
         .order_by(["source_id", "image_id"])
+    )
+
+
+def build_training_manifest(
+    annotations: ibis.Table,
+    images: ibis.Table,
+    checkpoint: ibis.Table,
+    output_prefix: str,
+    threshold: int = 2048,
+) -> ibis.Table:
+    """Build the annotation-level training parquet consumed by ``CoralNetDataset``.
+
+    Resolves the S3 key of the image to actually load (resized when the image was resized,
+    original otherwise) and rescales each point annotation's ``row``/``col`` to the loaded
+    image's dimensions, so the dataset needs no runtime scaling. Images that ``needs_resize``
+    but whose resize did not complete are excluded entirely (their annotations are dropped).
+
+    Args:
+        annotations: Annotation rows with [source_id, image_id, row, col, coralnet_id].
+        images: Image metadata with [source_id, image_id, s3_key, width, height, needs_resize, ...].
+        checkpoint: Resize checkpoint/manifest with [source_id, image_id, status, ...].
+        output_prefix: S3 prefix under which resized images live (e.g. ``"dev/images"``).
+        threshold: Resize threshold (longest edge in pixels) used when the corpus was resized.
+
+    Returns:
+        Annotation-level table with columns:
+        [source_id, image_id, row, col, coralnet_id, source_label_name, image_s3_key,
+         load_width, load_height, uses_resized_image]. ``row``/``col`` are already scaled
+        to (load_height, load_width).
+    """
+    joined = images.left_join(checkpoint, ["source_id", "image_id"])
+
+    # Treat a resize as usable only when the image needed resizing AND its checkpoint row
+    # completed; images absent from the checkpoint get a null status (-> not completed).
+    use_resized = joined.needs_resize & (joined.status.fill_null("") == "completed")  # noqa: PD004 — ibis API
+
+    resized_key = (
+        ibis.literal(f"{output_prefix}/resized/s")
+        + joined.source_id.cast("string")
+        + "/images/"
+        + joined.image_id
+        + ".jpg"
+    )
+
+    # Scale the longest edge to the threshold, flooring like the resize worker's int().
+    longest = ibis.greatest(joined.width, joined.height)
+    scale = ibis.literal(threshold).cast("float64") / longest.cast("float64")
+    load_width = ibis.ifelse(
+        use_resized, (joined.width.cast("float64") * scale).floor().cast("int64"), joined.width
+    )
+    load_height = ibis.ifelse(
+        use_resized, (joined.height.cast("float64") * scale).floor().cast("int64"), joined.height
+    )
+
+    image_manifest = (
+        joined.mutate(
+            image_s3_key=ibis.ifelse(use_resized, resized_key, joined.s3_key),
+            load_width=load_width,
+            load_height=load_height,
+            uses_resized_image=use_resized,
+        )
+        # Keep sub-threshold or completed-resize images, and only those with known original
+        # dimensions — null dims (e.g. header_status="not_found") can't be scaled or validated,
+        # and DuckDB's greatest(NULL, 0) would silently collapse their coords to (0, 0).
+        .filter(
+            ((~joined.needs_resize) | use_resized)  # noqa: PD004 — ibis API
+            & joined.width.notnull()
+            & joined.height.notnull()
+            & (joined.width > 0)
+            & (joined.height > 0)
+        )
+        .select(
+            "source_id",
+            "image_id",
+            "image_s3_key",
+            "load_width",
+            "load_height",
+            "uses_resized_image",
+            orig_width=ibis._.width,
+            orig_height=ibis._.height,
+        )
+    )
+
+    # Inner join drops annotations of excluded images.
+    out = annotations.inner_join(image_manifest, ["source_id", "image_id"])
+    scale_x = out.load_width.cast("float64") / out.orig_width.cast("float64")
+    scale_y = out.load_height.cast("float64") / out.orig_height.cast("float64")
+    col_scaled = ibis.least(
+        (out.col.cast("float64") * scale_x).floor().cast("int64"), out.load_width - 1
+    )
+    row_scaled = ibis.least(
+        (out.row.cast("float64") * scale_y).floor().cast("int64"), out.load_height - 1
+    )
+
+    # row/col and load dims are bounded by the resize threshold (<= 2048), so int16 stores them
+    # losslessly at a quarter of int64 — they dominate the file size at annotation scale.
+    return (
+        out.mutate(
+            row=ibis.greatest(row_scaled, ibis.literal(0)).cast("int16"),
+            col=ibis.greatest(col_scaled, ibis.literal(0)).cast("int16"),
+            load_width=out.load_width.cast("int16"),
+            load_height=out.load_height.cast("int16"),
+            source_label_name=out.coralnet_id.cast("string"),
+        )
+        .select(
+            "source_id",
+            "image_id",
+            "row",
+            "col",
+            "coralnet_id",
+            "source_label_name",
+            "image_s3_key",
+            "load_width",
+            "load_height",
+            "uses_resized_image",
+        )
+        .order_by(["source_id", "image_id", "row", "col"])
     )

--- a/mermaidseg/datasets/coralnet/preprocessing/resize.py
+++ b/mermaidseg/datasets/coralnet/preprocessing/resize.py
@@ -1,5 +1,5 @@
-"""Image resizing preprocessing pipeline: scan for missing resized images, then resize and
-upload."""
+"""Image resizing preprocessing pipeline: scan for missing resized images, then resize
+and upload."""
 
 from __future__ import annotations
 
@@ -35,8 +35,8 @@ DEFAULT_CHECKPOINT_EVERY = 1000
 def make_resize_s3_client(*, max_pool_connections: int = 10) -> Any:
     """Build an S3 client sized for concurrent resize/scan workers.
 
-    boto3 clients are thread-safe, so the orchestrator builds one client with ``max_pool_connections
-    >= workers`` and shares it across all worker threads.
+    boto3 clients are thread-safe, so the orchestrator builds one client with
+    ``max_pool_connections >= workers`` and shares it across all worker threads.
     """
     config = Config(
         retries={"max_attempts": 10, "mode": "adaptive"},
@@ -120,8 +120,8 @@ def _resized_s3_key_for(prefix: str, source_id: int, image_id: str, threshold: i
 def _list_existing_resized_keys(s3_client: Any, bucket: str, output_prefix: str) -> set[str]:
     """Return every object key under ``<output_prefix>/resized/`` via paginated LIST.
 
-    One LIST request covers 1000 objects, so this replaces hundreds of thousands of per-image
-    ``head_object`` calls with a few hundred sequential pages.
+    One LIST request covers 1000 objects, so this replaces hundreds of thousands of per-
+    image ``head_object`` calls with a few hundred sequential pages.
     """
     resized_prefix = f"{output_prefix}/resized/"
     paginator = s3_client.get_paginator("list_objects_v2")
@@ -444,13 +444,15 @@ def resize_and_upload_image(
 def _summarise_checkpoint(checkpoint_df: pd.DataFrame) -> tuple[int, int, int, int]:
     """Count (resized, skipped, failed, corrupted) from checkpoint statuses alone.
 
-    Counts come from the checkpoint, never from todo-list arithmetic — on a resume the todo can be
-    smaller than the checkpoint, which previously produced negative "skipped" counts.
+    Counts come from the checkpoint, never from todo-list arithmetic — on a resume the
+    todo can be smaller than the checkpoint, which previously produced negative
+    "skipped" counts.
     """
     num_resized = int((checkpoint_df["status"] == "completed").sum())
     num_failed = int((checkpoint_df["status"] == "failed").sum())
     is_skipped = checkpoint_df["status"] == "skipped"
-    is_corrupted = checkpoint_df["skip_reason"].str.startswith("corrupted_").fillna(False)
+    skip_reason = checkpoint_df.get("skip_reason", pd.Series("", index=checkpoint_df.index))
+    is_corrupted = skip_reason.str.startswith("corrupted_").fillna(False)
     num_corrupted = int((is_skipped & is_corrupted).sum())
     num_skipped = int((is_skipped & ~is_corrupted).sum())
     return num_resized, num_skipped, num_failed, num_corrupted
@@ -507,6 +509,18 @@ def resize_and_upload_all_images(
         df_todo[["source_id", "image_id", "original_s3_key", "output_s3_key"]],
         on=["source_id", "image_id"],
     )
+
+    # A non-empty checkpoint that shares zero (source_id, image_id) with the todo is never
+    # intentional — it means the checkpoint came from a different ETL run than the one that
+    # produced df_todo. Left unguarded this silently processes nothing and reports success
+    # (the "Resizing images: 0it" bug). Fail loudly so the stale checkpoint gets noticed.
+    if df_work.empty:
+        raise ValueError(
+            f"Checkpoint at {checkpoint_path} has {len(df_pending)} pending items but none "
+            f"intersect the {len(df_todo)} todo items — checkpoint is from a different ETL run. "
+            "Delete the stale checkpoint or pull the one matching this run."
+        )
+    logger.info("Merged %d pending checkpoint items → %d workable", len(df_pending), len(df_work))
 
     # Map (source_id, image_id) -> positional row index for O(1) in-memory status updates.
     row_index: dict[tuple[int, str], int] = {
@@ -566,3 +580,198 @@ def resize_and_upload_all_images(
     )
 
     return num_resized, num_skipped, num_failed, num_corrupted
+
+
+def _default_worker_count() -> int:
+    env = os.environ.get("MERMAID_CORALNET_RESIZE_WORKERS")
+    if env:
+        return max(1, int(env))
+    cpu = os.cpu_count() or 4
+    return min(64, max(32, cpu * 4))
+
+
+def _sync_checkpoint_to_s3(local_path: Path, bucket: str, s3_key: str) -> None:
+    import boto3
+
+    boto3.client("s3").upload_file(str(local_path), bucket, s3_key)
+    logger.info("Checkpoint synced to s3://%s/%s", bucket, s3_key)
+
+
+def _sync_checkpoint_from_s3(local_path: Path, bucket: str, s3_key: str) -> bool:
+    import boto3
+
+    s3 = boto3.client("s3")
+    try:
+        s3.head_object(Bucket=bucket, Key=s3_key)
+    except Exception:  # noqa: BLE001
+        return False
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    s3.download_file(bucket, s3_key, str(local_path))
+    logger.info("Checkpoint downloaded from s3://%s/%s", bucket, s3_key)
+    return True
+
+
+_DEFAULT_CHECKPOINT_S3_KEY = "etl-outputs/coralnet/{run}/resize_checkpoint_{run}.parquet"
+
+
+def _resolve_checkpoint_s3_keys(
+    run: str,
+    checkpoint_s3_key: str | None,
+    pull_checkpoint_s3_key: str | None,
+) -> tuple[str, str]:
+    """Resolve the (pull, push) checkpoint S3 keys.
+
+    Pull and push are deliberately independent: a job may seed from a prior run's checkpoint
+    (``pull_checkpoint_s3_key``) while writing its own results under the current run's path. When
+    only the push key is overridden, pull falls back to it; when neither is given, both derive from
+    the run version. Conflating the two is the wrong-path bug — a May-seeded job overwriting May's
+    checkpoint — so this returns them as a pair.
+
+    Returns:
+        (pull_key, push_key)
+    """
+    push_key = checkpoint_s3_key or _DEFAULT_CHECKPOINT_S3_KEY.format(run=run)
+    pull_key = pull_checkpoint_s3_key or push_key
+    return pull_key, push_key
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the CoralNet resize pipeline (SageMaker processing task)."""
+    import argparse
+
+    import pandas as pd
+
+    parser = argparse.ArgumentParser(description="Resize CoralNet images flagged needs_resize.")
+    parser.add_argument("--bucket", default="dev-datamermaid-sm-sources")
+    parser.add_argument("--run", default=None, help="ETL version tag (e.g. 20260624_nogit)")
+    parser.add_argument("--images-uri", default=None, help="Override S3/local images parquet URI")
+    parser.add_argument("--output-prefix", default="dev/images")
+    parser.add_argument("--threshold", type=int, default=2048)
+    parser.add_argument("--workers-scan", type=int, default=None)
+    parser.add_argument("--workers-resize", type=int, default=None)
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        default=Path("outputs/resize_checkpoint.parquet"),
+    )
+    parser.add_argument(
+        "--checkpoint-s3-key", default=None, help="S3 key for push (default: derived from --run)"
+    )
+    parser.add_argument(
+        "--pull-checkpoint-s3-key",
+        default=None,
+        help="S3 key to pull from (default: same as --checkpoint-s3-key)",
+    )
+    parser.add_argument("--pull-checkpoint", action="store_true")
+    parser.add_argument("--push-checkpoint", action="store_true")
+    parser.add_argument("--skip-scan", action="store_true")
+    parser.add_argument("--checkpoint-every", type=int, default=DEFAULT_CHECKPOINT_EVERY)
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    workers_default = _default_worker_count()
+    workers_scan = args.workers_scan or workers_default
+    workers_resize = args.workers_resize or workers_default
+    run = args.run or "unknown"
+    pull_s3_key, checkpoint_s3_key = _resolve_checkpoint_s3_keys(
+        run=run,
+        checkpoint_s3_key=args.checkpoint_s3_key,
+        pull_checkpoint_s3_key=args.pull_checkpoint_s3_key,
+    )
+
+    if args.pull_checkpoint:
+        _sync_checkpoint_from_s3(args.checkpoint, args.bucket, pull_s3_key)
+
+    if args.checkpoint.exists():
+        df_cp = read_checkpoint(args.checkpoint)
+        counts = df_cp["status"].value_counts().to_dict()
+        logger.info(
+            "Checkpoint: completed=%s pending=%s failed=%s",
+            counts.get("completed", 0),
+            counts.get("pending", 0),
+            counts.get("failed", 0),
+        )
+
+    if args.images_uri:
+        images_uri = args.images_uri
+    elif args.run:
+        images_uri = f"s3://{args.bucket}/etl-outputs/coralnet/{run}/coralnet_images_{run}.parquet"
+    else:
+        logger.error("Provide --images-uri or --run")
+        return 2
+
+    logger.info("Loading images parquet: %s", images_uri)
+    storage_options = None
+    if images_uri.startswith("s3://"):
+        storage_options = {
+            "config_kwargs": {"max_pool_connections": max(workers_scan, workers_resize) + 4}
+        }
+    df = pd.read_parquet(images_uri, storage_options=storage_options)
+    df_work = df.loc[df["needs_resize"]].copy()
+    logger.info(
+        "needs_resize=True: %s / %s total rows across %s sources",
+        f"{len(df_work):,}",
+        f"{len(df):,}",
+        df_work["source_id"].nunique(),
+    )
+
+    if args.skip_scan:
+        if not args.checkpoint.exists():
+            logger.error("--skip-scan requires an existing checkpoint at %s", args.checkpoint)
+            return 1
+        df_todo = build_todo_from_checkpoint(
+            df_images=df_work,
+            checkpoint_path=args.checkpoint,
+            output_prefix=args.output_prefix,
+            threshold=args.threshold,
+        )
+        logger.info("Skip-scan resume: %s pending images", f"{len(df_todo):,}")
+    else:
+        df_todo = scan_for_missing_resized_images(
+            df_images=df_work,
+            bucket=args.bucket,
+            output_prefix=args.output_prefix,
+            threshold=args.threshold,
+            workers=workers_scan,
+            s3_client=None,
+        )
+        logger.info("Scan complete: %s images to resize", f"{len(df_todo):,}")
+
+    if df_todo.empty:
+        logger.info("Nothing to do — all resized images already exist.")
+        if args.push_checkpoint and args.checkpoint.exists():
+            _sync_checkpoint_to_s3(args.checkpoint, args.bucket, checkpoint_s3_key)
+        return 0
+
+    args.checkpoint.parent.mkdir(parents=True, exist_ok=True)
+    num_resized, num_skipped, num_failed, num_corrupted = resize_and_upload_all_images(
+        df_todo=df_todo,
+        bucket=args.bucket,
+        output_prefix=args.output_prefix,
+        checkpoint_path=args.checkpoint,
+        threshold=args.threshold,
+        workers=workers_resize,
+        s3_client=None,
+        checkpoint_every=args.checkpoint_every,
+    )
+    logger.info(
+        "Done: resized=%s skipped=%s corrupted=%s failed=%s",
+        num_resized,
+        num_skipped,
+        num_corrupted,
+        num_failed,
+    )
+
+    if args.push_checkpoint:
+        _sync_checkpoint_to_s3(args.checkpoint, args.bucket, checkpoint_s3_key)
+
+    return 1 if num_failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mermaidseg/datasets/coralnet/scraper/classify.py
+++ b/mermaidseg/datasets/coralnet/scraper/classify.py
@@ -27,6 +27,7 @@ def classify_remediation_action(
     annotations_csv_read_failed: bool,
     annotations_empty: bool,
     image_count_match: bool,
+    image_list_covers_annotations: bool = True,
 ) -> RemediationAction:
     if not probe.accessible:
         return RemediationAction.SKIP_NOT_ACCESSIBLE
@@ -63,6 +64,9 @@ def classify_remediation_action(
     if csv_broken_or_empty and tw > 0:
         return RemediationAction.REDOWNLOAD_CSV
 
+    if csvs_ok_core and not image_list_covers_annotations:
+        return RemediationAction.REDOWNLOAD_CSV
+
     if csvs_ok_core and not image_count_match and gap > 0:
         return RemediationAction.REDOWNLOAD_IMAGES
 
@@ -72,7 +76,8 @@ def classify_remediation_action(
 def classify_from_audit_series(
     probe: SourceProbe, audit_row: Mapping[str, Any]
 ) -> RemediationAction:
-    """Convenience: map parquet/audit columns into :func:`classify_remediation_action`."""
+    """Convenience: map parquet/audit columns into
+    :func:`classify_remediation_action`."""
     return classify_remediation_action(
         probe=probe,
         has_images_folder=_row_bool(audit_row, "has_images_folder"),
@@ -84,4 +89,5 @@ def classify_from_audit_series(
         annotations_csv_read_failed=_row_bool(audit_row, "annotations_csv_read_failed"),
         annotations_empty=_row_bool(audit_row, "annotations_empty"),
         image_count_match=_row_bool(audit_row, "image_count_match"),
+        image_list_covers_annotations=_row_bool(audit_row, "image_list_covers_annotations"),
     )

--- a/mermaidseg/datasets/coralnet/scraper/downloader.py
+++ b/mermaidseg/datasets/coralnet/scraper/downloader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import concurrent
 import io
 import logging
+import random
 import re
 import threading
 import time
@@ -49,6 +50,7 @@ _PAGINATED_EXPORT_THRESHOLD = 5000  # sources above this use per-page export
 _PAGE_EXPORT_TIMEOUT = 180  # CoralNet session setup can take >60s even for 20 images
 _PAGE_RETRIES = 3
 _PAGE_RETRY_BACKOFF_S = 30  # sleep between retries, doubles each attempt
+_REACHABILITY_TIMEOUT = 30  # pre-flight "is CoralNet up?" probe; fail fast if not
 _PAGE_DELAY_SECONDS = 2.0  # politeness delay between page export requests
 _PAGE_PARALLEL_WORKERS = 3  # concurrent export_prep/serve requests in paginated export
 _CHECKPOINT_EVERY_PAGES = 50  # upload partial annotations.csv every N completed pages
@@ -63,9 +65,9 @@ _IMAGE_HREF_PK = re.compile(r"/image/(\d+)(?:/|$)")
 def _extract_page_image_ids(soup: BeautifulSoup) -> tuple[int, ...]:
     """Return the CoralNet image PKs (in DOM order) for the browse page in ``soup``.
 
-    Image IDs are taken from each thumb_wrapper's ``<a href="/image/NNN/view/">``. Duplicates are
-    removed while preserving first-seen order so callers can safely join with ``"_".join`` for
-    CoralNet's ``image_id_list`` POST field.
+    Image IDs are taken from each thumb_wrapper's ``<a href="/image/NNN/view/">``.
+    Duplicates are removed while preserving first-seen order so callers can safely join
+    with ``"_".join`` for CoralNet's ``image_id_list`` POST field.
     """
     seen: dict[int, None] = {}
     for wrapper in soup.find_all("span", class_="thumb_wrapper"):
@@ -82,10 +84,10 @@ def _extract_page_image_ids(soup: BeautifulSoup) -> tuple[int, ...]:
 class _PageWorkItem:
     """One browse-page worth of export work discovered during phase 1.
 
-    ``image_ids`` is the underscore-formatted CoralNet image PKs for the page (e.g. ``(5713071,
-    5713072, ...)``). The phase-2 POST sends these as ``image_id_list=N1_N2_...`` along with
-    ``image_select_type=selected`` so CoralNet exports only those images rather than the entire
-    source.
+    ``image_ids`` is the underscore-formatted CoralNet image PKs for the page (e.g.
+    ``(5713071, 5713072, ...)``). The phase-2 POST sends these as
+    ``image_id_list=N1_N2_...`` along with ``image_select_type=selected`` so CoralNet
+    exports only those images rather than the entire source.
     """
 
     page_num: int
@@ -96,7 +98,8 @@ class _PageWorkItem:
 
 
 def _merge_with_existing(new_df: pd.DataFrame, existing_df: pd.DataFrame | None) -> pd.DataFrame:
-    """Concat ``existing_df`` (if any) with ``new_df`` and dedup on (Name, Row, Column)."""
+    """Concat ``existing_df`` (if any) with ``new_df`` and dedup on (Name, Row,
+    Column)."""
     if existing_df is None:
         return new_df
     combined = pd.concat([existing_df, new_df], ignore_index=True)
@@ -109,6 +112,25 @@ def _upload_csv(s3_client: Any, bucket: str, key: str, df: pd.DataFrame) -> None
     s3_io.upload_csv_body(s3_client, bucket=bucket, key=key, csv_text=buf.getvalue())
 
 
+# Transient network failures worth retrying on a long (multi-hour) scrape.
+# ``requests.Timeout`` is the base of both ConnectTimeout and ReadTimeout;
+# ChunkedEncodingError is a mid-body connection drop. 5xx responses are handled
+# separately in ``_is_transient`` (4xx won't fix itself on retry).
+_TRANSIENT_ERRORS = (
+    requests.Timeout,
+    requests.ConnectionError,
+    requests.exceptions.ChunkedEncodingError,
+)
+
+
+def _is_transient(exc: requests.RequestException) -> bool:
+    """True for errors worth retrying: timeouts, dropped connections, and 5xx."""
+    if isinstance(exc, requests.HTTPError):
+        resp = exc.response
+        return resp is not None and resp.status_code >= 500
+    return isinstance(exc, _TRANSIENT_ERRORS)
+
+
 def _with_retry(
     operation: Callable[[], _T],
     *,
@@ -118,12 +140,15 @@ def _with_retry(
 ) -> _T:
     """Retry ``operation`` on transient HTTP errors with exponential backoff.
 
-    Raises the final exception after :data:`_PAGE_RETRIES` attempts.
+    Non-transient errors (e.g. a 4xx) propagate immediately. Transient errors raise
+    after :data:`_PAGE_RETRIES` attempts.
     """
     for attempt in range(1, _PAGE_RETRIES + 1):
         try:
             return operation()
-        except (requests.ReadTimeout, requests.ConnectionError) as e:
+        except requests.RequestException as e:
+            if not _is_transient(e):
+                raise
             if attempt >= _PAGE_RETRIES:
                 logger.error(
                     "source %s page=%s %s: %s after %s attempts; giving up",
@@ -134,7 +159,10 @@ def _with_retry(
                     _PAGE_RETRIES,
                 )
                 raise
-            backoff = _PAGE_RETRY_BACKOFF_S * (2 ** (attempt - 1))
+            # Jitter the exponential backoff so concurrent shards retrying the
+            # same failing site desync instead of stampeding in lockstep.
+            base = _PAGE_RETRY_BACKOFF_S * (2 ** (attempt - 1))
+            backoff = random.uniform(0.5 * base, 1.5 * base)
             logger.warning(
                 "source %s page=%s %s: %s (attempt %s/%s); retrying in %ss",
                 source_id,
@@ -209,7 +237,8 @@ class CoralNetDownloader:
         return response.text
 
     def probe_source(self, source_id: int) -> SourceProbe:
-        """HTTP GET overview page; extract accessibility + total images (no S3 writes)."""
+        """HTTP GET overview page; extract accessibility + total images (no S3
+        writes)."""
         url = self._source_main_url(source_id)
         try:
             html = self._get_source_overview_html(source_id)
@@ -252,21 +281,35 @@ class CoralNetDownloader:
         :meth:`login` (the main session) and :meth:`_new_logged_in_session`
         (per-worker independent sessions used by parallel export).
         """
-        response = session.get(self.LOGIN_URL, timeout=_PAGE_GET_TIMEOUT)
-        response.raise_for_status()
+
+        def _get_login_page() -> requests.Response:
+            r = session.get(self.LOGIN_URL, timeout=_PAGE_GET_TIMEOUT)
+            r.raise_for_status()
+            return r
+
+        # Retry the login round-trip on transient errors: CoralNet has brief
+        # availability dips, and a single login timeout otherwise kills the whole
+        # job before any source is scraped. Invalid-credential failures raise a
+        # RuntimeError (below), which _with_retry does not retry.
+        response = _with_retry(_get_login_page, source_id=0, page_num=0, kind="login")
         csrf_token = extract_csrf_token(response.text)
         if not csrf_token:
             raise RuntimeError("Could not find CSRF token")
-        login_response = session.post(
-            self.LOGIN_URL,
-            data={
-                "username": self.username,
-                "password": self.password,
-                "csrfmiddlewaretoken": csrf_token,
-            },
-            headers={"Referer": self.LOGIN_URL},
-            timeout=_PAGE_GET_TIMEOUT,
-            allow_redirects=True,
+        login_response = _with_retry(
+            lambda: session.post(
+                self.LOGIN_URL,
+                data={
+                    "username": self.username,
+                    "password": self.password,
+                    "csrfmiddlewaretoken": csrf_token,
+                },
+                headers={"Referer": self.LOGIN_URL},
+                timeout=_PAGE_GET_TIMEOUT,
+                allow_redirects=True,
+            ),
+            source_id=0,
+            page_num=0,
+            kind="login",
         )
         if "Sign out" not in login_response.text and login_response.url == self.LOGIN_URL:
             raise RuntimeError("Login failed - invalid credentials or other error")
@@ -280,6 +323,21 @@ class CoralNetDownloader:
             return True
         except Exception:
             logger.exception("CoralNet login failed for %s", self.username)
+            return False
+
+    def is_coralnet_reachable(self, *, timeout: float = _REACHABILITY_TIMEOUT) -> bool:
+        """Cheap pre-flight check that CoralNet is actually serving HTTP.
+
+        CoralNet has site-wide dips where it accepts TCP connections but never returns a
+        response. A single short GET distinguishes "down/degraded" (timeout or 5xx) from
+        "up" so a job can bail early instead of burning the full login-retry budget —
+        and, more importantly, so we don't pile load onto a site that's already
+        struggling.
+        """
+        try:
+            r = self.session.get(self.LOGIN_URL, timeout=timeout)
+            return r.status_code < 500
+        except requests.RequestException:
             return False
 
     def check_permissions(self, source_id: int) -> bool:
@@ -612,10 +670,10 @@ class CoralNetDownloader:
     ) -> tuple[pd.DataFrame | None, bool]:
         """Load an existing ``annotations.csv`` from S3 if present.
 
-        Returns ``(df, is_complete)``. ``df`` is ``None`` when the object does not exist;
-        ``is_complete`` is ``True`` only when the existing CSV's unique-image count already meets
-        ``total_images_website``, signalling the caller can skip re-export. Non-404 ``ClientError``s
-        propagate.
+        Returns ``(df, is_complete)``. ``df`` is ``None`` when the object does not
+        exist; ``is_complete`` is ``True`` only when the existing CSV's unique-image
+        count already meets ``total_images_website``, signalling the caller can skip re-
+        export. Non-404 ``ClientError``s propagate.
         """
         existing_df = read_csv_s3(self.s3, bucket_name, annotations_key)
         if existing_df is None:
@@ -639,9 +697,10 @@ class CoralNetDownloader:
     def _walk_browse_pages(self, source_id: int) -> list[_PageWorkItem]:
         """Phase 1: sequentially walk browse pages, collecting CSRF + URL per page.
 
-        Has to be sequential because each page's "Next page" link and CSRF token are only known
-        after parsing the previous page. Logs progress every :data:`_BROWSE_PROGRESS_EVERY` pages so
-        long walks (50+ pages) are observable rather than appearing hung.
+        Has to be sequential because each page's "Next page" link and CSRF token are
+        only known after parsing the previous page. Logs progress every
+        :data:`_BROWSE_PROGRESS_EVERY` pages so long walks (50+ pages) are observable
+        rather than appearing hung.
         """
         base_url = f"{self.CORALNET_URL}/source/{source_id}/browse/images/"
         logger.info("source %s: phase 1 starting browse-page walk", source_id)
@@ -703,19 +762,21 @@ class CoralNetDownloader:
     def _export_one_page(self, source_id: int, item: _PageWorkItem) -> pd.DataFrame:
         """Phase 2 worker: export_prep POST + serve GET for one page, with retries.
 
-        Uses a worker-local, independently-logged-in session (:meth:`_get_export_session`) so
-        concurrent workers don't trample each other's server-side Django session state.
+        Uses a worker-local, independently-logged-in session
+        (:meth:`_get_export_session`) so concurrent workers don't trample each other's
+        server-side Django session state.
 
-        The phase-1 CSRF token on ``item`` was captured from the *main* session and is therefore not
-        valid for the worker's separate session; instead the worker GETs the browse page once on its
-        own session to capture a fresh CSRF before POSTing.
+        The phase-1 CSRF token on ``item`` was captured from the *main* session and is
+        therefore not valid for the worker's separate session; instead the worker GETs
+        the browse page once on its own session to capture a fresh CSRF before POSTing.
 
-        Sends ``image_select_type=selected`` plus ``image_id_list`` (underscore- separated PKs) so
-        CoralNet's ``image_search_kwargs_to_queryset`` filters to just this page's images, rather
-        than exporting the entire source. ``image_form_type=search`` is the hidden,
-        ``required=True`` discriminator on CoralNet's ``ImageSearchForm`` -- omitting it makes the
-        form invalid and the serve response returns HTML instead of CSV. CoralNet caps
-        ``image_id_list`` at 100 entries; browse pages have 20.
+        Sends ``image_select_type=selected`` plus ``image_id_list`` (underscore-
+        separated PKs) so CoralNet's ``image_search_kwargs_to_queryset`` filters to just
+        this page's images, rather than exporting the entire source.
+        ``image_form_type=search`` is the hidden, ``required=True`` discriminator on
+        CoralNet's ``ImageSearchForm`` -- omitting it makes the form invalid and the
+        serve response returns HTML instead of CSV. CoralNet caps ``image_id_list`` at
+        100 entries; browse pages have 20.
         """
         session = self._get_export_session()
         export_url = f"{self.CORALNET_URL}/source/{source_id}/annotation/export_prep/"
@@ -779,8 +840,8 @@ class CoralNetDownloader:
     ) -> dict[int, pd.DataFrame]:
         """Phase 2: parallel export_prep + serve, with periodic S3 checkpoints.
 
-        Checkpoint partials are concatenated incrementally (O(N) per checkpoint, not O(N²)) and use
-        completion order rather than page order; the final upload in
+        Checkpoint partials are concatenated incrementally (O(N) per checkpoint, not
+        O(N²)) and use completion order rather than page order; the final upload in
         :meth:`download_annotations_paginated` rewrites the object in page order.
         """
         chunks_by_page: dict[int, pd.DataFrame] = {}
@@ -847,21 +908,99 @@ class CoralNetDownloader:
         return images, next_rel
 
     def get_images(
-        self, source_id: int, *, annotation_status: str | None = None
+        self,
+        source_id: int,
+        *,
+        annotation_status: str | None = None,
+        total_images_hint: int | None = None,
+        browse_workers: int = 1,
     ) -> tuple[pd.DataFrame | None, bool]:
+        """Walk CoralNet browse pages and return a DataFrame of all images.
+
+        When ``total_images_hint`` is provided and ``browse_workers > 1``, pages
+        2..N are fetched in parallel via ``?page=N`` URLs rather than sequentially
+        following next-link cursors. Page 1 is always fetched first to establish
+        the actual page size; subsequent pages are constructed as
+        ``base_url?page=N`` (or ``base_url&page=N`` when annotation_status is set).
+
+        Falls back to sequential cursor-following when ``total_images_hint`` is
+        absent or ``browse_workers == 1``.
+        """
         base_url = f"{self.CORALNET_URL}/source/{source_id}/browse/images"
         if annotation_status:
             base_url = f"{base_url}/?annotation_status={annotation_status}"
-        all_images: dict[str, str] = {}
-        current_url: str | None = base_url
+
+        def fetch(url: str, page_num: int) -> tuple[dict[str, str], str | None]:
+            return _with_retry(
+                lambda: self.get_images_on_page(url),
+                source_id=source_id,
+                page_num=page_num,
+                kind="browse",
+            )
+
         p_bar = tqdm(desc="Fetching images", unit="page")
         try:
-            while current_url is not None:
-                imgs, next_rel = self.get_images_on_page(current_url)
-                all_images.update(imgs)
-                p_bar.update(1)
-                current_url = urllib.parse.urljoin(current_url, next_rel) if next_rel else None
-            df = pd.DataFrame(list(all_images.items()), columns=["Name", "Image Page"])
+            page1_imgs, next_rel = fetch(base_url, 1)
+            p_bar.update(1)
+
+            # Ordered list of per-page dicts; page 1 is always first.
+            ordered_pages: list[dict[str, str]] = [page1_imgs]
+
+            can_parallel = browse_workers > 1 and total_images_hint is not None
+            page1_size = len(page1_imgs)
+
+            if can_parallel and page1_size > 0 and total_images_hint > page1_size:
+                # Ceil-divide without importing math.
+                n_pages = -(-total_images_hint // page1_size)
+                sep = "&" if "?" in base_url else "?"
+
+                workers = min(browse_workers, n_pages - 1)
+                page_results: dict[int, dict[str, str]] = {}
+                with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as ex:
+                    futs = {
+                        ex.submit(fetch, f"{base_url}{sep}page={n}", n): n
+                        for n in range(2, n_pages + 1)
+                    }
+                    for fut in concurrent.futures.as_completed(futs):
+                        n = futs[fut]
+                        try:
+                            page_results[n], _ = fut.result()
+                        except requests.RequestException:
+                            # One dead page must not abort the whole source; leave it
+                            # out and let the caller's coverage guard reject a short list.
+                            logger.warning(
+                                "source %s page=%s failed after retries; skipping", source_id, n
+                            )
+                        p_bar.update(1)
+                missing = (n_pages - 1) - len(page_results)
+                if missing:
+                    logger.warning(
+                        "source %s: %d/%d browse pages failed; result is partial",
+                        source_id,
+                        missing,
+                        n_pages - 1,
+                    )
+                for n in range(2, n_pages + 1):
+                    ordered_pages.append(page_results.get(n, {}))
+            else:
+                current_url: str | None = (
+                    urllib.parse.urljoin(base_url, next_rel) if next_rel else None
+                )
+                seq_page = 2
+                while current_url is not None:
+                    imgs, next_rel = fetch(current_url, seq_page)
+                    ordered_pages.append(imgs)
+                    p_bar.update(1)
+                    seq_page += 1
+                    current_url = urllib.parse.urljoin(current_url, next_rel) if next_rel else None
+
+            # Merge in page order; first-seen wins for any duplicate name.
+            merged: dict[str, str] = {}
+            for page_imgs in ordered_pages:
+                for name, href in page_imgs.items():
+                    merged.setdefault(name, href)
+
+            df = pd.DataFrame(list(merged.items()), columns=["Name", "Image Page"])
             return df, True
         except Exception:
             logger.exception("get_images failed source %s", source_id)
@@ -875,9 +1014,10 @@ class CoralNetDownloader:
     def _get_thread_session(self) -> requests.Session:
         """Per-thread session with cookies copied from the main session.
 
-        Safe for read-only requests (e.g. image URL resolution) where threads only consume server
-        state. NOT safe for ``export_prep``-style endpoints that write to the Django server-side
-        session keyed on ``sessionid`` -- use :meth:`_get_export_session` for those.
+        Safe for read-only requests (e.g. image URL resolution) where threads only
+        consume server state. NOT safe for ``export_prep``-style endpoints that write to
+        the Django server-side session keyed on ``sessionid`` -- use
+        :meth:`_get_export_session` for those.
         """
         s = getattr(self._thread_local, "session", None)
         if s is None:
@@ -890,10 +1030,11 @@ class CoralNetDownloader:
     def _new_logged_in_session(self) -> requests.Session:
         """Create a fresh ``requests.Session`` and log it in independently.
 
-        Each call produces an isolated cookie jar (own ``sessionid``), so the returned session
-        corresponds to its own server-side Django session. Used by :meth:`_get_export_session` to
-        give each phase-2 worker its own session and avoid the ``export_prep`` / ``serve`` race that
-        happens when multiple threads share one Django sessionid.
+        Each call produces an isolated cookie jar (own ``sessionid``), so the returned
+        session corresponds to its own server-side Django session. Used by
+        :meth:`_get_export_session` to give each phase-2 worker its own session and
+        avoid the ``export_prep`` / ``serve`` race that happens when multiple threads
+        share one Django sessionid.
         """
         session = requests.Session()
         session.headers.update(dict(self.session.headers))

--- a/mermaidseg/datasets/coralnet/scraper/refresh_image_lists.py
+++ b/mermaidseg/datasets/coralnet/scraper/refresh_image_lists.py
@@ -1,0 +1,250 @@
+"""Refresh truncated CoralNet ``image_list.csv`` files on S3.
+
+``image_list.csv`` is the only bridge the ETL has from an annotation ``Name`` to CoralNet's numeric
+``image_id`` (how image files are keyed in S3). When that list is truncated, the
+annotations x image_list join silently drops every uncovered annotated image regardless of
+confirmed status. This happened to ~32 sources in the ``20260526_807b611`` run (e.g. ``s295`` listed
+1,064 images while ``annotations.csv`` referenced 79,064).
+
+This script re-walks the CoralNet browse pages for the requested sources via
+:meth:`CoralNetDownloader.get_images` (which keeps the per-image ``" - Confirmed/Unconfirmed"``
+status suffix in ``Name``) and overwrites ``s<id>/image_list.csv``. The image **files** are intact
+in S3 and are NOT re-downloaded. A guard refuses to replace an existing list with a shorter scrape.
+
+Usage::
+
+    export AWS_PROFILE=mermaid-core CORALNET_USERNAME=... CORALNET_PASSWORD=...
+    uv run python scripts/refresh_coralnet_image_lists.py --source-ids 295,372,3371 --dry-run
+    uv run python scripts/refresh_coralnet_image_lists.py \
+        --source-ids-file outputs/coralnet_truncated_imagelist_sources.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import logging
+import random
+import time
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from mermaidseg.datasets.coralnet.etl import config
+from mermaidseg.datasets.coralnet.scraper import s3_io
+from mermaidseg.datasets.coralnet.scraper.batch_download import load_coralnet_credentials
+from mermaidseg.datasets.coralnet.scraper.downloader import CoralNetDownloader
+
+logger = logging.getLogger("refresh_coralnet_image_lists")
+
+
+def _image_list_key(prefix: str, source_id: int) -> str:
+    return f"{prefix}/s{source_id}/image_list.csv"
+
+
+def count_s3_images(client: Any, bucket: str, prefix: str, source_id: int) -> int:
+    """Number of image files under ``s<id>/images/`` (single paginator pass)."""
+    paginator = client.get_paginator("list_objects_v2")
+    total = 0
+    for page in paginator.paginate(Bucket=bucket, Prefix=f"{prefix}/s{source_id}/images/"):
+        total += page.get("KeyCount", 0)
+    return total
+
+
+def existing_image_list_rows(client: Any, bucket: str, prefix: str, source_id: int) -> int | None:
+    """Row count (excluding header) of the current ``image_list.csv``; ``None`` if
+    absent/unreadable."""
+    try:
+        obj = client.get_object(Bucket=bucket, Key=_image_list_key(prefix, source_id))
+        body = obj["Body"].read()
+    except Exception:  # noqa: BLE001 - NoSuchKey or any read error -> treat as absent
+        return None
+    text = body.decode("utf-8", "replace") if isinstance(body, bytes | bytearray) else str(body)
+    rows = [ln for ln in text.splitlines() if ln.strip()]
+    return max(0, len(rows) - 1)  # minus header
+
+
+def refresh_one(
+    downloader: Any,
+    client: Any,
+    bucket: str,
+    prefix: str,
+    source_id: int,
+    *,
+    min_coverage: float = 0.9,
+    browse_workers: int = 1,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Re-scrape and (unless guarded/dry-run) overwrite one source's ``image_list.csv``.
+
+    Guards against shipping another truncated list: the new scrape must list at least as many images
+    as the existing file AND at least ``min_coverage`` of the actual S3 image files.
+
+    ``browse_workers`` is forwarded to :meth:`CoralNetDownloader.get_images` to enable
+    parallel page fetching. Use ``n_s3`` as the ``total_images_hint`` so the fan-out
+    covers the full source even when the existing image_list.csv is truncated.
+    """
+    existing = existing_image_list_rows(client, bucket, prefix, source_id)
+    n_s3 = count_s3_images(client, bucket, prefix, source_id)
+    result: dict[str, Any] = {
+        "source_id": source_id,
+        "existing_rows": existing,
+        "s3_images": n_s3,
+        "new_rows": 0,
+        "uploaded": False,
+        "skipped_reason": None,
+    }
+
+    df, ok = downloader.get_images(
+        source_id,
+        total_images_hint=n_s3 or None,
+        browse_workers=browse_workers,
+    )
+    if not ok or df is None or len(df) == 0:
+        result["skipped_reason"] = "scrape_failed_or_empty"
+        return result
+    new_n = len(df)
+    result["new_rows"] = new_n
+
+    if existing is not None and new_n < existing:
+        result["skipped_reason"] = f"guard: new({new_n}) < existing({existing})"
+        return result
+    if n_s3 and new_n < min_coverage * n_s3:
+        result["skipped_reason"] = f"guard: new({new_n}) < {min_coverage:.0%} of s3_images({n_s3})"
+        return result
+    if dry_run:
+        result["skipped_reason"] = "dry_run"
+        return result
+
+    buf = io.StringIO()
+    df.to_csv(buf, index=False)
+    s3_io.upload_csv_body(
+        client, bucket=bucket, key=_image_list_key(prefix, source_id), csv_text=buf.getvalue()
+    )
+    result["uploaded"] = True
+    return result
+
+
+def parse_source_ids(args: argparse.Namespace) -> list[int]:
+    if args.source_ids:
+        return [int(x) for x in args.source_ids.split(",") if x.strip()]
+    path = Path(args.source_ids_file)
+    df = pd.read_csv(path) if path.suffix == ".csv" else pd.read_parquet(path)
+    if "source_id" not in df.columns:
+        raise SystemExit(f"{path} has no 'source_id' column")
+    return [int(x) for x in df["source_id"].tolist()]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="refresh-coralnet-image-lists", description=__doc__)
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--source-ids", default=None, help="Comma-separated CoralNet source ids")
+    src.add_argument(
+        "--source-ids-file", default=None, help="CSV/Parquet with a 'source_id' column"
+    )
+    p.add_argument("--bucket", default=config.get_bucket())
+    p.add_argument("--prefix", default=config.get_prefix())
+    p.add_argument(
+        "--min-coverage",
+        type=float,
+        default=0.9,
+        help="New list must list >= this fraction of S3 image files to be accepted",
+    )
+    p.add_argument(
+        "--max-workers",
+        type=int,
+        default=None,
+        help="Connection-pool size for the downloader (sources processed sequentially)",
+    )
+    p.add_argument(
+        "--browse-workers",
+        type=int,
+        default=10,
+        help="Parallel browse-page workers per source (uses ?page=N fan-out; default 10)",
+    )
+    p.add_argument(
+        "--startup-jitter-seconds",
+        type=float,
+        default=30.0,
+        help=(
+            "Sleep a random 0..N seconds before the first CoralNet request. Shards launch "
+            "simultaneously; jitter desyncs their first hit so they don't stampede the site "
+            "(set 0 to disable)."
+        ),
+    )
+    p.add_argument("--dry-run", action="store_true", help="Report new vs old counts, do not upload")
+    p.add_argument("-v", "--verbose", action="store_true")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    source_ids = parse_source_ids(args)
+    logger.info("Refreshing image_list.csv for %d source(s)", len(source_ids))
+
+    username, password = load_coralnet_credentials()
+    downloader = CoralNetDownloader(username, password, max_workers=args.max_workers)
+
+    # Per-shard startup jitter: shards launch together, so without this they all
+    # hit CoralNet at the same instant (thundering herd). A random short delay
+    # spreads the first request out across shards.
+    if args.startup_jitter_seconds > 0:
+        delay = random.uniform(0, args.startup_jitter_seconds)
+        logger.info("Startup jitter: sleeping %.1fs before first CoralNet request", delay)
+        time.sleep(delay)
+
+    # Pre-flight reachability gate: bail early (without hammering) if CoralNet is
+    # down/degraded site-wide, instead of burning the login-retry budget per shard.
+    if not downloader.is_coralnet_reachable():
+        logger.error(
+            "CoralNet is unreachable (no HTTP response within the probe window); "
+            "aborting without scraping. Retry once the site recovers."
+        )
+        return 2
+    if not downloader.login():
+        logger.error("CoralNet login failed")
+        return 1
+    client = downloader.s3
+
+    rows: list[dict[str, Any]] = []
+    for sid in source_ids:
+        try:
+            r = refresh_one(
+                downloader,
+                client,
+                args.bucket,
+                args.prefix,
+                sid,
+                min_coverage=args.min_coverage,
+                browse_workers=args.browse_workers,
+                dry_run=args.dry_run,
+            )
+        except Exception as e:  # noqa: BLE001 - never abort the batch on one source
+            r = {"source_id": sid, "skipped_reason": f"error: {type(e).__name__}: {e}"}
+            logger.exception("source %s failed", sid)
+        rows.append(r)
+        logger.info(
+            "s%s: existing=%s s3=%s new=%s uploaded=%s%s",
+            sid,
+            r.get("existing_rows"),
+            r.get("s3_images"),
+            r.get("new_rows"),
+            r.get("uploaded"),
+            f" ({r['skipped_reason']})" if r.get("skipped_reason") else "",
+        )
+
+    summary = pd.DataFrame(rows)
+    uploaded = int(summary.get("uploaded", pd.Series(dtype=bool)).fillna(False).sum())
+    logger.info("Done: %d uploaded, %d skipped/failed", uploaded, len(rows) - uploaded)
+    if not args.dry_run:
+        print(summary.to_string(index=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "torch>=2.4,<2.8",
     "transformers",
     "datasets>=3.0",
-    "s3fs",
+    "s3fs>=2024.2.0",
     "segmentation-models-pytorch",
     "mlflow",
     "pyyaml",
@@ -41,6 +41,7 @@ dependencies = [
 [project.scripts]
 coralnet-etl = "mermaidseg.datasets.coralnet.etl.__main__:main"
 coralnet-remediate = "mermaidseg.datasets.coralnet.scraper.remediate_incomplete:main"
+coralnet-refresh = "mermaidseg.datasets.coralnet.scraper.refresh_image_lists:main"
 
 [project.optional-dependencies]
 notebooks = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
 coralnet-etl = "mermaidseg.datasets.coralnet.etl.__main__:main"
 coralnet-remediate = "mermaidseg.datasets.coralnet.scraper.remediate_incomplete:main"
 coralnet-refresh = "mermaidseg.datasets.coralnet.scraper.refresh_image_lists:main"
+coralnet-resize = "mermaidseg.datasets.coralnet.preprocessing.resize:main"
 
 [project.optional-dependencies]
 notebooks = [

--- a/scripts/build_coralnet_training_manifest.py
+++ b/scripts/build_coralnet_training_manifest.py
@@ -1,0 +1,134 @@
+"""Build the CoralNet annotation-level training parquet (resized + original-below-
+threshold).
+
+Resolves each image to the key actually loaded at train time — the resized key when a resized
+object exists on S3, the original ``s3_key`` for sub-threshold images — and scales each point
+annotation's row/col to the loaded image's dimensions, so ``CoralNetDataset`` needs no runtime
+scaling.
+
+Resize-existence is read from the S3 LIST of ``<output_prefix>/resized/`` objects, NOT from the
+resize checkpoint: historical checkpoints under-record completed resizes (uploads succeeded but the
+status was never flushed), so the checkpoint would wrongly drop hundreds of thousands of images
+that are genuinely resized on S3. The S3 object listing is the same source of truth the resize scan
+trusts.
+
+Usage:
+    uv run python scripts/build_coralnet_training_manifest.py --run 20260623_nogit
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+
+import boto3
+import ibis
+import pandas as pd
+
+from mermaidseg.datasets.coralnet.preprocessing.manifest import build_training_manifest
+from mermaidseg.datasets.coralnet.preprocessing.resize import _list_existing_resized_keys
+
+logger = logging.getLogger("build_training_manifest")
+
+# Matches resize._resized_s3_key_for: <prefix>/resized/s<source_id>/images/<image_id>.jpg
+_KEY_RE = re.compile(r"/resized/s(\d+)/images/(.+)\.jpg$")
+
+
+def _resized_existence_table(s3_client, bucket: str, output_prefix: str) -> pd.DataFrame:
+    """A (source_id, image_id, status='completed') row for every resized object on
+    S3."""
+    keys = _list_existing_resized_keys(s3_client, bucket, output_prefix)
+    rows = []
+    for k in keys:
+        m = _KEY_RE.search(k)
+        if m:
+            rows.append((int(m.group(1)), m.group(2)))
+    df = pd.DataFrame(rows, columns=["source_id", "image_id"])
+    df["status"] = "completed"
+    return df
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bucket", default="dev-datamermaid-sm-sources")
+    parser.add_argument("--run", required=True, help="ETL version tag, e.g. 20260623_nogit")
+    parser.add_argument("--output-prefix", default="dev/images", help="Prefix holding /resized/")
+    parser.add_argument("--threshold", type=int, default=2048)
+    parser.add_argument("--profile", default="mermaid-core", help="AWS profile (empty for default)")
+    parser.add_argument("--out-key", default=None, help="Override output S3 key")
+    parser.add_argument("--dry-run", action="store_true", help="Compute + report, but don't write")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+
+    session = boto3.Session(profile_name=args.profile) if args.profile else boto3.Session()
+    s3 = session.client("s3")
+    storage_options = {"profile": args.profile} if args.profile else None
+
+    base = f"s3://{args.bucket}/etl-outputs/coralnet/{args.run}"
+    ann = pd.read_parquet(
+        f"{base}/coralnet_annotations_{args.run}.parquet", storage_options=storage_options
+    )
+    img = pd.read_parquet(
+        f"{base}/coralnet_images_{args.run}.parquet", storage_options=storage_options
+    )
+    logger.info("Loaded annotations=%s images=%s", f"{len(ann):,}", f"{len(img):,}")
+
+    n_needs = int(img["needs_resize"].sum())
+    n_sub = int((~img["needs_resize"]).sum())
+    n_nulldim = int((img["width"].isna() | img["height"].isna()).sum())
+    logger.info(
+        "Images: needs_resize=%s sub_threshold=%s null_dims=%s",
+        f"{n_needs:,}",
+        f"{n_sub:,}",
+        f"{n_nulldim:,}",
+    )
+
+    logger.info(
+        "Listing resized objects under s3://%s/%s/resized/ ...", args.bucket, args.output_prefix
+    )
+    ckpt = _resized_existence_table(s3, args.bucket, args.output_prefix)
+    logger.info("Resized objects on S3: %s", f"{len(ckpt):,}")
+
+    manifest = build_training_manifest(
+        annotations=ibis.memtable(ann),
+        images=ibis.memtable(img),
+        checkpoint=ibis.memtable(ckpt),
+        output_prefix=args.output_prefix,
+        threshold=args.threshold,
+    ).to_pandas()
+
+    # --- data-quality numbers ---
+    n_rows = len(manifest)
+    imgs = manifest.drop_duplicates(["source_id", "image_id"])
+    n_imgs = len(imgs)
+    n_resized = int(imgs["uses_resized_image"].sum())
+    n_original = n_imgs - n_resized
+    ann_imgs = ann.drop_duplicates(["source_id", "image_id"])
+    dropped_imgs = len(ann_imgs) - n_imgs
+    dropped_rows = len(ann) - n_rows
+    logger.info("=== Training manifest ===")
+    logger.info("Annotation rows:        %s  (dropped %s)", f"{n_rows:,}", f"{dropped_rows:,}")
+    logger.info("Distinct images:        %s  (dropped %s)", f"{n_imgs:,}", f"{dropped_imgs:,}")
+    logger.info("  using RESIZED key:    %s", f"{n_resized:,}")
+    logger.info("  using ORIGINAL key:   %s", f"{n_original:,}")
+
+    if args.dry_run:
+        logger.info("--dry-run: not writing")
+        return 0
+
+    out_key = (
+        args.out_key
+        or f"etl-outputs/coralnet/{args.run}/coralnet_training_manifest_{args.run}.parquet"
+    )
+    out_uri = f"s3://{args.bucket}/{out_key}"
+    manifest.to_parquet(out_uri, storage_options=storage_options, index=False)
+    logger.info("Wrote %s rows -> %s", f"{n_rows:,}", out_uri)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sagemaker_processing_entrypoint.py
+++ b/scripts/sagemaker_processing_entrypoint.py
@@ -29,7 +29,7 @@ def main():
     parser.add_argument(
         "--task",
         required=True,
-        choices=["eval", "inference", "coralnet-etl", "coralnet-refresh"],
+        choices=["eval", "inference", "coralnet-etl", "coralnet-refresh", "coralnet-resize"],
         help="Which processing routine to run.",
     )
     # Pass-through args specific to each task.
@@ -51,6 +51,10 @@ def main():
         from mermaidseg.datasets.coralnet.scraper.refresh_image_lists import main as refresh_main
 
         sys.exit(refresh_main(extra))
+    elif args.task == "coralnet-resize":
+        from mermaidseg.datasets.coralnet.preprocessing.resize import main as resize_main
+
+        sys.exit(resize_main(extra))
     else:
         raise SystemExit(f"Unknown task: {args.task}")
 

--- a/scripts/sagemaker_processing_entrypoint.py
+++ b/scripts/sagemaker_processing_entrypoint.py
@@ -29,7 +29,7 @@ def main():
     parser.add_argument(
         "--task",
         required=True,
-        choices=["eval", "inference"],
+        choices=["eval", "inference", "coralnet-etl", "coralnet-refresh"],
         help="Which processing routine to run.",
     )
     # Pass-through args specific to each task.
@@ -43,6 +43,14 @@ def main():
         from mermaidseg.inference import run_inference
 
         run_inference(extra)
+    elif args.task == "coralnet-etl":
+        from mermaidseg.datasets.coralnet.etl.__main__ import main as etl_main
+
+        etl_main(extra)
+    elif args.task == "coralnet-refresh":
+        from mermaidseg.datasets.coralnet.scraper.refresh_image_lists import main as refresh_main
+
+        sys.exit(refresh_main(extra))
     else:
         raise SystemExit(f"Unknown task: {args.task}")
 

--- a/tests/datasets/coralnet/test_audit.py
+++ b/tests/datasets/coralnet/test_audit.py
@@ -79,3 +79,38 @@ def test_audit_sources_respects_explicit_source_ids(fake_s3, sample_csv_factory,
         source_ids=[11],
     )
     assert df["source_id"].tolist() == [11]
+
+
+def test_truncated_image_list_fails_is_complete(fake_s3, sample_csv_factory, populate):
+    """image_list.csv listing fewer images than annotations reference must NOT be
+    is_complete.
+
+    Regression for the 2026-06 truncation incident: all files present but a short image_list.csv
+    silently dropped most annotated images downstream.
+    """
+    bucket, prefix = "b", "p"
+    files = sample_csv_factory(source_id=9, n_images=5, n_points_per_image=2)
+    # Truncate image_list.csv to header + a single data row (lists 1 of 5 annotated images).
+    lines = files["image_list.csv"].decode().splitlines()
+    files["image_list.csv"] = ("\n".join(lines[:2]) + "\n").encode()
+    populate(fake_s3, bucket, prefix, 9, files)
+
+    df = audit_sources(bucket=bucket, prefix=prefix, workers=1, s3_client=fake_s3)
+    row = df.loc[df["source_id"] == 9].iloc[0]
+
+    assert row["has_image_list_csv"]  # file is present, just short
+    assert row["n_images_csv"] == 1
+    assert row["n_unique_images_annotated"] == 5
+    assert not row["image_list_covers_annotations"]
+    assert not row["is_complete"]
+
+
+def test_complete_source_covers_annotations(fake_s3, sample_csv_factory, populate):
+    bucket, prefix = "b", "p"
+    populate(fake_s3, bucket, prefix, 3, sample_csv_factory(source_id=3, n_images=4))
+    df = audit_sources(bucket=bucket, prefix=prefix, workers=1, s3_client=fake_s3)
+    row = df.loc[df["source_id"] == 3].iloc[0]
+    assert row["n_images_csv"] == 4
+    assert row["n_unique_images_annotated"] == 4
+    assert row["image_list_covers_annotations"]
+    assert row["is_complete"]

--- a/tests/datasets/coralnet/test_coralnet_dataset_resized.py
+++ b/tests/datasets/coralnet/test_coralnet_dataset_resized.py
@@ -1,0 +1,133 @@
+"""CoralNetDataset consuming the resized training parquet (per-image image_s3_key).
+
+These tests are hermetic: parquet reads, the boto3 client, and S3 image fetches are all
+stubbed, so nothing touches AWS.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+from PIL import Image
+
+import mermaidseg.datasets.coralnet.coralnet_dataset as cnd
+from mermaidseg.datasets.coralnet.coralnet_dataset import CoralNetDataset
+
+
+def _make_dataset(monkeypatch, df_annotations, captured_keys, image_provider, **base_kwargs):
+    """Build a CoralNetDataset offline.
+
+    ``df_annotations`` is returned in place of any S3 parquet read. ``image_provider``
+    maps a requested S3 key to a PIL image; every requested key is appended to
+    ``captured_keys``.
+    """
+    monkeypatch.setattr(pd, "read_parquet", lambda *a, **k: df_annotations.copy())
+    monkeypatch.setattr(cnd.boto3, "client", lambda *a, **k: MagicMock())
+
+    def fake_get_image_s3(s3, bucket, key, **kwargs):
+        captured_keys.append(key)
+        return image_provider(key)
+
+    monkeypatch.setattr(cnd, "get_image_s3", fake_get_image_s3)
+    return CoralNetDataset(**base_kwargs)
+
+
+def _resized_parquet_df():
+    """One image, two points, with a resolved resized image_s3_key (new-parquet
+    shape)."""
+    return pd.DataFrame(
+        {
+            "source_id": [1, 1],
+            "image_id": ["img1", "img1"],
+            "row": [10, 5],
+            "col": [20, 7],
+            "coralnet_id": [82, 82],
+            "source_label_name": ["82", "82"],
+            "image_s3_key": ["dev/images/resized/s1/images/img1.jpg"] * 2,
+        }
+    )
+
+
+def test_read_image_prefers_resolved_key(monkeypatch):
+    """When the parquet carries image_s3_key, read_image loads exactly that key."""
+    keys: list[str] = []
+    ds = _make_dataset(
+        monkeypatch,
+        _resized_parquet_df(),
+        keys,
+        lambda key: Image.new("RGB", (50, 30)),
+    )
+    # df_images must carry the resolved key through to read_image.
+    assert "image_s3_key" in ds.df_images.columns
+    ds.read_image(
+        image_id="img1", source_id="1", image_s3_key="dev/images/resized/s1/images/img1.jpg"
+    )
+    assert keys[-1] == "dev/images/resized/s1/images/img1.jpg"
+
+
+def test_read_image_falls_back_to_constructed_key(monkeypatch):
+    """Legacy parquet (no image_s3_key) -> read_image constructs the original key."""
+    legacy = _resized_parquet_df().drop(columns=["image_s3_key"])
+    keys: list[str] = []
+    ds = _make_dataset(monkeypatch, legacy, keys, lambda key: Image.new("RGB", (50, 30)))
+    assert "image_s3_key" not in ds.df_images.columns
+    ds.read_image(image_id="img1", source_id="1")
+    assert keys[-1] == "coralnet-public-images/s1/images/img1.jpg"
+
+
+def test_getitem_places_label_at_point_with_correct_orientation(monkeypatch):
+    """End-to-end alignment: the (row, col) from the parquet lands at mask[row, col] on
+    the loaded image, with row indexing height and col indexing width (guards a row/col
+    transpose).
+
+    Uses a single point and a non-square image so a transpose would move the label.
+    """
+    df = pd.DataFrame(
+        {
+            "source_id": [1],
+            "image_id": ["img1"],
+            "row": [10],
+            "col": [20],
+            "coralnet_id": [82],
+            "source_label_name": ["82"],
+            "image_s3_key": ["dev/images/resized/s1/images/img1.jpg"],
+        }
+    )
+    keys: list[str] = []
+    # PIL size is (width, height) -> numpy array shape (30, 50, 3): H=30, W=50.
+    ds = _make_dataset(monkeypatch, df, keys, lambda key: Image.new("RGB", (50, 30)), padding=None)
+
+    image, mask = ds[0]
+
+    assert keys == ["dev/images/resized/s1/images/img1.jpg"]
+    assert image.shape == (30, 50, 3)
+    assert mask.shape == (30, 50)  # (height, width) — matches the loaded image
+    # Single foreground class -> local id 1, placed exactly at (row=10, col=20).
+    assert mask[10, 20] == 1
+    assert int((mask != 0).sum()) == 1  # nothing else set; no transpose to (20, 10)
+
+
+def test_missing_required_column_raises(monkeypatch):
+    """A parquet missing a required column fails fast with a clear error, not a pandas
+    KeyError."""
+    bad = _resized_parquet_df().drop(columns=["coralnet_id"])
+    with pytest.raises(ValueError, match="missing required columns.*coralnet_id"):
+        _make_dataset(monkeypatch, bad, [], lambda key: Image.new("RGB", (8, 8)))
+
+
+def test_collate_fn_skips_failed_loads(monkeypatch):
+    """A (None, None) failed-load item is dropped; the surviving sample is stacked."""
+    import torch
+
+    keys: list[str] = []
+    ds = _make_dataset(
+        monkeypatch, _resized_parquet_df(), keys, lambda key: Image.new("RGB", (8, 8))
+    )
+    good_img = np.zeros((3, 8, 8), dtype=np.float32)
+    good_mask = np.zeros((8, 8), dtype=np.int64)
+    images, masks = ds.collate_fn([(None, None), (good_img, good_mask)])
+    assert isinstance(images, torch.Tensor)
+    assert images.shape[0] == 1 and masks.shape[0] == 1

--- a/tests/datasets/coralnet/test_live_smoke.py
+++ b/tests/datasets/coralnet/test_live_smoke.py
@@ -1,4 +1,5 @@
-"""Live Playwright smoke tests against coralnet.ucsd.edu (excluded from default pytest)."""
+"""Live Playwright smoke tests against coralnet.ucsd.edu (excluded from default
+pytest)."""
 
 # ruff: noqa: E402
 
@@ -164,8 +165,8 @@ def test_pagination_links_well_formed(page, public_source_id):
     """Walk to page 2 and verify the resolved URL is well-formed.
 
     Exercises the same ``urljoin`` flow used by ``download_annotations_paginated`` and
-    ``get_images``. Regression test for the bug where path/query concatenation produced URLs like
-    ``.../images/?...?page=2``.
+    ``get_images``. Regression test for the bug where path/query concatenation produced
+    URLs like ``.../images/?...?page=2``.
     """
     browse_url = f"{CORALNET_BASE}/source/{public_source_id}/browse/images/"
     response = page.goto(browse_url, wait_until="domcontentloaded")
@@ -189,6 +190,116 @@ def test_pagination_links_well_formed(page, public_source_id):
     response = page.goto(page_two_url, wait_until="domcontentloaded")
     assert response is not None and response.status < 400
     assert page.locator("span.thumb_wrapper").count() >= 1
+
+
+def _page_image_ids(page) -> tuple[int, ...]:
+    """CoralNet image PKs (DOM order) for the browse page currently loaded in
+    ``page``."""
+    return _extract_page_image_ids(BeautifulSoup(page.content(), "html.parser"))
+
+
+def test_get_images_parallel_live_end_to_end(public_source_id, coralnet_credentials):
+    """Run the real ``CoralNetDownloader.get_images`` parallel fan-out against the site.
+
+    Unlike the Playwright tests above (which drive a browser), this exercises the
+    production ``requests``-based code path — parallel ``?page=N`` fetching, the
+    ``_with_retry`` wrapper, and per-page graceful degradation — end to end on the live
+    site. Bounded with a small ``total_images_hint`` so only ~3 pages are fetched
+    regardless of how large the source is.
+    """
+    from mermaidseg.datasets.coralnet.scraper.downloader import CoralNetDownloader
+
+    dl = CoralNetDownloader("anon", "anon")
+    if coralnet_credentials is not None:
+        # Log in when creds are available (mirrors the refresh job); public browse
+        # works without it, so a failed login is non-fatal.
+        dl.username, dl.password = coralnet_credentials
+        dl.login()
+
+    probe = dl.probe_source(public_source_id)
+    if not probe.accessible:
+        pytest.skip(f"source {public_source_id} not accessible: {probe.error}")
+    total = probe.total_images_website or 0
+
+    page_size = 20  # CoralNet browse pages hold 20 thumbnails
+    if total <= page_size:
+        pytest.skip(f"source {public_source_id} has a single browse page ({total} images)")
+
+    # Cap the fan-out to ~3 pages so the test stays bounded on huge sources.
+    hint = min(total, 3 * page_size)
+    df, ok = dl.get_images(public_source_id, total_images_hint=hint, browse_workers=3)
+
+    assert ok is True
+    assert df is not None and not df.empty
+    # Fan-out actually fetched more than page 1.
+    assert len(df) > page_size, f"expected multi-page result, got {len(df)} rows"
+    # Bounded by the hint and never more than the source's true total.
+    assert len(df) <= hint <= total
+    # No duplicate image names across merged pages.
+    assert df["Name"].is_unique, "merged parallel pages contain duplicate Names"
+    assert list(df.columns) == ["Name", "Image Page"]
+
+
+def test_browse_page_param_direct_pagination(page, public_source_id):
+    """Verify ``?page=N`` URLs can be constructed directly (no cursor-following).
+
+    This is the live contract the parallel browse fan-out in ``get_images`` depends
+    on: rather than walking ``a[title="Next page"]`` links one page at a time, it
+    computes ``n_pages = ceil(total / page_size)`` and fetches ``?page=2..N`` in
+    parallel. This test confirms against the real site that:
+
+      * a directly-constructed ``?page=2`` returns images disjoint from page 1, and
+      * the directly-constructed last page ``?page=n_pages`` returns exactly the
+        expected remainder — proving the page-count math is right.
+
+    Browse pages are slow under load (the reason ``get_images`` now retries), so a
+    generous 90s navigation timeout is used to mirror ``_PAGE_GET_TIMEOUT``.
+    """
+    nav_timeout = 90_000
+
+    # Total image count comes from the source overview page.
+    overview = page.goto(
+        f"{CORALNET_BASE}/source/{public_source_id}/",
+        wait_until="domcontentloaded",
+        timeout=nav_timeout,
+    )
+    if reason := skip_reason_for_source_response(overview, public_source_id):
+        pytest.skip(reason)
+    total = parse_total_images_from_source_html(page.content())
+    assert total and total > 0
+
+    base = f"{CORALNET_BASE}/source/{public_source_id}/browse/images"
+    p1 = page.goto(base, wait_until="domcontentloaded", timeout=nav_timeout)
+    if reason := skip_reason_for_source_response(p1, public_source_id):
+        pytest.skip(reason)
+    page1_ids = _page_image_ids(page)
+    page_size = len(page1_ids)
+    if page_size == 0 or total <= page_size:
+        pytest.skip(f"source {public_source_id} has a single browse page ({total} images)")
+
+    # ceil-divide — identical to the formula get_images uses.
+    n_pages = -(-total // page_size)
+
+    # Directly construct ?page=2 (NOT via the Next-page link) and confirm it
+    # returns a distinct set of images.
+    p2 = page.goto(f"{base}?page=2", wait_until="domcontentloaded", timeout=nav_timeout)
+    assert p2 is not None and p2.status < 400
+    page2_ids = _page_image_ids(page)
+    assert page2_ids, "?page=2 returned no thumbnails"
+    assert set(page1_ids).isdisjoint(page2_ids), (
+        "?page=2 returned the same images as page 1 — direct page-param pagination is broken"
+    )
+
+    # Directly construct the LAST page and confirm the remainder count matches the
+    # page math (last page holds total - (n_pages-1)*page_size images).
+    last = page.goto(f"{base}?page={n_pages}", wait_until="domcontentloaded", timeout=nav_timeout)
+    assert last is not None and last.status < 400
+    last_ids = _page_image_ids(page)
+    expected_last = total - (n_pages - 1) * page_size
+    assert len(last_ids) == expected_last, (
+        f"last page ?page={n_pages} returned {len(last_ids)} images, "
+        f"expected remainder {expected_last} (total={total}, page_size={page_size})"
+    )
 
 
 def test_paginated_annotation_export_produces_csv(page, public_source_id, coralnet_credentials):
@@ -277,12 +388,12 @@ def _parse_post_body(body: str, content_type: str | None) -> dict[str, str]:
     """Parse a Playwright-captured POST body into ``{field_name: value}``.
 
     Handles both ``application/x-www-form-urlencoded`` (what our scraper sends) and
-    ``multipart/form-data`` (what CoralNet's UI sends). The multipart path uses a hand-rolled
-    boundary split rather than the ``email`` module so it doesn't choke on body-only content (no
-    headers).
+    ``multipart/form-data`` (what CoralNet's UI sends). The multipart path uses a hand-
+    rolled boundary split rather than the ``email`` module so it doesn't choke on body-
+    only content (no headers).
 
-    Fails the calling test if the multipart boundary can't be located; a silent empty dict would
-    masquerade as a body-shape mismatch and hide a parser regression.
+    Fails the calling test if the multipart boundary can't be located; a silent empty
+    dict would masquerade as a body-shape mismatch and hide a parser regression.
     """
     ct = content_type or ""
     looks_multipart = "multipart/form-data" in ct.lower() or body.lstrip().startswith("--")

--- a/tests/datasets/coralnet/test_preprocessing.py
+++ b/tests/datasets/coralnet/test_preprocessing.py
@@ -17,10 +17,13 @@ from mermaidseg.datasets.coralnet.preprocessing.inspect import (
 )
 from mermaidseg.datasets.coralnet.preprocessing.manifest import (
     build_manifest,
+    build_training_manifest,
     combine_checkpoints,
 )
 from mermaidseg.datasets.coralnet.preprocessing.resize import (
     _resized_s3_key_for,
+    _resolve_checkpoint_s3_keys,
+    _summarise_checkpoint,
     get_pending_items,
     read_checkpoint,
     resize_and_upload_all_images,
@@ -83,7 +86,8 @@ def test_resize_image_square():
 
 
 def test_resize_converts_rgba_to_rgb_jpeg():
-    """RGBA images are converted to RGB so they can be JPEG-encoded (not RGBA-as-JPEG error)."""
+    """RGBA images are converted to RGB so they can be JPEG-encoded (not RGBA-as-JPEG
+    error)."""
     img = Image.new("RGBA", (3000, 2000), color=(255, 0, 0, 128))
     img_bytes = BytesIO()
     img.save(img_bytes, format="PNG")
@@ -100,7 +104,8 @@ def test_resize_converts_rgba_to_rgb_jpeg():
 
 
 def test_resize_converts_rgba_below_threshold():
-    """A small RGBA image is still re-encoded to RGB JPEG, not passed through as raw bytes."""
+    """A small RGBA image is still re-encoded to RGB JPEG, not passed through as raw
+    bytes."""
     img = Image.new("RGBA", (800, 400), color=(0, 255, 0, 64))
     img_bytes = BytesIO()
     img.save(img_bytes, format="PNG")
@@ -117,7 +122,8 @@ def test_resize_converts_rgba_below_threshold():
 
 
 def test_scan_for_missing_resized_images_builds_todo_list():
-    """Scan lists the resized prefix once and diffs in memory — no per-image head_object."""
+    """Scan lists the resized prefix once and diffs in memory — no per-image
+    head_object."""
     df_images = pd.DataFrame(
         {
             "source_id": [1, 1, 2],
@@ -212,7 +218,8 @@ def test_checkpoint_pending_items_extracted():
 
 
 def test_resize_and_upload_image_returns_completed_result():
-    """Worker downloads/resizes/uploads and RETURNS a checkpoint row; it does no checkpoint I/O."""
+    """Worker downloads/resizes/uploads and RETURNS a checkpoint row; it does no
+    checkpoint I/O."""
     # Create mock S3 client
     mock_s3 = Mock()
 
@@ -264,7 +271,8 @@ def test_resize_and_upload_image_returns_completed_result():
 
 
 def _checkpoint_table(df: pd.DataFrame) -> ibis.Table:
-    """Memtable with the dtypes the checkpoint parquet schema guarantees in production."""
+    """Memtable with the dtypes the checkpoint parquet schema guarantees in
+    production."""
     return ibis.memtable(
         df.astype(
             {
@@ -312,7 +320,8 @@ def test_combine_checkpoints_later_run_wins():
 
 
 def test_combine_checkpoints_most_recent_timestamp_wins_regardless_of_order():
-    """The freshest resize_timestamp wins even when checkpoints are passed out of order."""
+    """The freshest resize_timestamp wins even when checkpoints are passed out of
+    order."""
     ckpt_newer = pd.DataFrame(
         {
             "source_id": [1],
@@ -354,7 +363,8 @@ def test_combine_checkpoints_empty_raises():
 
 
 def test_combine_checkpoints_single_input_dedups():
-    """A single checkpoint passes through, still deduped by latest timestamp per image."""
+    """A single checkpoint passes through, still deduped by latest timestamp per
+    image."""
     ckpt = pd.DataFrame(
         {
             "source_id": [1, 1],
@@ -424,8 +434,8 @@ def test_manifest_schema_is_correct():
 
 
 def test_manifest_dimensions_and_keys_match_resize():
-    """Below threshold keeps original dims; above threshold floors like the resize worker, and
-    output_s3_key matches _resized_s3_key_for."""
+    """Below threshold keeps original dims; above threshold floors like the resize
+    worker, and output_s3_key matches _resized_s3_key_for."""
     threshold = 2048
     df_images = pd.DataFrame(
         {
@@ -471,6 +481,161 @@ def test_manifest_dimensions_and_keys_match_resize():
     )
 
 
+def test_training_manifest_scales_coords_and_excludes():
+    """Sub-threshold coords unchanged + original key; resized coords floored to load
+    dims + resized key; needs_resize-but-not-completed images (failed / absent from
+    checkpoint) excluded."""
+    images = pd.DataFrame(
+        {
+            "source_id": [1, 1, 1, 1, 1],
+            "image_id": ["sub", "big", "fail", "missing", "nodims"],
+            "s3_key": [
+                "coralnet-public-images/s1/images/sub.jpg",
+                "coralnet-public-images/s1/images/big.jpg",
+                "coralnet-public-images/s1/images/fail.jpg",
+                "coralnet-public-images/s1/images/missing.jpg",
+                "coralnet-public-images/s1/images/nodims.jpg",
+            ],
+            # "nodims" has unknown dimensions (e.g. header_status="not_found").
+            "width": [1000, 4000, 5000, 6000, None],
+            "height": [800, 2000, 3000, 3000, None],
+            "needs_resize": [False, True, True, True, False],
+        }
+    )
+    # "missing" needs_resize but has no checkpoint row at all -> must be excluded.
+    checkpoint = pd.DataFrame(
+        {
+            "source_id": [1, 1],
+            "image_id": ["big", "fail"],
+            "status": ["completed", "failed"],
+            "resize_timestamp": [datetime.now(), None],
+            "error_message": [None, "decode failed"],
+        }
+    )
+    annotations = pd.DataFrame(
+        {
+            "source_id": [1, 1, 1, 1, 1, 1],
+            "image_id": ["sub", "big", "big", "fail", "missing", "nodims"],
+            "row": [400, 1000, 1999, 10, 10, 10],
+            "col": [500, 2000, 3999, 10, 10, 10],
+            "coralnet_id": [82, 91, 91, 7, 7, 7],
+        }
+    )
+
+    out = build_training_manifest(
+        annotations=ibis.memtable(annotations),
+        images=ibis.memtable(images),
+        checkpoint=ibis.memtable(checkpoint),
+        output_prefix="dev/images",
+        threshold=2048,
+    ).to_pandas()
+
+    # Only sub-threshold + completed-resize images with known dims survive
+    # ("fail"/"missing" excluded for incomplete resize, "nodims" for null dimensions).
+    assert set(out["image_id"]) == {"sub", "big"}
+
+    # Every surviving point is in bounds (no nulls, no out-of-range from null-dim collapse).
+    assert out["load_width"].notna().all() and out["load_height"].notna().all()
+    assert (out["row"] >= 0).all() and (out["row"] < out["load_height"]).all()
+    assert (out["col"] >= 0).all() and (out["col"] < out["load_width"]).all()
+
+    # Coords/dims are stored as int16 (bounded by the 2048 resize threshold) to keep the file small.
+    for c in ("row", "col", "load_width", "load_height"):
+        assert out[c].dtype == "int16", (c, out[c].dtype)
+
+    # Sub-threshold image: original key, coords unchanged, source_label_name = str(coralnet_id).
+    sub = out[out["image_id"] == "sub"].iloc[0]
+    assert sub["image_s3_key"] == "coralnet-public-images/s1/images/sub.jpg"
+    assert (int(sub["row"]), int(sub["col"])) == (400, 500)
+    assert bool(sub["uses_resized_image"]) is False
+    assert sub["source_label_name"] == "82"
+
+    # Resized image: resized key, dims floored to threshold (4000 -> 2048, 2000 -> 1024).
+    big = out[out["image_id"] == "big"]
+    assert (big["image_s3_key"] == "dev/images/resized/s1/images/big.jpg").all()
+    assert big["uses_resized_image"].all()
+    assert (big["load_width"] == 2048).all() and (big["load_height"] == 1024).all()
+    coords = set(zip(big["row"].astype(int), big["col"].astype(int), strict=True))
+    # (1000,2000) -> (floor(1000*1024/2000), floor(2000*2048/4000)) = (512, 1024)
+    assert (512, 1024) in coords
+    # (1999,3999) -> (floor(1999*1024/2000), floor(3999*2048/4000)) = (1023, 2047), within bounds
+    assert (1023, 2047) in coords
+
+
+def _build_one_image_manifest(orig_w, orig_h, row, col, *, threshold=2048):
+    """Run build_training_manifest for a single image+point; return (out_df,
+    needs_resize)."""
+    needs = max(orig_w, orig_h) > threshold
+    images = pd.DataFrame(
+        {
+            "source_id": [1],
+            "image_id": ["x"],
+            "s3_key": ["coralnet-public-images/s1/images/x.jpg"],
+            "width": [orig_w],
+            "height": [orig_h],
+            "needs_resize": [needs],
+        }
+    )
+    checkpoint = pd.DataFrame(
+        {
+            "source_id": [1],
+            "image_id": ["x"],
+            "status": ["completed"],
+            "resize_timestamp": [datetime.now()],
+            "error_message": [None],
+        }
+    )
+    annotations = pd.DataFrame(
+        {"source_id": [1], "image_id": ["x"], "row": [row], "col": [col], "coralnet_id": [82]}
+    )
+    out = build_training_manifest(
+        annotations=ibis.memtable(annotations),
+        images=ibis.memtable(images),
+        checkpoint=ibis.memtable(checkpoint),
+        output_prefix="dev/images",
+        threshold=threshold,
+    ).to_pandas()
+    return out, needs
+
+
+@pytest.mark.parametrize(
+    "orig_w,orig_h",
+    [
+        (4000, 2000),  # landscape, resized
+        (2000, 4000),  # portrait, resized
+        (3000, 3000),  # square, resized (non-power-of-2 ratio)
+        (2049, 2049),  # just over threshold
+        (800, 600),  # sub-threshold, not resized
+        (2048, 1000),  # longest == threshold, not resized
+    ],
+)
+def test_training_manifest_load_dims_and_coords_match_real_resize(orig_w, orig_h):
+    """Builder load dims + scaled coords agree with the actual PIL resize (oracle), and
+    a far-corner point stays in bounds after the floor+clip."""
+    threshold = 2048
+    r, c = orig_h - 1, orig_w - 1  # far corner stresses the clip
+    out, needs = _build_one_image_manifest(orig_w, orig_h, r, c, threshold=threshold)
+    assert len(out) == 1
+    rowd = out.iloc[0]
+
+    buf = BytesIO()
+    Image.new("RGB", (orig_w, orig_h)).save(buf, format="JPEG")
+    buf.seek(0)
+    resized = Image.open(resize_image_to_threshold(buf, threshold=threshold))
+    resized.load()
+
+    # Oracle: recorded load dims == dimensions the real resize produced.
+    assert int(rowd["load_width"]) == resized.width
+    assert int(rowd["load_height"]) == resized.height
+    assert bool(rowd["uses_resized_image"]) == needs
+
+    # Coords scale by load/orig (same factor the builder uses) and stay in bounds.
+    assert int(rowd["col"]) == min(int(c * resized.width / orig_w), resized.width - 1)
+    assert int(rowd["row"]) == min(int(r * resized.height / orig_h), resized.height - 1)
+    assert 0 <= int(rowd["row"]) < resized.height
+    assert 0 <= int(rowd["col"]) < resized.width
+
+
 # ============================================================================
 # Image inspection and robustness tests
 # ============================================================================
@@ -490,7 +655,8 @@ def test_inspect_image_valid_rgb(valid_rgb_jpeg_bytes):
 
 
 def test_inspect_image_rgba_png(rgba_png_bytes):
-    """Inspection passes for RGBA PNG; the resize step converts it to RGB before JPEG encoding."""
+    """Inspection passes for RGBA PNG; the resize step converts it to RGB before JPEG
+    encoding."""
     image_bytes = BytesIO(rgba_png_bytes)
     inspection = inspect_image(image_bytes)
 
@@ -501,7 +667,8 @@ def test_inspect_image_rgba_png(rgba_png_bytes):
 
 
 def test_inspect_image_grayscale(grayscale_jpeg_bytes):
-    """Inspection passes for grayscale JPEG; the resize step encodes single-channel L directly."""
+    """Inspection passes for grayscale JPEG; the resize step encodes single-channel L
+    directly."""
     image_bytes = BytesIO(grayscale_jpeg_bytes)
     inspection = inspect_image(image_bytes)
 
@@ -553,7 +720,8 @@ def test_inspect_image_none():
 
 
 def test_resize_converts_and_uploads_rgba_png(rgba_png_bytes):
-    """Worker converts an RGBA PNG to RGB JPEG, uploads it, and returns a completed result."""
+    """Worker converts an RGBA PNG to RGB JPEG, uploads it, and returns a completed
+    result."""
     mock_s3 = MagicMock()
 
     # Mock GET to return RGBA PNG bytes
@@ -650,8 +818,8 @@ def test_resize_mixed_batch(valid_rgb_jpeg_bytes, truncated_jpeg_bytes, tmp_path
 
 
 def test_resize_resumes_only_pending_items(valid_rgb_jpeg_bytes, tmp_path):
-    """An existing checkpoint with completed rows is resumed: completed images are not re-
-    downloaded."""
+    """An existing checkpoint with completed rows is resumed: completed images are not
+    re- downloaded."""
     mock_s3 = MagicMock()
     mock_s3.get_object.return_value = {"Body": BytesIO(valid_rgb_jpeg_bytes)}
     mock_s3.put_object = MagicMock()
@@ -711,8 +879,8 @@ def test_resize_resumes_only_pending_items(valid_rgb_jpeg_bytes, tmp_path):
 
 
 def test_resume_summary_counts_never_negative(valid_rgb_jpeg_bytes, tmp_path):
-    """Resuming with a todo smaller than the checkpoint reports counts from the checkpoint
-    itself."""
+    """Resuming with a todo smaller than the checkpoint reports counts from the
+    checkpoint itself."""
     mock_s3 = MagicMock()
     mock_s3.get_object.return_value = {"Body": BytesIO(valid_rgb_jpeg_bytes)}
 
@@ -761,10 +929,126 @@ def test_resume_summary_counts_never_negative(valid_rgb_jpeg_bytes, tmp_path):
     assert num_corrupted == 1  # 'c'
 
 
+def test_summarise_checkpoint_handles_old_schema_without_skip_reason():
+    """A pre-schema checkpoint (no skip_reason column) summarizes without KeyError.
+
+    Reproduces the May-checkpoint crash: that file predates the skip_reason column, and
+    summarizing it raised KeyError. The summary must treat absent skip_reason as "no corrupted
+    skips".
+    """
+    old_checkpoint = pd.DataFrame(
+        {
+            "source_id": [1, 1, 1, 1],
+            "image_id": ["a", "b", "c", "d"],
+            "status": ["completed", "completed", "skipped", "failed"],
+            "resize_timestamp": [datetime.now(), datetime.now(), None, None],
+            "error_message": [None, None, None, "boom"],
+        }
+    )
+    assert "skip_reason" not in old_checkpoint.columns
+
+    num_resized, num_skipped, num_failed, num_corrupted = _summarise_checkpoint(old_checkpoint)
+
+    assert num_resized == 2
+    assert num_skipped == 1  # the lone skip is counted as a plain skip, not corrupted
+    assert num_failed == 1
+    assert num_corrupted == 0
+
+
+def test_checkpoint_keys_default_pull_and_push_to_same_run_path():
+    """With no overrides, pull and push both derive from the run version."""
+    pull_key, push_key = _resolve_checkpoint_s3_keys(
+        run="20260623_nogit", checkpoint_s3_key=None, pull_checkpoint_s3_key=None
+    )
+    assert pull_key == push_key
+    assert "20260623_nogit" in push_key
+
+
+def test_checkpoint_keys_pull_from_old_run_push_to_new_run():
+    """Pulling a prior run's checkpoint must NOT redirect the push to that prior path.
+
+    Reproduces the wrong-path bug: one --checkpoint-s3-key served both pull and push, so a job
+    that seeded from May's checkpoint wrote its results back over May's path. Pull and push are
+    now independent.
+    """
+    pull_key, push_key = _resolve_checkpoint_s3_keys(
+        run="20260623_nogit",
+        checkpoint_s3_key=None,
+        pull_checkpoint_s3_key="etl-outputs/coralnet/20260526_807b611/resize_checkpoint_20260526_807b611.parquet",
+    )
+    assert "20260526_807b611" in pull_key  # pulls the old run
+    assert "20260623_nogit" in push_key  # but pushes under the new run
+    assert pull_key != push_key
+
+
+def test_checkpoint_keys_pull_falls_back_to_push_override():
+    """When only the push key is overridden, pull reuses it (single-key behavior
+    preserved)."""
+    pull_key, push_key = _resolve_checkpoint_s3_keys(
+        run="20260623_nogit",
+        checkpoint_s3_key="custom/path/checkpoint.parquet",
+        pull_checkpoint_s3_key=None,
+    )
+    assert pull_key == "custom/path/checkpoint.parquet"
+    assert push_key == "custom/path/checkpoint.parquet"
+
+
+def test_resize_raises_when_checkpoint_does_not_intersect_todo(tmp_path):
+    """A pre-existing checkpoint whose pending IDs don't match the todo must fail
+    loudly.
+
+    Reproduces the cross-version bug: a checkpoint from an earlier ETL run is on disk, but the new
+    run's todo has different image IDs. The pending/todo merge collapses to zero rows. The old code
+    silently processed nothing and reported success; it must now raise.
+    """
+    mock_s3 = MagicMock()
+
+    checkpoint_path = tmp_path / "checkpoint.parquet"
+
+    # Old run's checkpoint: pending images from a different ETL version.
+    write_checkpoint(
+        checkpoint_path,
+        pd.DataFrame(
+            {
+                "source_id": [1, 1],
+                "image_id": ["old_a", "old_b"],
+                "status": ["pending", "pending"],
+                "resize_timestamp": [None, None],
+                "error_message": [None, None],
+                "skip_reason": [None, None],
+            }
+        ),
+    )
+
+    # This run's todo: entirely different image IDs — zero overlap with the checkpoint.
+    todo_df = pd.DataFrame(
+        [
+            {
+                "source_id": 2,
+                "image_id": "new_c",
+                "original_s3_key": "coralnet-public-images/s2/images/new_c.jpg",
+                "output_s3_key": "etl-outputs/coralnet/resized/s2/images/new_c.jpg",
+            }
+        ]
+    )
+
+    with pytest.raises(ValueError, match="intersect"):
+        resize_and_upload_all_images(
+            df_todo=todo_df,
+            bucket="test-bucket",
+            output_prefix="etl-outputs/coralnet",
+            checkpoint_path=checkpoint_path,
+            threshold=2048,
+            workers=2,
+            s3_client=mock_s3,
+        )
+
+
 def test_resize_all_images_builds_one_pool_sized_client(
     monkeypatch, valid_rgb_jpeg_bytes, tmp_path
 ):
-    """With no client injected, the orchestrator builds ONE shared client with pool >= workers."""
+    """With no client injected, the orchestrator builds ONE shared client with pool >=
+    workers."""
     from mermaidseg.datasets.coralnet.preprocessing import resize as resize_module
 
     created_pools: list[int] = []

--- a/tests/datasets/coralnet/test_refresh_image_lists.py
+++ b/tests/datasets/coralnet/test_refresh_image_lists.py
@@ -1,0 +1,141 @@
+"""Tests for mermaidseg.datasets.coralnet.scraper.refresh_image_lists."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+import mermaidseg.datasets.coralnet.scraper.refresh_image_lists as refresh
+
+BUCKET, PREFIX = "b", "coralnet-public-images"
+
+
+class _StubDownloader:
+    """Returns a fixed browse-image DataFrame from get_images()."""
+
+    def __init__(self, n_rows: int, ok: bool = True):
+        self._n = n_rows
+        self._ok = ok
+
+    def get_images(self, source_id, **_kwargs):  # noqa: ARG002
+        if not self._ok:
+            return None, False
+        df = pd.DataFrame(
+            {
+                "Name": [f"img_{i}.jpg - Confirmed" for i in range(self._n)],
+                "Image Page": [f"/image/{i}/view/" for i in range(self._n)],
+            }
+        )
+        return df, True
+
+
+def _seed(fake_s3, sid, *, n_s3_images: int, existing_list_rows: int | None):
+    base = f"{PREFIX}/s{sid}/"
+    for i in range(n_s3_images):
+        fake_s3.put(BUCKET, f"{base}images/{i}.jpg", b"\xff\xd8\xff\xd9")
+    if existing_list_rows is not None:
+        body = "Name,Image Page\n" + "".join(
+            f"x_{i}.jpg - Confirmed,/image/{i}/view/\n" for i in range(existing_list_rows)
+        )
+        fake_s3.put(BUCKET, f"{base}image_list.csv", body.encode())
+
+
+def _list_key(sid):
+    return f"{PREFIX}/s{sid}/image_list.csv"
+
+
+def test_refresh_uploads_full_list(fake_s3):
+    _seed(fake_s3, 1, n_s3_images=10, existing_list_rows=2)  # truncated existing
+    r = refresh.refresh_one(_StubDownloader(10), fake_s3, BUCKET, PREFIX, 1)
+    assert r["uploaded"] is True
+    assert r["new_rows"] == 10
+    assert r["existing_rows"] == 2
+    # Uploaded object has all 10 rows and preserves the status suffix in Name.
+    body = fake_s3.objects[(BUCKET, _list_key(1))].decode()
+    assert body.count("/image/") == 10
+    assert "- Confirmed" in body
+
+
+def test_refresh_guard_rejects_shorter_scrape(fake_s3):
+    _seed(fake_s3, 2, n_s3_images=10, existing_list_rows=10)
+    r = refresh.refresh_one(_StubDownloader(3), fake_s3, BUCKET, PREFIX, 2)
+    assert r["uploaded"] is False
+    assert "existing(10)" in r["skipped_reason"]
+    assert (BUCKET, _list_key(2)) not in fake_s3.objects or fake_s3.objects[
+        (BUCKET, _list_key(2))
+    ].decode().count("/image/") == 10  # original untouched
+
+
+def test_refresh_guard_rejects_low_coverage(fake_s3):
+    _seed(fake_s3, 3, n_s3_images=100, existing_list_rows=None)
+    r = refresh.refresh_one(_StubDownloader(10), fake_s3, BUCKET, PREFIX, 3)
+    assert r["uploaded"] is False
+    assert "of s3_images(100)" in r["skipped_reason"]
+
+
+def test_refresh_dry_run_does_not_upload(fake_s3):
+    _seed(fake_s3, 4, n_s3_images=10, existing_list_rows=2)
+    r = refresh.refresh_one(_StubDownloader(10), fake_s3, BUCKET, PREFIX, 4, dry_run=True)
+    assert r["uploaded"] is False
+    assert r["skipped_reason"] == "dry_run"
+    assert r["new_rows"] == 10  # scrape happened, reported, but not written
+    # Existing list left untouched (still the seeded 2 rows).
+    assert fake_s3.objects[(BUCKET, _list_key(4))].decode().count("/image/") == 2
+
+
+def test_refresh_handles_failed_scrape(fake_s3):
+    _seed(fake_s3, 5, n_s3_images=10, existing_list_rows=2)
+    r = refresh.refresh_one(_StubDownloader(0, ok=False), fake_s3, BUCKET, PREFIX, 5)
+    assert r["uploaded"] is False
+    assert r["skipped_reason"] == "scrape_failed_or_empty"
+
+
+def test_main_aborts_early_when_coralnet_unreachable(monkeypatch):
+    """Pre-flight gate: if CoralNet is down, main() exits 2 without logging in or
+    scraping — so we don't pile load onto a struggling site."""
+    monkeypatch.setattr(refresh, "load_coralnet_credentials", lambda: ("u", "p"))
+    fake_dl = MagicMock()
+    fake_dl.is_coralnet_reachable.return_value = False
+    monkeypatch.setattr(refresh, "CoralNetDownloader", lambda *a, **k: fake_dl)
+
+    rc = refresh.main(
+        [
+            "--source-ids",
+            "1,2",
+            "--bucket",
+            BUCKET,
+            "--prefix",
+            PREFIX,
+            "--startup-jitter-seconds",
+            "0",
+        ]
+    )
+
+    assert rc == 2
+    fake_dl.login.assert_not_called()  # never attempted login on a down site
+
+
+def test_main_proceeds_when_reachable(monkeypatch):
+    """When reachable but login fails, main() returns 1 (gate passed, login tried)."""
+    monkeypatch.setattr(refresh, "load_coralnet_credentials", lambda: ("u", "p"))
+    fake_dl = MagicMock()
+    fake_dl.is_coralnet_reachable.return_value = True
+    fake_dl.login.return_value = False
+    monkeypatch.setattr(refresh, "CoralNetDownloader", lambda *a, **k: fake_dl)
+
+    rc = refresh.main(
+        [
+            "--source-ids",
+            "1",
+            "--bucket",
+            BUCKET,
+            "--prefix",
+            PREFIX,
+            "--startup-jitter-seconds",
+            "0",
+        ]
+    )
+
+    assert rc == 1
+    fake_dl.login.assert_called_once()

--- a/tests/datasets/coralnet/test_schemas.py
+++ b/tests/datasets/coralnet/test_schemas.py
@@ -58,3 +58,8 @@ def test_images_schema_has_needs_resize_flag():
 def test_audit_schema_carries_is_complete_and_image_count_match():
     names = [f.name for f in AUDIT_SCHEMA]
     assert {"is_complete", "image_count_match"}.issubset(names)
+
+
+def test_audit_schema_has_image_list_coverage_flag():
+    names = {field.name for field in AUDIT_SCHEMA}
+    assert "image_list_covers_annotations" in names

--- a/tests/datasets/coralnet/test_scraper.py
+++ b/tests/datasets/coralnet/test_scraper.py
@@ -22,6 +22,7 @@ from mermaidseg.datasets.coralnet.scraper.downloader import (
     _PAGINATED_EXPORT_THRESHOLD,
     CoralNetDownloader,
     _extract_page_image_ids,
+    _is_transient,
     export_prep_timeout_seconds,
     export_serve_timeout_seconds,
     half_open_batches,
@@ -268,6 +269,26 @@ def test_classify_redownload_images_when_csvs_ok_but_gap():
     assert act == RemediationAction.REDOWNLOAD_IMAGES
 
 
+def test_classify_redownload_csv_when_image_list_truncated():
+    # Regression: sources where image_list.csv is shorter than annotated images were
+    # previously falling through to MANUAL_REVIEW (issue #130).
+    probe = SourceProbe(295, "url", True, None, total_images_website=79_064)
+    act = classify_remediation_action(
+        probe=probe,
+        has_images_folder=True,
+        has_annotations_csv=True,
+        has_image_list_csv=True,
+        n_images_s3=79_062,
+        n_images_csv=1_064,
+        n_annotations=79_064,
+        annotations_csv_read_failed=False,
+        annotations_empty=False,
+        image_count_match=False,
+        image_list_covers_annotations=False,
+    )
+    assert act == RemediationAction.REDOWNLOAD_CSV
+
+
 def test_download_source_skips_zero_confirmed_on_website():
     dl = CoralNetDownloader("u", "p")
     dl.logged_in = True
@@ -357,7 +378,8 @@ def _thumb(image_id: int) -> str:
 def _browse_page(
     csrf: str, n_thumbs: int = 1, next_href: str | None = None, start_id: int = 1
 ) -> str:
-    """Build a fake browse page with ``n_thumbs`` thumbs whose image IDs start at ``start_id``.
+    """Build a fake browse page with ``n_thumbs`` thumbs whose image IDs start at
+    ``start_id``.
 
     Each page in a multi-page test should use a disjoint ``start_id`` range so
     ``_extract_page_image_ids`` produces distinct ID tuples across pages.
@@ -450,9 +472,9 @@ def _mock_paginated_session(
 ) -> Iterator[MagicMock]:
     """Patch ``dl.session.get``/``post`` and ``time.sleep`` for a paginated-export test.
 
-    Yields the ``post`` mock so tests can introspect ``call_args_list`` to assert the export_prep
-    POST body. ``get`` and ``post`` accept either a list (consumed in order as ``side_effect``) or a
-    callable (for URL-based dispatch in the parallel test).
+    Yields the ``post`` mock so tests can introspect ``call_args_list`` to assert the
+    export_prep POST body. ``get`` and ``post`` accept either a list (consumed in order
+    as ``side_effect``) or a callable (for URL-based dispatch in the parallel test).
     """
     with (
         patch.object(dl.session, "get", side_effect=get),
@@ -504,7 +526,8 @@ def test_download_annotations_bulk_for_small_source():
 def test_paginated_export_skips_when_existing_annotations_are_complete(
     paginated_downloader, fake_s3
 ):
-    """No pages are fetched when existing annotations.csv already covers all website images."""
+    """No pages are fetched when existing annotations.csv already covers all website
+    images."""
     dl = paginated_downloader
 
     existing_csv = _ann_csv([("img1.jpg", 1, 1, 10), ("img2.jpg", 2, 2, 20)])
@@ -578,7 +601,8 @@ def test_paginated_export_three_pages_concatenated(paginated_downloader, fake_s3
 
 
 def test_paginated_export_merges_with_existing_annotations(paginated_downloader, fake_s3):
-    """When annotations.csv already exists on S3, new rows are merged and deduplicated."""
+    """When annotations.csv already exists on S3, new rows are merged and
+    deduplicated."""
     dl = paginated_downloader
 
     existing_csv = _ann_csv(
@@ -624,8 +648,8 @@ def test_get_images_multi_page_uses_urljoin():
     """Second-page URL must be resolved via urljoin, not f-string concatenation.
 
     Regression test for the bug where ``f"{base_url}/{next_page}"`` produced paths like
-    ``.../images/?page=2`` instead of ``.../images?page=2``. Also pins the resulting DataFrame shape
-    (``Name`` and ``Image Page`` columns).
+    ``.../images/?page=2`` instead of ``.../images?page=2``. Also pins the resulting
+    DataFrame shape (``Name`` and ``Image Page`` columns).
     """
     dl = CoralNetDownloader("u", "p")
     dl.logged_in = True
@@ -682,8 +706,8 @@ def test_get_images_with_annotation_status_preserves_filter():
 def test_paginated_export_retries_on_page_timeout(paginated_downloader, fake_s3):
     """A ReadTimeout on attempt 1 of page 2's export_prep is retried and succeeds.
 
-    Phase 2 ``do_round_trip`` re-fetches the browse page for a fresh CSRF before each attempt, so
-    the retry triggers a second browse GET for page 2.
+    Phase 2 ``do_round_trip`` re-fetches the browse page for a fresh CSRF before each
+    attempt, so the retry triggers a second browse GET for page 2.
     """
     dl = paginated_downloader
 
@@ -719,8 +743,8 @@ def test_paginated_export_retries_on_page_timeout(paginated_downloader, fake_s3)
 def test_paginated_export_checkpoint_uploads_partial(paginated_downloader, fake_s3):
     """With ``checkpoint_every_pages=2`` and 3 pages, the CSV is uploaded twice.
 
-    Once at the checkpoint after page 2, and again as the final upload after page 3. The final CSV
-    must contain rows from all three pages.
+    Once at the checkpoint after page 2, and again as the final upload after page 3. The
+    final CSV must contain rows from all three pages.
     """
     dl = paginated_downloader
 
@@ -766,7 +790,8 @@ def test_paginated_export_checkpoint_uploads_partial(paginated_downloader, fake_
 def test_paginated_export_parallel_produces_correct_output(paginated_downloader, fake_s3):
     """``page_workers > 1`` produces the same final CSV regardless of completion order.
 
-    Uses URL-based mock dispatch so the test is not dependent on call order across worker threads.
+    Uses URL-based mock dispatch so the test is not dependent on call order across
+    worker threads.
     """
     dl = paginated_downloader
 
@@ -811,3 +836,516 @@ def test_paginated_export_parallel_produces_correct_output(paginated_downloader,
     key = s3_io.object_key_annotation_csv("p", 1)
     df = pd.read_csv(io.BytesIO(fake_s3.objects[("b", key)]))
     assert set(df["Name"]) == {"a.jpg", "b.jpg", "c.jpg", "d.jpg"}
+
+
+# ---------------------------------------------------------------------------
+# get_images parallel browse tests
+# ---------------------------------------------------------------------------
+# CoralNet browse pages use simple ?page=N pagination. When browse_workers > 1
+# and total_images_hint is provided, get_images() should fan out pages 2..N
+# directly by URL rather than following the sequential next-link chain.
+# ---------------------------------------------------------------------------
+
+
+def _build_browse_pages(n_pages: int, thumbs_per_page: int = 20) -> dict[str, str]:
+    """Build a URL→HTML map for n_pages of a source-1 browse.
+
+    Each page has disjoint image IDs so the merged DataFrame has exactly n_pages *
+    thumbs_per_page rows (or fewer on the last page if partial).
+    """
+    base = "https://coralnet.ucsd.edu/source/1/browse/images"
+    pages: dict[str, str] = {}
+    for n in range(1, n_pages + 1):
+        next_href = f"?page={n + 1}" if n < n_pages else None
+        start_id = (n - 1) * thumbs_per_page + 1
+        url = base if n == 1 else f"{base}?page={n}"
+        pages[url] = _browse_page(
+            f"csrf{n}", n_thumbs=thumbs_per_page, next_href=next_href, start_id=start_id
+        )
+    return pages
+
+
+def _url_dispatch_get(pages: dict[str, str]) -> Callable:
+    def fake_get(url: str, timeout=None, **_) -> MagicMock:
+        if url not in pages:
+            raise AssertionError(f"unexpected GET {url!r}; known: {list(pages)}")
+        return _mock_response(text=pages[url])
+
+    return fake_get
+
+
+def test_get_images_parallel_fans_out_page_urls():
+    """With browse_workers=4 and a 3-page source, pages 2 and 3 are fetched via ?page=2
+    and ?page=3 directly — not by following next-link cursors.
+
+    Pins the contract that parallel mode constructs page URLs independently rather than
+    inheriting the sequential cursor-following path.
+    """
+    dl = CoralNetDownloader("u", "p")
+    dl.logged_in = True
+    pages = _build_browse_pages(n_pages=3, thumbs_per_page=20)
+    fetched_urls: list[str] = []
+
+    def tracking_get(url: str, timeout=None, **_) -> MagicMock:
+        fetched_urls.append(url)
+        return _mock_response(text=pages[url])
+
+    with patch.object(dl.session, "get", side_effect=tracking_get):
+        df, ok = dl.get_images(1, total_images_hint=60, browse_workers=4)
+
+    assert ok is True
+    assert df is not None and len(df) == 60
+    base = "https://coralnet.ucsd.edu/source/1/browse/images"
+    assert base in fetched_urls
+    assert f"{base}?page=2" in fetched_urls
+    assert f"{base}?page=3" in fetched_urls
+
+
+def test_get_images_parallel_result_matches_sequential():
+    """Parallel and sequential get_images() return the same DataFrame content.
+
+    Ensures the fan-out doesn't lose or duplicate images vs the cursor path.
+    """
+    dl_seq = CoralNetDownloader("u", "p")
+    dl_par = CoralNetDownloader("u", "p")
+    dl_seq.logged_in = True
+    dl_par.logged_in = True
+
+    pages = _build_browse_pages(n_pages=4, thumbs_per_page=20)
+    make_get = _url_dispatch_get(pages)
+
+    with patch.object(dl_seq.session, "get", side_effect=make_get):
+        df_seq, ok_seq = dl_seq.get_images(1)
+
+    with patch.object(dl_par.session, "get", side_effect=_url_dispatch_get(pages)):
+        df_par, ok_par = dl_par.get_images(1, total_images_hint=80, browse_workers=4)
+
+    assert ok_seq and ok_par
+    assert set(df_seq["Name"]) == set(df_par["Name"])
+    assert set(df_seq["Image Page"]) == set(df_par["Image Page"])
+
+
+def test_get_images_parallel_single_page_no_fanout():
+    """When total_images_hint fits on page 1, no ?page=2 URL is constructed."""
+    dl = CoralNetDownloader("u", "p")
+    dl.logged_in = True
+    # Single-page source — no next link
+    page1 = _browse_page("csrf1", n_thumbs=5, next_href=None, start_id=1)
+    fetched_urls: list[str] = []
+
+    def tracking_get(url: str, timeout=None, **_) -> MagicMock:
+        fetched_urls.append(url)
+        return _mock_response(text=page1)
+
+    with patch.object(dl.session, "get", side_effect=tracking_get):
+        df, ok = dl.get_images(1, total_images_hint=5, browse_workers=4)
+
+    assert ok is True
+    assert df is not None and len(df) == 5
+    assert len(fetched_urls) == 1
+    assert "page=2" not in fetched_urls[0]
+
+
+def test_get_images_parallel_preserves_page_order():
+    """Images from page 1 appear before page 2, page 2 before page 3 in the output.
+
+    Page order matters because the ETL joins on Name; stable ordering makes the output
+    deterministic and diffable across runs.
+    """
+    dl = CoralNetDownloader("u", "p")
+    dl.logged_in = True
+    pages = _build_browse_pages(n_pages=3, thumbs_per_page=3)
+
+    with patch.object(dl.session, "get", side_effect=_url_dispatch_get(pages)):
+        df, ok = dl.get_images(1, total_images_hint=9, browse_workers=3)
+
+    assert ok is True
+    assert df is not None
+    names = df["Name"].tolist()
+    # page 1: img1, img2, img3 | page 2: img4..6 | page 3: img7..9
+    page1_last_idx = names.index("img3.jpg")
+    page2_first_idx = names.index("img4.jpg")
+    page3_first_idx = names.index("img7.jpg")
+    assert page1_last_idx < page2_first_idx < page3_first_idx
+
+
+def test_get_images_parallel_annotation_status_preserved():
+    """annotation_status filter appears in all worker page URLs.
+
+    Regression guard: parallel fanout must not drop the ?annotation_status=
+    query param when constructing ?page=N URLs.
+    """
+    dl = CoralNetDownloader("u", "p")
+    dl.logged_in = True
+
+    base = "https://coralnet.ucsd.edu/source/1/browse/images"
+    pages = {
+        f"{base}/?annotation_status=confirmed": _browse_page(
+            "csrf1", n_thumbs=20, next_href="?annotation_status=confirmed&page=2", start_id=1
+        ),
+        f"{base}/?annotation_status=confirmed&page=2": _browse_page(
+            "csrf2", n_thumbs=10, start_id=21
+        ),
+    }
+    fetched_urls: list[str] = []
+
+    def tracking_get(url: str, timeout=None, **_) -> MagicMock:
+        fetched_urls.append(url)
+        if url not in pages:
+            raise AssertionError(f"unexpected GET {url!r}")
+        return _mock_response(text=pages[url])
+
+    with patch.object(dl.session, "get", side_effect=tracking_get):
+        df, ok = dl.get_images(
+            1, annotation_status="confirmed", total_images_hint=30, browse_workers=2
+        )
+
+    assert ok is True
+    assert df is not None and len(df) == 30
+    assert all("annotation_status=confirmed" in u for u in fetched_urls)
+
+
+def test_get_images_parallel_falls_back_without_hint():
+    """browse_workers > 1 without total_images_hint falls back to sequential cursor-
+    following.
+
+    No ?page=N URL is constructed; the next-link href drives navigation instead.
+    """
+    dl = CoralNetDownloader("u", "p")
+    dl.logged_in = True
+
+    call_urls: list[str] = []
+
+    def fake_get_images_on_page(url: str):
+        call_urls.append(url)
+        if len(call_urls) == 1:
+            return {"a.jpg": "/image/1/view/"}, "?page=2"
+        return {"b.jpg": "/image/2/view/"}, None
+
+    with patch.object(dl, "get_images_on_page", side_effect=fake_get_images_on_page):
+        df, ok = dl.get_images(1, browse_workers=8)  # no hint → sequential
+
+    assert ok is True
+    assert df is not None and len(df) == 2
+    # Page 2 was reached by following the next-link, not by constructing ?page=2
+    assert call_urls[1] == "https://coralnet.ucsd.edu/source/1/browse/images?page=2"
+
+
+# ---------------------------------------------------------------------------
+# Retry tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_images_retries_on_page1_timeout():
+    """A ReadTimeout on page 1 is retried; scrape succeeds after the retry."""
+    dl = CoralNetDownloader("u", "p")
+    dl.logged_in = True
+
+    call_count = [0]
+
+    def flaky_get_images_on_page(url: str):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise requests.ReadTimeout("simulated timeout")
+        return {"img1.jpg": "/image/1/view/", "img2.jpg": "/image/2/view/"}, None
+
+    with (
+        patch.object(dl, "get_images_on_page", side_effect=flaky_get_images_on_page),
+        patch("mermaidseg.datasets.coralnet.scraper.downloader.time.sleep"),
+    ):
+        df, ok = dl.get_images(1)
+
+    assert ok is True
+    assert call_count[0] == 2  # timed out once, then succeeded
+    assert df is not None and len(df) == 2
+
+
+def test_get_images_page1_gives_up_after_max_retries():
+    """After _PAGE_RETRIES failed attempts on page 1, get_images returns (None,
+    False)."""
+    dl = CoralNetDownloader("u", "p")
+    dl.logged_in = True
+
+    def always_timeout(url: str):
+        raise requests.ReadTimeout("always")
+
+    with (
+        patch.object(dl, "get_images_on_page", side_effect=always_timeout),
+        patch("mermaidseg.datasets.coralnet.scraper.downloader.time.sleep"),
+    ):
+        df, ok = dl.get_images(1)
+
+    assert ok is False
+    assert df is None
+
+
+def test_get_images_parallel_retries_on_inner_page_timeout():
+    """A ReadTimeout on a parallel page is retried; final result includes that page's
+    images."""
+    dl = CoralNetDownloader("u", "p")
+    dl.logged_in = True
+
+    pages = _build_browse_pages(n_pages=3, thumbs_per_page=2)
+    call_counts: dict[str, int] = {}
+
+    def flaky_dispatch(url: str, timeout=None, **_) -> MagicMock:
+        call_counts[url] = call_counts.get(url, 0) + 1
+        # Fail page 3 on the first attempt only
+        page3_url = "https://coralnet.ucsd.edu/source/1/browse/images?page=3"
+        if url == page3_url and call_counts[url] == 1:
+            raise requests.ReadTimeout("page 3 timeout")
+        if url not in pages:
+            raise AssertionError(f"unexpected GET {url!r}")
+        return _mock_response(text=pages[url])
+
+    with (
+        patch.object(dl.session, "get", side_effect=flaky_dispatch),
+        patch("mermaidseg.datasets.coralnet.scraper.downloader.time.sleep"),
+    ):
+        df, ok = dl.get_images(1, total_images_hint=6, browse_workers=3)
+
+    assert ok is True
+    assert df is not None and len(df) == 6  # all 3 pages present
+
+
+def _http_error(status: int) -> requests.HTTPError:
+    resp = requests.Response()
+    resp.status_code = status
+    return requests.HTTPError(response=resp)
+
+
+def test_is_transient_covers_timeouts_drops_and_5xx():
+    """Transient set spans connect/read timeouts, dropped connections, and 5xx."""
+    assert _is_transient(requests.ReadTimeout()) is True
+    assert _is_transient(requests.ConnectTimeout()) is True  # sibling of ReadTimeout
+    assert _is_transient(requests.ConnectionError()) is True
+    assert _is_transient(requests.exceptions.ChunkedEncodingError()) is True
+    assert _is_transient(_http_error(503)) is True
+    # 4xx won't fix itself on retry.
+    assert _is_transient(_http_error(404)) is False
+
+
+def test_get_images_retries_on_5xx_then_succeeds():
+    """A 503 on a browse page is retried, not fatal."""
+    dl = CoralNetDownloader("u", "p")
+    dl.logged_in = True
+    call_count = [0]
+
+    def flaky(url: str):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            raise _http_error(503)
+        return {"img1.jpg": "/image/1/view/"}, None
+
+    with (
+        patch.object(dl, "get_images_on_page", side_effect=flaky),
+        patch("mermaidseg.datasets.coralnet.scraper.downloader.time.sleep"),
+    ):
+        df, ok = dl.get_images(1)
+
+    assert ok is True
+    assert call_count[0] == 2
+    assert df is not None and len(df) == 1
+
+
+def test_get_images_4xx_is_not_retried():
+    """A 404 propagates immediately (no retry) and fails the source."""
+    dl = CoralNetDownloader("u", "p")
+    dl.logged_in = True
+    call_count = [0]
+
+    def always_404(url: str):
+        call_count[0] += 1
+        raise _http_error(404)
+
+    with (
+        patch.object(dl, "get_images_on_page", side_effect=always_404),
+        patch("mermaidseg.datasets.coralnet.scraper.downloader.time.sleep"),
+    ):
+        df, ok = dl.get_images(1)
+
+    assert ok is False
+    assert df is None
+    assert call_count[0] == 1  # not retried
+
+
+def test_get_images_parallel_skips_dead_page_after_retries():
+    """A page that exhausts retries is dropped; other pages still return (partial).
+
+    The original bug was one timeout killing a whole 79k-image source; the parallel path
+    must degrade per-page instead of aborting.
+    """
+    dl = CoralNetDownloader("u", "p")
+    dl.logged_in = True
+    pages = _build_browse_pages(n_pages=3, thumbs_per_page=2)
+    page3_url = "https://coralnet.ucsd.edu/source/1/browse/images?page=3"
+
+    def dispatch(url: str, timeout=None, **_) -> MagicMock:
+        if url == page3_url:
+            raise requests.ReadTimeout("page 3 always times out")
+        if url not in pages:
+            raise AssertionError(f"unexpected GET {url!r}")
+        return _mock_response(text=pages[url])
+
+    with (
+        patch.object(dl.session, "get", side_effect=dispatch),
+        patch("mermaidseg.datasets.coralnet.scraper.downloader.time.sleep"),
+    ):
+        df, ok = dl.get_images(1, total_images_hint=6, browse_workers=3)
+
+    assert ok is True  # did not abort
+    assert df is not None and len(df) == 4  # pages 1 + 2 only; page 3 dropped
+
+
+def test_get_images_sequential_retries_on_inner_page_timeout():
+    """A ReadTimeout on page 2 (sequential mode) is retried transparently."""
+    dl = CoralNetDownloader("u", "p")
+    dl.logged_in = True
+
+    call_count = [0]
+
+    def flaky_get_images_on_page(url: str):
+        call_count[0] += 1
+        if call_count[0] == 2:
+            raise requests.ReadTimeout("page 2 timeout")
+        if call_count[0] in (1, 3):
+            return {f"img{call_count[0]}.jpg": f"/image/{call_count[0]}/view/"}, (
+                "?page=2" if call_count[0] == 1 else None
+            )
+        return {f"img{call_count[0]}.jpg": f"/image/{call_count[0]}/view/"}, None
+
+    with (
+        patch.object(dl, "get_images_on_page", side_effect=flaky_get_images_on_page),
+        patch("mermaidseg.datasets.coralnet.scraper.downloader.time.sleep"),
+    ):
+        df, ok = dl.get_images(1)  # no hint → sequential
+
+    assert ok is True
+    assert df is not None and len(df) == 2  # page 1 + page 2 (after retry)
+
+
+# ---------------------------------------------------------------------------
+# Login retry + jittered backoff
+# ---------------------------------------------------------------------------
+
+
+def _login_get_html() -> str:
+    return '<input type="hidden" name="csrfmiddlewaretoken" value="logintok"/>'
+
+
+def test_login_retries_transient_timeout_then_succeeds():
+    """A ReadTimeout on the login GET is retried; login then succeeds.
+
+    The original bug: a single login timeout killed the whole job before any
+    source was touched, because _perform_login's GET was not retry-wrapped.
+    """
+    dl = CoralNetDownloader("u", "p")
+    get_calls = [0]
+
+    def flaky_get(url, timeout=None, **_):
+        get_calls[0] += 1
+        if get_calls[0] == 1:
+            raise requests.ReadTimeout("login page slow")
+        return _mock_response(text=_login_get_html())
+
+    post_resp = _mock_response(text="<html>Sign out</html>")
+
+    with (
+        patch.object(dl.session, "get", side_effect=flaky_get),
+        patch.object(dl.session, "post", return_value=post_resp),
+        patch("mermaidseg.datasets.coralnet.scraper.downloader.time.sleep"),
+    ):
+        ok = dl.login()
+
+    assert ok is True
+    assert dl.logged_in is True
+    assert get_calls[0] == 2  # timed out once, retried, then succeeded
+
+
+def test_login_gives_up_after_repeated_timeouts():
+    """If the login GET keeps timing out, login() returns False after retries (so the
+    shard exits cleanly instead of hammering CoralNet per-source)."""
+    dl = CoralNetDownloader("u", "p")
+    get_calls = [0]
+
+    def always_timeout(url, timeout=None, **_):
+        get_calls[0] += 1
+        raise requests.ReadTimeout("coralnet down")
+
+    with (
+        patch.object(dl.session, "get", side_effect=always_timeout),
+        patch("mermaidseg.datasets.coralnet.scraper.downloader.time.sleep"),
+    ):
+        ok = dl.login()
+
+    assert ok is False
+    assert dl.logged_in is False
+    assert get_calls[0] == 3  # exhausted the retry budget
+
+
+def test_login_does_not_retry_invalid_credentials():
+    """A genuine auth failure (not a transient error) fails fast — no retry."""
+    dl = CoralNetDownloader("u", "p")
+    post_calls = [0]
+    bad_post = _mock_response(text="<html>Please enter a correct username and password</html>")
+    bad_post.url = dl.LOGIN_URL  # stayed on the login page => failed auth
+
+    def fake_post(*_a, **_k):
+        post_calls[0] += 1
+        return bad_post
+
+    with (
+        patch.object(dl.session, "get", return_value=_mock_response(text=_login_get_html())),
+        patch.object(dl.session, "post", side_effect=fake_post),
+        patch("mermaidseg.datasets.coralnet.scraper.downloader.time.sleep"),
+    ):
+        ok = dl.login()
+
+    assert ok is False
+    assert post_calls[0] == 1  # not retried — invalid creds won't fix themselves
+
+
+def test_with_retry_backoff_is_jittered():
+    """Backoff is randomized within [0.5x, 1.5x] of the exponential base so that
+    concurrent shards desync instead of retrying in lockstep (thundering herd)."""
+    slept: list[float] = []
+
+    def always_timeout():
+        raise requests.ReadTimeout("x")
+
+    with (
+        patch.object(downloader_mod.time, "sleep", side_effect=lambda s: slept.append(s)),
+        patch.object(downloader_mod.random, "uniform", side_effect=lambda lo, _hi: lo) as uni,
+        pytest.raises(requests.ReadTimeout),
+    ):
+        downloader_mod._with_retry(always_timeout, source_id=1, page_num=1, kind="test")
+
+    # 3 attempts => 2 backoff sleeps; exponential bases are 30 and 60, jittered
+    # over [0.5*base, 1.5*base].
+    assert [c.args for c in uni.call_args_list] == [(0.5 * 30, 1.5 * 30), (0.5 * 60, 1.5 * 60)]
+    assert slept == [0.5 * 30, 0.5 * 60]  # stub returns the low bound
+
+
+def _status_response(status: int) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status
+    return r
+
+
+def test_is_coralnet_reachable_true_on_200():
+    dl = CoralNetDownloader("u", "p")
+    with patch.object(dl.session, "get", return_value=_status_response(200)):
+        assert dl.is_coralnet_reachable() is True
+
+
+def test_is_coralnet_reachable_false_on_5xx():
+    """A 5xx means CoralNet is up but degraded — treat as unreachable for pre-flight."""
+    dl = CoralNetDownloader("u", "p")
+    with patch.object(dl.session, "get", return_value=_status_response(503)):
+        assert dl.is_coralnet_reachable() is False
+
+
+def test_is_coralnet_reachable_false_on_timeout():
+    dl = CoralNetDownloader("u", "p")
+    with patch.object(dl.session, "get", side_effect=requests.ReadTimeout("down")):
+        assert dl.is_coralnet_reachable() is False

--- a/tests/sagemaker_launcher/test_processing_entrypoint.py
+++ b/tests/sagemaker_launcher/test_processing_entrypoint.py
@@ -1,0 +1,62 @@
+"""Tests for the in-container processing entrypoint
+(scripts/sagemaker_processing_entrypoint.py).
+
+The entrypoint dispatches on --task and forwards the remaining args to the matching
+routine. A task that isn't wired into the argparse choices fails the whole job at
+container start (the "invalid choice: 'coralnet-resize'" CloudWatch error), so these
+tests lock the dispatch table.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import sagemaker_processing_entrypoint as entrypoint  # type: ignore  # noqa: E402
+
+
+def test_dispatches_coralnet_resize_and_forwards_args(monkeypatch):
+    """--task=coralnet-resize routes to resize.main with the remaining args and exits its code."""
+    received: dict[str, object] = {}
+
+    def fake_resize_main(extra: list[str]) -> int:
+        received["extra"] = extra
+        return 0
+
+    monkeypatch.setattr("mermaidseg.datasets.coralnet.preprocessing.resize.main", fake_resize_main)
+    monkeypatch.setattr(sys, "argv", ["prog", "--task=coralnet-resize", "--run=foo", "--bucket=b"])
+
+    with pytest.raises(SystemExit) as exc:
+        entrypoint.main()
+
+    assert exc.value.code == 0
+    assert received["extra"] == ["--run=foo", "--bucket=b"]
+
+
+def test_resize_nonzero_exit_propagates(monkeypatch):
+    """A non-zero return from resize.main becomes the entrypoint's exit code (failed-job
+    signal)."""
+    monkeypatch.setattr("mermaidseg.datasets.coralnet.preprocessing.resize.main", lambda extra: 1)
+    monkeypatch.setattr(sys, "argv", ["prog", "--task=coralnet-resize", "--run=foo"])
+
+    with pytest.raises(SystemExit) as exc:
+        entrypoint.main()
+
+    assert exc.value.code == 1
+
+
+def test_unknown_task_is_rejected(monkeypatch):
+    """An unregistered task is rejected by argparse before any routine runs."""
+    monkeypatch.setattr(sys, "argv", ["prog", "--task=does-not-exist"])
+
+    with pytest.raises(SystemExit) as exc:
+        entrypoint.main()
+
+    # argparse exits with code 2 on invalid choice.
+    assert exc.value.code == 2

--- a/uv.lock
+++ b/uv.lock
@@ -36,6 +36,24 @@ wheels = [
 ]
 
 [[package]]
+name = "aiobotocore"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aioitertools" },
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "multidict" },
+    { name = "python-dateutil" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/75/42cce839c2ec263ff74b10b650fe36b066fbb124cbee6f247eac0983e1ab/aiobotocore-3.7.0.tar.gz", hash = "sha256:c64d871ed5491a6571948dd48eabd185b46c6c23b64e3afd0c059fc7593ada30", size = 127054, upload-time = "2026-05-09T10:02:52.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/5f/85535dfb3cfd6442d66d1df1694062c5d6df02f895329e7e120b2a3d2b8b/aiobotocore-3.7.0-py3-none-any.whl", hash = "sha256:680bde7c64679a821a9312641b759d9497f790ba8b2e88c6959e6273ee765b8e", size = 89539, upload-time = "2026-05-09T10:02:50.389Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -144,6 +162,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b7/15fb7a9d52e112a25b621c67b69c167805cb1f2ab8f1708a5c490d1b52fe/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9", size = 1772072, upload-time = "2026-03-31T22:00:07.494Z" },
     { url = "https://files.pythonhosted.org/packages/7e/df/57ba7f0c4a553fc2bd8b6321df236870ec6fd64a2a473a8a13d4f733214e/aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8", size = 471819, upload-time = "2026-03-31T22:00:10.277Z" },
     { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload-time = "2026-03-31T22:00:12.791Z" },
+]
+
+[[package]]
+name = "aioitertools"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/3c/53c4a17a05fb9ea2313ee1777ff53f5e001aefd5cc85aa2f4c2d982e1e38/aioitertools-0.13.0.tar.gz", hash = "sha256:620bd241acc0bbb9ec819f1ab215866871b4bbd1f73836a55f799200ee86950c", size = 19322, upload-time = "2025-11-06T22:17:07.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl", hash = "sha256:0be0292b856f08dfac90e31f4739432f4cb6d7520ab9eb73e143f4f2fa5259be", size = 24182, upload-time = "2025-11-06T22:17:06.502Z" },
 ]
 
 [[package]]
@@ -478,30 +505,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.3"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/50/ea184e159c4ac64fef816a72094fb8656eb071361a39ed22c0e3b15a35b4/boto3-1.43.3.tar.gz", hash = "sha256:7c7777862ffc898f05efa566032bbabfe226dbb810e35ec11125817f128bc5c5", size = 113111, upload-time = "2026-05-04T19:34:09.731Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/65/47670987f2f9e181397872c7ee6415b7b95156d711b7eab6c55f66e575bc/boto3-1.43.0.tar.gz", hash = "sha256:80d44a943ef90aba7958ab31d30c155c198acc8a9581b5846b3878b2c8951086", size = 113143, upload-time = "2026-04-29T22:07:49.084Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/ad/8a6946a329f0127322108e537dc1c0d9f8eea4f1d1231702c073d2e85f46/boto3-1.43.3-py3-none-any.whl", hash = "sha256:fb9fe51849ef2a78198d582756fc06f14f7de27f73e0fa90275d6aa4171eb4d0", size = 140501, upload-time = "2026-05-04T19:34:07.991Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a0/3e6a0b1c1ea6bec76f71473727ef27abf3cd40e9709b3ebcbfbcfaae6f79/boto3-1.43.0-py3-none-any.whl", hash = "sha256:8ebe03754a4b73a5cb6ec2f14cca03ac33bd4760d0adea53da4724845130258b", size = 140497, upload-time = "2026-04-29T22:07:46.216Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.3"
+version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/ac/cd55f886e17b6b952dbc95b792d3645a73d58586a1400ababe54406073bd/botocore-1.43.3.tar.gz", hash = "sha256:eac6da0fffccf87888ebf4d89f0b2378218a707efa748cd955b838995e944695", size = 15308705, upload-time = "2026-05-04T19:33:56.28Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/79/2f4be1896db3db7ccf44504253a175d56b6bd6b669619edc5147d1aa21ea/botocore-1.43.0.tar.gz", hash = "sha256:e933b31a2d644253e1d029d7d39e99ba41b87e29300534f189744cc438cdf928", size = 15286817, upload-time = "2026-04-29T22:07:31.723Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/99/1d9e296edf244f47e0508032f20999f8fd40704dd3c5b601fed099424eb6/botocore-1.43.3-py3-none-any.whl", hash = "sha256:ec0769eb0f7c5034856bb406a92698dbc02a3d4be0f78a384747106b161d8ea3", size = 14989027, upload-time = "2026-05-04T19:33:50.81Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4b/afc1fef8a43bafb139f57f73bbd70df82807af5934321e8112ae50668827/botocore-1.43.0-py3-none-any.whl", hash = "sha256:cc5b15eaec3c6eac05d8012cb5ef17ebe891beb88a16ca13c374bfaece1241e6", size = 14970102, upload-time = "2026-04-29T22:07:27Z" },
 ]
 
 [[package]]
@@ -2839,7 +2866,7 @@ requires-dist = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "requests-auth-aws-sigv4", specifier = ">=0.7" },
-    { name = "s3fs" },
+    { name = "s3fs", specifier = ">=2024.2.0" },
     { name = "safetensors", specifier = ">=0.4.0" },
     { name = "sagemaker", marker = "extra == 'sagemaker'", specifier = ">=2.0,<3.0" },
     { name = "sagemaker-mlflow", specifier = ">=0.2.0" },
@@ -4980,15 +5007,16 @@ wheels = [
 
 [[package]]
 name = "s3fs"
-version = "0.4.2"
+version = "2026.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "botocore" },
+    { name = "aiobotocore" },
+    { name = "aiohttp" },
     { name = "fsspec" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/504cb277632c4d325beabbd03bb43778f0decb9be22d9e0e6c62f44540c7/s3fs-0.4.2.tar.gz", hash = "sha256:2ca5de8dc18ad7ad350c0bd01aef0406aa5d0fff78a561f0f710f9d9858abdd0", size = 57527, upload-time = "2020-03-31T15:24:26.388Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/be/392c8c5e0da9bfa139e41084690dd49a5e3e931099f78f52d3f6070105c6/s3fs-2026.2.0.tar.gz", hash = "sha256:91cb2a9f76e35643b76eeac3f47a6165172bb3def671f76b9111c8dd5779a2ac", size = 84152, upload-time = "2026-02-05T21:57:57.968Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/e4/b8fc59248399d2482b39340ec9be4bb2493846ac23641b43115a7e5cd675/s3fs-0.4.2-py3-none-any.whl", hash = "sha256:91c1dfb45e5217bd441a7a560946fe865ced6225ff7eb0fb459fe6e601a95ed3", size = 19791, upload-time = "2020-03-31T15:24:24.952Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e1/64c264db50b68de8a438b60ceeb921b2f22da3ebb7ad6255150225d0beac/s3fs-2026.2.0-py3-none-any.whl", hash = "sha256:65198835b86b1d5771112b0085d1da52a6ede36508b1aaa6cae2aedc765dfe10", size = 31328, upload-time = "2026-02-05T21:57:56.532Z" },
 ]
 
 [[package]]
@@ -6236,6 +6264,81 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/15/0c2d55168707465abfc41f33c0b23d792a5fa9b65c26983606940900a120/wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73", size = 80782, upload-time = "2026-06-20T23:47:44.367Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b5/5c0b093eb48f8a062ef6267d3cb36e9bb1b88440181f6545a383c60efdf8/wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e", size = 81678, upload-time = "2026-06-20T23:47:45.857Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f3/de70937472dd3e8a4e6811192f9c6075efdffd4a2cd9b4596bf160f89668/wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d", size = 159671, upload-time = "2026-06-20T23:47:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/40aed2330e7f02ecf74386ffcfef9ccb7108c6a430f15b6a252b663b1bed/wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328", size = 160785, upload-time = "2026-06-20T23:47:48.759Z" },
+    { url = "https://files.pythonhosted.org/packages/45/04/aa5309beed5344b00220ae6b3b24055852192656194c27947bee1736306a/wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5", size = 153699, upload-time = "2026-06-20T23:47:50.177Z" },
+    { url = "https://files.pythonhosted.org/packages/01/df/2def7e99d1fe87eea413f95f671924cdddcb08823b1ffd212748dfa6d062/wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0", size = 159695, upload-time = "2026-06-20T23:47:51.602Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f6/a906d01a2ce12157bad2404957b3e2140da354b8a70b2fa48bbf282871c0/wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae", size = 152813, upload-time = "2026-06-20T23:47:53.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/49/bc0086292d239575b4c08f4cf8a4079fa58abbad58ec23abf84833a283ed/wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099", size = 158809, upload-time = "2026-06-20T23:47:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/55/83/8fbd034de1f3e907edaa18786d5dd8f6932874edee0826c7cecb5cab03a1/wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c", size = 77414, upload-time = "2026-06-20T23:47:55.882Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9c/23695baa331c6de4e874c3d78b8e0bed92e1d2a274e665b29858f6841672/wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971", size = 80368, upload-time = "2026-06-20T23:47:57.237Z" },
+    { url = "https://files.pythonhosted.org/packages/08/49/40cefc342bf89b234a4490d741290fce781774b831aefb39c25471da96c9/wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30", size = 79489, upload-time = "2026-06-20T23:47:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]
 
 [[package]]

--- a/wiki/CoralNet-ETL.md
+++ b/wiki/CoralNet-ETL.md
@@ -94,6 +94,41 @@ latency. Checkpoint part files are written every `--checkpoint-every` rows
 (default `50_000`) so an interrupted run resumes by reading the existing
 checkpoint parts.
 
+## Running on SageMaker
+
+Use SageMaker for full rebuilds and overnight runs — IAM credentials rotate every
+~60 minutes, which would require manual intervention for long local runs.
+
+### Full ETL rebuild (`coralnet-etl`)
+
+The `coralnet-etl` task runs `audit → build-annotations → build-images` in one
+ProcessingJob and uploads versioned parquets to the canonical S3 prefix:
+
+```bash
+export AWS_PROFILE=wcs-launcher
+uv run --extra sagemaker python scripts/launch_processing.py \
+    --run-config sagemaker/runs/<run>.yaml \
+    --config-dir sagemaker/configs/coralnet-refresh/
+```
+
+> The operational run specs (`issue_130_coralnet_*.yaml`) and refresh source CSVs live on the
+> local `sagemaker-jobs` branch, not in this repo — check that branch out to launch these jobs.
+
+### Image-list refresh (`coralnet-refresh`)
+
+After an audit, any source where `image_list_covers_annotations=False` has a
+truncated `image_list.csv` (fix for [#130](https://github.com/data-mermaid/mermaid-segmentation/issues/130)).
+The `coralnet-refresh` task re-downloads those CSVs by scraping the CoralNet browse
+listing. It has been run against the full set of affected sources; see
+[SageMaker Jobs — Run a processing job](SageMaker-Jobs#run-a-processing-job)
+for the full runbook including concurrency guidance, the pre-flight reachability
+probe, and CloudWatch monitoring.
+
+**Quick concurrency rule:** use 2–3 `workers`, not more. CoralNet's browse pages
+are server-side rendered; many simultaneous requests cause thundering-herd timeouts.
+The task ships with startup jitter and login retries, but low concurrency is the
+primary lever.
+
 ## Determinism
 
 All three writers route through `write_parquet_deterministic` in
@@ -145,7 +180,9 @@ go through boto3 with adaptive retries.
 - Corrupt JPEG → `header_status="corrupt"`, dimensions NULL — not a hard
   failure.
 - SageMaker IAM credentials rotate every ~60 min:
-  - Boto3 adaptive retries cover short-window expirations on non-CSV ops.
+  - Each audit worker thread refreshes its own boto3 session on a wall-clock
+    timer (`_CRED_REFRESH_INTERVAL_SECONDS = 3000`, i.e. every 50 min) so the
+    rotation never races against the 60-min SageMaker boundary.
   - DuckDB httpfs does NOT auto-refresh credentials. The audit loop re-runs
     `CREATE OR REPLACE SECRET s3 (TYPE S3, PROVIDER CREDENTIAL_CHAIN)` every
     `--checkpoint-every` sources on each worker's thread-local ibis connection.


### PR DESCRIPTION
Lands the **PR 2 + PR 3** content of the #155 split onto `main`. Those merged via #160 and #161 into their stacked *base branches* (not `main`), so this brings them home. Rebased onto current `main` — diff is exactly PR2+PR3 (PR1/#159 already merged).

**PR 2 — CoralNet ETL audit + scraper (#130, #153):** scraper download/refresh/classify, ETL audit/schemas; entrypoint `coralnet-etl`+`coralnet-refresh`; `s3fs>=2024.2.0` pin.
**PR 3 — resize + training manifest + dataset (#146, #154):** resize fixes, `build_training_manifest` + builder script, `coralnet_dataset` per-image `image_s3_key` consumption; entrypoint `coralnet-resize`.

111 tests pass locally. Processing-job run specs/CSVs intentionally not shipped (local `sagemaker-jobs` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)