### PR TITLE
refactor(eval): own the metric lifecycle in Evaluator (Seam 1)

### DIFF
--- a/mermaidseg/model/eval.py
+++ b/mermaidseg/model/eval.py
@@ -151,6 +151,42 @@ class Evaluator:
 
         return metric_results
 
+    def accumulate(self, preds: torch.Tensor, targets: torch.Tensor) -> None:
+        """Update the classification metric bank with one batch.
+
+        ``preds`` may be raw logits (``(B, C, H, W)`` — argmaxed to class ids) or
+        already class-id maps (``(B, H, W)`` — used as- is). Callers pass the mode-
+        appropriate ``(preds, targets)`` pair (e.g. ``(logits, target_labels)`` for
+        standard/CBM, or ``(concept_class_preds, target_concept_preds)`` for concept
+        mode). No-op when the classification bank is empty. This is the single owner of
+        the metric-update lifecycle, shared by the train/val loops and
+        :meth:`evaluate_model`.
+        """
+        if not self.metric_dict:
+            return
+        if preds.ndim > 3:
+            preds = preds.argmax(dim=1)
+        for metric in self.metric_dict.values():
+            metric.update(preds.detach(), targets)
+
+    def compute_and_reset(
+        self, include_concepts: bool = False
+    ) -> dict[str, float | NDArray[np.float64]]:
+        """Compute every accumulated metric, reset the bank(s), and return the results.
+
+        Scalars are returned as Python floats; per-class metrics stay as arrays. When
+        ``include_concepts`` is True, concept metrics are computed + reset and merged
+        in.
+        """
+        metric_results: dict[str, float | NDArray[np.float64]] = {}
+        for metric_name in self.metric_dict:
+            value = self.metric_dict[metric_name].compute().cpu().numpy()
+            metric_results[metric_name] = value.item() if value.ndim == 0 else value
+            self.metric_dict[metric_name].reset()
+        if include_concepts:
+            metric_results.update(self._compute_concept_metric_results())
+        return metric_results
+
     @torch.no_grad()
     def evaluate_model(
         self,
@@ -167,32 +203,19 @@ class Evaluator:
             Dict of metric_name -> scalar/array result.
         """
         meta_model.model.eval()
-        metric_results: dict[str, float | NDArray[np.float64]] = {}
+        is_concept = meta_model.training_mode in ("concept-bottleneck", "concept")
         for data in tqdm.tqdm(dataloader):
             inputs, source_labels = data
             source_labels = source_labels.long().to(self.device)
             target_labels = meta_model._to_target_labels(source_labels)
             outputs, concept_outputs = meta_model.batch_predict(inputs)
 
-            if self.metric_dict:
-                if outputs.ndim > 3:
-                    outputs = outputs.argmax(dim=1)
-                for metric in self.metric_dict.values():
-                    metric.update(outputs, target_labels)
-
-            if meta_model.training_mode in ("concept-bottleneck", "concept"):
+            self.accumulate(outputs, target_labels)
+            if is_concept:
                 concept_labels = meta_model._to_concept_labels(source_labels)
                 self.evaluate_concepts(concept_outputs, concept_labels)
 
-        for metric_name in self.metric_dict:
-            metric_results[metric_name] = self.metric_dict[metric_name].compute().cpu().numpy()
-            if metric_results[metric_name].ndim == 0:
-                metric_results[metric_name] = metric_results[metric_name].item()
-            self.metric_dict[metric_name].reset()
-
-        if meta_model.training_mode in ("concept-bottleneck", "concept"):
-            metric_results.update(self._compute_concept_metric_results())
-
+        metric_results = self.compute_and_reset(include_concepts=is_concept)
         self.epoch += 1
         return metric_results
 

--- a/mermaidseg/model/meta.py
+++ b/mermaidseg/model/meta.py
@@ -533,31 +533,21 @@ class MetaModel:
                         self.concept_matrix,
                         self.conceptid2labelid,
                     ).to(self.device)
-                    for metric in evaluator.metric_dict.values():
-                        metric.update(outputs, target_concept_preds)
+                    evaluator.accumulate(outputs, target_concept_preds)
                 else:
-                    if outputs.ndim > 3:
-                        outputs = outputs.argmax(dim=1)
-                    for metric in evaluator.metric_dict.values():
-                        metric.update(outputs.detach(), target_labels)
-
-            if evaluator is not None and self.training_mode in ("concept-bottleneck", "concept"):
-                evaluator.evaluate_concepts(concept_outputs.detach(), target_concepts)
+                    evaluator.accumulate(outputs, target_labels)
+                if self.training_mode in ("concept-bottleneck", "concept"):
+                    evaluator.evaluate_concepts(concept_outputs.detach(), target_concepts)
             if use_cuda:
                 torch.cuda.synchronize()
             batch_end = time.perf_counter()
 
         if evaluator is not None:
-            for metric_name in evaluator.metric_dict:
-                metric_results[metric_name] = (
-                    evaluator.metric_dict[metric_name].compute().cpu().numpy()
+            metric_results.update(
+                evaluator.compute_and_reset(
+                    include_concepts=self.training_mode in ("concept-bottleneck", "concept")
                 )
-                if metric_results[metric_name].ndim == 0:
-                    metric_results[metric_name] = metric_results[metric_name].item()
-                evaluator.metric_dict[metric_name].reset()
-
-            if self.training_mode in ("concept-bottleneck", "concept"):
-                metric_results.update(evaluator.compute_concept_metric_results())
+            )
 
         last_loss = running_loss / iterations_per_train_epoch
         avg_loss_components = {
@@ -633,28 +623,18 @@ class MetaModel:
                         self.concept_matrix,
                         self.conceptid2labelid,
                     ).to(self.device)
-                    for metric in evaluator.metric_dict.values():
-                        metric.update(outputs, target_concept_preds)
+                    evaluator.accumulate(outputs, target_concept_preds)
                 else:
-                    if outputs.ndim > 3:
-                        outputs = outputs.argmax(dim=1)
-                    for metric in evaluator.metric_dict.values():
-                        metric.update(outputs.detach(), target_labels)
-
-            if evaluator is not None and self.training_mode in ("concept-bottleneck", "concept"):
-                evaluator.evaluate_concepts(concept_outputs.detach(), target_concepts)
+                    evaluator.accumulate(outputs, target_labels)
+                if self.training_mode in ("concept-bottleneck", "concept"):
+                    evaluator.evaluate_concepts(concept_outputs.detach(), target_concepts)
 
         if evaluator is not None:
-            for metric_name in evaluator.metric_dict:
-                metric_results[metric_name] = (
-                    evaluator.metric_dict[metric_name].compute().cpu().numpy()
+            metric_results.update(
+                evaluator.compute_and_reset(
+                    include_concepts=self.training_mode in ("concept-bottleneck", "concept")
                 )
-                if metric_results[metric_name].ndim == 0:
-                    metric_results[metric_name] = metric_results[metric_name].item()
-                evaluator.metric_dict[metric_name].reset()
-
-            if self.training_mode in ("concept-bottleneck", "concept"):
-                metric_results.update(evaluator.compute_concept_metric_results())
+            )
 
         last_loss = running_loss / iterations_per_val_epoch
         avg_loss_components = {

--- a/tests/model/test_eval_lifecycle.py
+++ b/tests/model/test_eval_lifecycle.py
@@ -1,0 +1,63 @@
+"""Tests for the Evaluator metric lifecycle (accumulate / compute_and_reset).
+
+Seam 1: the metric update/compute/reset lifecycle now lives on Evaluator (was duplicated
+inline in MetaModel.train_epoch/validation_epoch and Evaluator.evaluate_model). These
+lock the extracted behavior: logits-vs- class-id handling, scalar results, and that
+compute_and_reset actually resets so metrics don't bleed across epochs.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from mermaidseg.model.eval import Evaluator
+
+NUM_CLASSES = 3  # ids: 0 = ignore, 1..2 = classes
+
+
+def _logits_predicting(class_id: int, *, bs=1, size=4) -> torch.Tensor:
+    logits = torch.zeros(bs, NUM_CLASSES, size, size)
+    logits[:, class_id] = 10.0  # argmax -> class_id everywhere
+    return logits
+
+
+def _targets(class_id: int, *, bs=1, size=4) -> torch.Tensor:
+    return torch.full((bs, size, size), class_id, dtype=torch.long)
+
+
+def test_accumulate_then_compute_and_reset_returns_scalar_metrics():
+    ev = Evaluator(num_classes=NUM_CLASSES, device="cpu")
+    ev.accumulate(_logits_predicting(1), _targets(1))  # perfect predictions of class 1
+    results = ev.compute_and_reset()
+    assert set(results) >= {"accuracy", "miou"}
+    assert isinstance(results["accuracy"], float) and results["accuracy"] == 1.0
+    assert isinstance(results["miou"], float) and 0.0 <= results["miou"] <= 1.0
+
+
+def test_compute_and_reset_actually_resets_between_epochs():
+    ev = Evaluator(num_classes=NUM_CLASSES, device="cpu")
+    ev.accumulate(_logits_predicting(1), _targets(1))
+    assert ev.compute_and_reset()["accuracy"] == 1.0
+    # Fresh epoch: all-wrong predictions. If reset didn't happen, the prior perfect
+    # batch would still count and accuracy would be > 0.
+    ev.accumulate(_logits_predicting(2), _targets(1))
+    assert ev.compute_and_reset()["accuracy"] == 0.0
+
+
+def test_accumulate_accepts_class_id_maps_equivalently_to_logits():
+    ev_logits = Evaluator(num_classes=NUM_CLASSES, device="cpu")
+    ev_logits.accumulate(_logits_predicting(1), _targets(1))  # (B, C, H, W)
+
+    ev_ids = Evaluator(num_classes=NUM_CLASSES, device="cpu")
+    ev_ids.accumulate(_targets(1), _targets(1))  # (B, H, W) class-id map, no argmax
+
+    assert (
+        ev_logits.compute_and_reset()["accuracy"] == ev_ids.compute_and_reset()["accuracy"] == 1.0
+    )
+
+
+def test_empty_bank_is_a_noop():
+    ev = Evaluator(num_classes=NUM_CLASSES, device="cpu", include_classification=False)
+    assert ev.metric_dict == {}
+    ev.accumulate(_logits_predicting(1), _targets(1))  # no-op, must not raise
+    assert ev.compute_and_reset() == {}

--- a/tests/model/test_meta_characterization.py
+++ b/tests/model/test_meta_characterization.py
@@ -1,0 +1,109 @@
+"""Characterization tests for MetaModel's standard-mode train/val loops.
+
+Locks the current observable behavior of ``MetaModel.train_epoch`` /
+``validation_epoch`` / ``batch_predict_loss`` before the planned Trainer/ModelWrapper
+decomposition, so that refactor can be shown behavior-preserving. Runs fully offline on
+CPU with a tiny stub model (no HF download, no S3, no CUDA).
+"""
+
+from __future__ import annotations
+
+import types
+
+import torch
+from torch import nn
+
+import mermaidseg.model.models as models_mod
+from mermaidseg.io import ConfigDict
+from mermaidseg.model.eval import Evaluator
+from mermaidseg.model.meta import MetaModel
+
+NUM_CLASSES = 3
+
+
+class _TinyLogitsModel(nn.Module):
+    """Standard-mode output contract: forward(x) -> obj with ``.logits`` (B, C, H,
+    W)."""
+
+    def __init__(self, num_classes: int = NUM_CLASSES, in_ch: int = 3):
+        super().__init__()
+        self.head = nn.Conv2d(in_ch, num_classes, kernel_size=1)
+
+    def forward(self, x: torch.Tensor):
+        return types.SimpleNamespace(logits=self.head(x))
+
+
+def _make_meta(monkeypatch, *, iters_train=2, iters_val=2) -> MetaModel:
+    monkeypatch.setattr(models_mod, "TinyLogitsModel", _TinyLogitsModel, raising=False)
+    training_kwargs = ConfigDict(
+        {
+            "training_mode": "standard",
+            "iterations_per_train_epoch": iters_train,
+            "iterations_per_val_epoch": iters_val,
+            "loss": {"type": "CrossEntropyLoss", "ignore_index": 0},
+            "optimizer": {"type": "AdamW", "lr": 1e-2},
+        }
+    )
+    return MetaModel(
+        run_name="char-test",
+        num_classes=NUM_CLASSES,
+        model_kwargs=ConfigDict({"name": "TinyLogitsModel"}),
+        device="cpu",
+        training_kwargs=training_kwargs,
+    )
+
+
+def _loader(*, n_batches=2, bs=2, size=8, empty_at=None):
+    batches = []
+    for i in range(n_batches):
+        if empty_at is not None and i == empty_at:
+            batches.append((torch.tensor([]), torch.tensor([])))
+            continue
+        img = torch.randn(bs, 3, size, size)
+        lbl = torch.randint(0, NUM_CLASSES, (bs, size, size))
+        batches.append((img, lbl))
+    return batches
+
+
+def test_train_epoch_returns_loss_metrics_timing_and_steps_optimizer(monkeypatch):
+    torch.manual_seed(0)
+    meta = _make_meta(monkeypatch, iters_train=2)
+    evaluator = Evaluator(num_classes=NUM_CLASSES, device="cpu")
+    before = meta.model.head.weight.detach().clone()
+
+    loss, metrics, timing = meta.train_epoch(_loader(n_batches=2, bs=2), evaluator)
+
+    assert isinstance(loss, float) and torch.isfinite(torch.tensor(loss)) and loss > 0
+    # metric bank produces scalar accuracy + miou, plus averaged loss components.
+    assert "accuracy" in metrics and "miou" in metrics
+    assert any(k.startswith("loss/") for k in metrics)
+    # timing reports successfully-processed samples = iterations * batch_size.
+    assert timing["num_samples"] == 2 * 2
+    # optimizer actually stepped (weights moved).
+    assert not torch.allclose(before, meta.model.head.weight)
+
+
+def test_validation_epoch_computes_metrics_without_updating_weights(monkeypatch):
+    torch.manual_seed(0)
+    meta = _make_meta(monkeypatch, iters_val=2)
+    evaluator = Evaluator(num_classes=NUM_CLASSES, device="cpu")
+    before = meta.model.head.weight.detach().clone()
+
+    loss, metrics = meta.validation_epoch(_loader(n_batches=2, bs=2), evaluator)
+
+    assert isinstance(loss, float) and loss > 0
+    assert "accuracy" in metrics and "miou" in metrics
+    # validation must not mutate weights (no optimizer step, no_grad).
+    assert torch.allclose(before, meta.model.head.weight)
+
+
+def test_train_epoch_skips_empty_batches(monkeypatch):
+    """An empty (all-failed-load) batch is skipped, not counted in num_samples."""
+    torch.manual_seed(0)
+    meta = _make_meta(monkeypatch, iters_train=2)
+    evaluator = Evaluator(num_classes=NUM_CLASSES, device="cpu")
+
+    # 2 iterations over [empty, full] -> only the full batch (bs=2) contributes.
+    _, _, timing = meta.train_epoch(_loader(n_batches=2, bs=2, empty_at=0), evaluator)
+
+    assert timing["num_samples"] == 2


### PR DESCRIPTION
Seam 1 of the training-path cleanup (scoped down from the full MetaModel/Logger decomposition).

## Problem
The classification metric `update`/`compute`/`reset` lifecycle was duplicated inline in three places — `MetaModel.train_epoch`, `MetaModel.validation_epoch`, and `Evaluator.evaluate_model` — i.e. **three drivers of one metric bank**. That divergence is the structural shape behind the silent `val = 0.0` bug (train and val accumulating differently, no single owner).

## Change
- Add `Evaluator.accumulate(preds, targets)` — the single owner of the update loop (argmaxes logits when `ndim > 3`, leaves class-id maps as-is; no-op on an empty bank).
- Add `Evaluator.compute_and_reset(include_concepts=False)` — compute + reset the bank, optionally merging concept results.
- Route all three call sites through them, **preserving each caller's mode-specific inputs** (standard/CBM feed `target_labels`; concept mode feeds `target_concept_preds`). No behavior change.

## Safety
- Ships with a **characterization test** (`test_meta_characterization.py`) that locks `MetaModel`'s standard-mode train/val loop outputs; it stays green across the refactor → behavior-preserving.
- +4 focused lifecycle tests (`test_eval_lifecycle.py`): logits-vs-class-id handling, reset-between-epochs, empty-bank no-op.
- Full suite: 352 passed.

The full `MetaModel`→`Trainer`/`ModelWrapper` and 4-way `Logger` splits remain parked (see the cleanup plan); this PR is one targeted seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)