### PR TITLE
refactor(logger): narrow blanket except-swallow in MLflow logging (Seam 2)

### DIFF
--- a/mermaidseg/logger.py
+++ b/mermaidseg/logger.py
@@ -25,6 +25,8 @@ import warnings
 from datetime import datetime, timedelta
 from typing import Any
 
+import boto3.exceptions
+import botocore.exceptions
 import mlflow
 import numpy as np
 import torch
@@ -58,6 +60,18 @@ _MLFLOW_LOG_ERRORS = (mlflow.exceptions.MlflowException, OSError)
 # unreachable-tracking-server failure as RuntimeError (see below), and init degrades gracefully
 # (disable MLflow, keep training) on that expected infra failure.
 _MLFLOW_CONNECT_ERRORS = (*_MLFLOW_LOG_ERRORS, RuntimeError)
+# Artifact uploads (log_artifact) additionally tolerate transient S3 failures. On the SageMaker
+# managed backend, artifacts go to S3 and mlflow's S3ArtifactRepository calls boto3 upload_file
+# with no wrapping, so a throttle/timeout/connection blip surfaces as a boto exception — NOT an
+# MlflowException or OSError. Catching these keeps a transient artifact-store hiccup from killing
+# a long training run at checkpoint time (its prior behavior), while a programming bug in the
+# upload path still propagates. Note: an auth/permission ClientError raised directly (not wrapped
+# in S3UploadFailedError) still surfaces — a misconfigured artifact store should fail loudly.
+_MLFLOW_ARTIFACT_ERRORS = (
+    *_MLFLOW_LOG_ERRORS,
+    botocore.exceptions.BotoCoreError,
+    boto3.exceptions.S3UploadFailedError,
+)
 
 
 def get_mlflow_tracking_uri(config_uri: str | None = None) -> str:
@@ -372,7 +386,7 @@ class Logger:
                 concept_matrix.to_csv(csv_path)
                 mlflow.log_artifact(csv_path, artifact_path="metadata")
                 logger.info("Logged concept matrix to MLflow")
-        except _MLFLOW_LOG_ERRORS as e:
+        except _MLFLOW_ARTIFACT_ERRORS as e:
             logger.warning("Failed to log concept matrix to MLflow: %s", e)
 
     def _unpack_metrics(self, metrics_dict: dict, key_prefix: str = "") -> dict[str, float]:
@@ -845,7 +859,7 @@ class Logger:
                     )
 
                 logger.info("Checkpoint logged to MLflow (epoch %d): %s", epoch, model_path)
-            except _MLFLOW_LOG_ERRORS as e:
+            except _MLFLOW_ARTIFACT_ERRORS as e:
                 logger.warning("Failed to log checkpoint/model to MLflow: %s", e)
                 if is_best:
                     with contextlib.suppress(Exception):

--- a/mermaidseg/logger.py
+++ b/mermaidseg/logger.py
@@ -48,6 +48,17 @@ logger = logging.getLogger(__name__)
 
 LOCAL_DEFAULT_URI = "./segmentation"
 
+# Expected, non-fatal failures for MLflow-logging calls: a tracking-backend/connection error
+# (MlflowException) or local artifact IO (OSError). These are caught + warned so a transient
+# logging failure never crashes training. Everything else — AttributeError/KeyError/TypeError,
+# i.e. the "dropped/misnamed metric" class of bug — is intentionally NOT caught so it surfaces
+# loudly instead of silently degrading observability (the failure mode /ml-training-review targets).
+_MLFLOW_LOG_ERRORS = (mlflow.exceptions.MlflowException, OSError)
+# Init/connect additionally tolerates RuntimeError: `mlflow_connect` deliberately re-raises an
+# unreachable-tracking-server failure as RuntimeError (see below), and init degrades gracefully
+# (disable MLflow, keep training) on that expected infra failure.
+_MLFLOW_CONNECT_ERRORS = (*_MLFLOW_LOG_ERRORS, RuntimeError)
+
 
 def get_mlflow_tracking_uri(config_uri: str | None = None) -> str:
     """Resolve MLflow tracking URI using a simple priority chain.
@@ -322,7 +333,7 @@ class Logger:
                         # Log concept metadata
                         self._log_concept_metadata(meta_model)
 
-                except Exception as e:
+                except _MLFLOW_CONNECT_ERRORS as e:
                     logger.warning("Failed to initialize MLflow logging: %s", e)
                     if self.mlflow_run_id is not None:
                         with contextlib.suppress(Exception):
@@ -361,7 +372,7 @@ class Logger:
                 concept_matrix.to_csv(csv_path)
                 mlflow.log_artifact(csv_path, artifact_path="metadata")
                 logger.info("Logged concept matrix to MLflow")
-        except Exception as e:
+        except _MLFLOW_LOG_ERRORS as e:
             logger.warning("Failed to log concept matrix to MLflow: %s", e)
 
     def _unpack_metrics(self, metrics_dict: dict, key_prefix: str = "") -> dict[str, float]:
@@ -423,7 +434,7 @@ class Logger:
                 name=dataset.__class__.__name__,
             )
             mlflow.log_input(meta, context=context)
-        except Exception as e:
+        except _MLFLOW_LOG_ERRORS as e:
             logger.warning("Failed to log dataset to MLflow: %s", e)
 
     def log_datasets(self, dataset, context: str = "training") -> None:
@@ -474,7 +485,7 @@ class Logger:
                 )
             mlflow.log_param("num_target_classes", int(registry.num_target_classes))
             mlflow.log_param("num_global_source_classes", int(registry.num_global_source_classes))
-        except Exception as e:
+        except _MLFLOW_LOG_ERRORS as e:
             logger.warning("Failed to log SourceLabelRegistry to MLflow: %s", e)
 
     def log_dataset_statistics(
@@ -582,7 +593,7 @@ class Logger:
             if dataset_variant is not None:
                 tags["benchmark.dataset_variant"] = dataset_variant
             mlflow.set_tags(tags)
-        except Exception as e:
+        except _MLFLOW_LOG_ERRORS as e:
             logger.warning("Failed to log benchmark context: %s", e)
 
     def log_dataloader_params(self, loader: DataLoader, prefix: str = "dataloader") -> None:
@@ -599,7 +610,7 @@ class Logger:
                     f"{prefix}_prefetch_factor": getattr(loader, "prefetch_factor", None),
                 }
             )
-        except Exception as e:
+        except _MLFLOW_LOG_ERRORS as e:
             logger.warning("Failed to log dataloader params: %s", e)
 
     def _ensure_active_run(self) -> bool:
@@ -638,7 +649,7 @@ class Logger:
                 "Started new MLflow run %s (was %s)", self.mlflow_run_id, original_run_id
             )
             return True
-        except Exception as e:
+        except _MLFLOW_LOG_ERRORS as e:
             logger.warning("Failed to ensure active MLflow run: %s", e)
             return False
 
@@ -648,7 +659,7 @@ class Logger:
                 metrics_to_log = self._unpack_metrics(log_dict)
                 if metrics_to_log:
                     mlflow.log_metrics(metrics_to_log, step=step)
-            except Exception as e:
+            except _MLFLOW_LOG_ERRORS as e:
                 logger.warning("Failed to log metrics to MLflow: %s", e)
 
     def _prune_local_checkpoints(self, run_name: str) -> None:
@@ -834,7 +845,7 @@ class Logger:
                     )
 
                 logger.info("Checkpoint logged to MLflow (epoch %d): %s", epoch, model_path)
-            except Exception as e:
+            except _MLFLOW_LOG_ERRORS as e:
                 logger.warning("Failed to log checkpoint/model to MLflow: %s", e)
                 if is_best:
                     with contextlib.suppress(Exception):

--- a/tests/test_logger_narrowed_excepts.py
+++ b/tests/test_logger_narrowed_excepts.py
@@ -1,0 +1,46 @@
+"""Seam 2: Logger swallows only expected MLflow/IO failures — real bugs surface.
+
+The logging try/excepts were `except Exception: warning(...)`, which silently swallowed
+programming errors (the dropped/misnamed-metric class of bug). They now catch only
+(MlflowException, OSError), so a genuine bug in a logging call propagates instead of
+degrading observability unnoticed.
+"""
+
+from __future__ import annotations
+
+import mlflow
+import pytest
+
+from mermaidseg.logger import Logger
+
+
+def _enabled_logger(make_config, fake_meta_model) -> Logger:
+    lgr = Logger(config=make_config(), meta_model=fake_meta_model, enable_mlflow=True)
+    assert lgr.enabled is True
+    return lgr
+
+
+def test_log_propagates_programming_error(
+    tmp_mlflow_uri, make_config, fake_meta_model, monkeypatch
+):
+    """A non-MLflow error (e.g. ValueError) in a logging call must NOT be swallowed."""
+    lgr = _enabled_logger(make_config, fake_meta_model)
+
+    def boom(*_args, **_kwargs):
+        raise ValueError("real bug, not a tracking failure")
+
+    monkeypatch.setattr(mlflow, "log_metrics", boom)
+    with pytest.raises(ValueError, match="real bug"):
+        lgr.log({"train/loss": 1.0}, step=0)
+
+
+def test_log_swallows_mlflow_exception(tmp_mlflow_uri, make_config, fake_meta_model, monkeypatch):
+    """A transient MlflowException stays swallowed (warn + continue) — not fatal to
+    training."""
+    lgr = _enabled_logger(make_config, fake_meta_model)
+
+    def boom(*_args, **_kwargs):
+        raise mlflow.exceptions.MlflowException("transient tracking failure")
+
+    monkeypatch.setattr(mlflow, "log_metrics", boom)
+    lgr.log({"train/loss": 1.0}, step=0)  # must not raise

--- a/tests/test_logger_narrowed_excepts.py
+++ b/tests/test_logger_narrowed_excepts.py
@@ -1,13 +1,22 @@
 """Seam 2: Logger swallows only expected MLflow/IO failures — real bugs surface.
 
 The logging try/excepts were `except Exception: warning(...)`, which silently swallowed
-programming errors (the dropped/misnamed-metric class of bug). They now catch only
-(MlflowException, OSError), so a genuine bug in a logging call propagates instead of
-degrading observability unnoticed.
+programming errors (the dropped/misnamed-metric class of bug). Metadata-logging sites
+now catch only (MlflowException, OSError), so a genuine bug in a logging call propagates
+instead of degrading observability unnoticed.
+
+Artifact-upload sites (save_model_checkpoint / concept matrix) additionally tolerate
+transient S3 failures: mlflow's S3ArtifactRepository calls boto3 upload_file unwrapped,
+so a throttle/ timeout blip surfaces as a boto exception (not MlflowException/OSError).
+Those must stay swallowed — losing a whole training run to a transient checkpoint-upload
+hiccup is the regression we're guarding against — while a real bug in the upload path
+still propagates.
 """
 
 from __future__ import annotations
 
+import boto3.exceptions
+import botocore.exceptions
 import mlflow
 import pytest
 
@@ -44,3 +53,59 @@ def test_log_swallows_mlflow_exception(tmp_mlflow_uri, make_config, fake_meta_mo
 
     monkeypatch.setattr(mlflow, "log_metrics", boom)
     lgr.log({"train/loss": 1.0}, step=0)  # must not raise
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        boto3.exceptions.S3UploadFailedError("throttled while uploading checkpoint"),
+        botocore.exceptions.EndpointConnectionError(endpoint_url="s3://artifacts"),
+    ],
+    ids=["s3_upload_failed", "endpoint_connection"],
+)
+def test_save_checkpoint_swallows_transient_s3_error(
+    tmp_mlflow_uri, make_config, fake_meta_model, monkeypatch, exc
+):
+    """A transient S3 failure during checkpoint artifact upload must NOT crash training.
+
+    Under the SageMaker managed backend these surface as boto exceptions (not
+    MlflowException/OSError); the artifact sites tolerate them so a blip doesn't kill a
+    run.
+    """
+    lgr = Logger(
+        config=make_config(logger={"save_local_checkpoints": False}),
+        meta_model=fake_meta_model,
+        enable_mlflow=True,
+    )
+    assert lgr.enabled is True
+
+    def boom(*_args, **_kwargs):
+        raise exc
+
+    monkeypatch.setattr(mlflow, "log_artifact", boom)
+    # is_best=False -> single checkpoints/ upload path; must warn-and-continue, not raise.
+    lgr.save_model_checkpoint(
+        fake_meta_model, epoch=0, metrics_dict={"accuracy": 0.5}, is_best=False
+    )
+
+
+def test_save_checkpoint_propagates_programming_error(
+    tmp_mlflow_uri, make_config, fake_meta_model, monkeypatch
+):
+    """A real bug (e.g. ValueError) in the checkpoint upload path must still
+    propagate."""
+    lgr = Logger(
+        config=make_config(logger={"save_local_checkpoints": False}),
+        meta_model=fake_meta_model,
+        enable_mlflow=True,
+    )
+    assert lgr.enabled is True
+
+    def boom(*_args, **_kwargs):
+        raise ValueError("real bug in upload path")
+
+    monkeypatch.setattr(mlflow, "log_artifact", boom)
+    with pytest.raises(ValueError, match="real bug"):
+        lgr.save_model_checkpoint(
+            fake_meta_model, epoch=0, metrics_dict={"accuracy": 0.5}, is_best=False
+        )


### PR DESCRIPTION
Seam 2 of the training-path cleanup.

## Problem
Nine MLflow-logging sites in `logger.py` used `except Exception: logger.warning(...)`. That swallows **programming errors** (AttributeError/KeyError/TypeError) — the dropped/misnamed-metric class of observability regression that `/ml-training-review` exists to catch. A logging bug would silently degrade tracking and never surface.

## Change
- Introduce `_MLFLOW_LOG_ERRORS = (mlflow.exceptions.MlflowException, OSError)` and point the 9 logging sites at it: a transient tracking/IO failure still warns-and-continues, but a real bug propagates loudly.
- Init/connect uses `_MLFLOW_CONNECT_ERRORS = (*_MLFLOW_LOG_ERRORS, RuntimeError)` because `mlflow_connect` deliberately re-raises an unreachable-server `MlflowException` as a friendly `RuntimeError`, and Logger init must degrade gracefully on that expected infra failure.
- **Left untouched:** the 3 `# noqa: BLE001` dataset-stats catches (already acknowledged broad) and the `end_run`/SafeTensors cleanup catches.

## Safety
- +tests (`test_logger_narrowed_excepts.py`): a real `ValueError` in `log()` now propagates; a transient `MlflowException` stays swallowed.
- The existing "MLflow unreachable → graceful degradation" test still passes (verified it caught the init `RuntimeError` path).
- Full suite: 347 passed.

No structural split of `Logger` — that (and the `MetaModel` decomposition) remains parked per the cleanup plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)