### PR TITLE
refactor(meta): dedupe concept-postprocess into _concepts_to_label_map (Seam 4)

### DIFF
--- a/mermaidseg/model/meta.py
+++ b/mermaidseg/model/meta.py
@@ -320,6 +320,22 @@ class MetaModel:
             )
         return source_labels_to_concepts(source_labels, self.source_to_concepts_lookup)
 
+    def _concepts_to_label_map(self, concept_scores: torch.Tensor) -> torch.Tensor:
+        """Reduce per-pixel concept scores to a target-label map on-device.
+
+        Wraps :func:`postprocess_predicted_concepts` (hierarchical argmax over the
+        concept matrix). Shared by ``batch_predict``, ``batch_predict_loss``, and the
+        concept-mode metric accumulation. NOTE: callers currently pass different score
+        spaces — ``batch_predict`` passes raw concept logits, ``batch_predict_loss``
+        passes sigmoid probabilities — which ``postprocess_predicted_concepts``
+        thresholds identically at 0.5; this helper preserves whatever the caller passes.
+        """
+        return postprocess_predicted_concepts(
+            concept_scores.detach().cpu().numpy(),
+            self.concept_matrix,
+            self.conceptid2labelid,
+        ).to(self.device)
+
     def batch_predict(
         self,
         inputs: torch.Tensor,
@@ -346,11 +362,7 @@ class MetaModel:
             outputs = segmentation_outputs.logits
         elif self.training_mode == "concept":
             concept_outputs = segmentation_outputs.logits
-            outputs = postprocess_predicted_concepts(
-                concept_outputs.detach().cpu().numpy(),
-                self.concept_matrix,
-                self.conceptid2labelid,
-            ).to(self.device)
+            outputs = self._concepts_to_label_map(concept_outputs)
             concept_outputs = torch.sigmoid(concept_outputs)
         else:
             outputs = segmentation_outputs.logits
@@ -405,11 +417,7 @@ class MetaModel:
             concept_outputs = segmentation_outputs.logits.float()
             loss, loss_components = self.loss(concept_outputs, target_concepts, target_labels)
             concept_outputs = torch.sigmoid(concept_outputs)
-            outputs = postprocess_predicted_concepts(
-                concept_outputs.detach().cpu().numpy(),
-                self.concept_matrix,
-                self.conceptid2labelid,
-            ).to(self.device)
+            outputs = self._concepts_to_label_map(concept_outputs)
 
         else:
             outputs = segmentation_outputs.logits.float()
@@ -548,11 +556,7 @@ class MetaModel:
 
             if evaluator is not None:
                 if self.training_mode == "concept":
-                    target_concept_preds = postprocess_predicted_concepts(
-                        target_concepts.detach().cpu().numpy(),
-                        self.concept_matrix,
-                        self.conceptid2labelid,
-                    ).to(self.device)
+                    target_concept_preds = self._concepts_to_label_map(target_concepts)
                     evaluator.accumulate(outputs, target_concept_preds)
                 else:
                     evaluator.accumulate(outputs, target_labels)


### PR DESCRIPTION
Seam 4 of the training-path cleanup. **Stacked on #178 (Seam 3)** — review/merge that first; this PR's diff is against `seam3-unify-epochs`.

## Change
The `postprocess_predicted_concepts(x.detach().cpu().numpy(), concept_matrix, conceptid2labelid).to(device)` chain was repeated verbatim **3×** (`batch_predict`, `batch_predict_loss`, and the concept-mode metric accumulation). Extract it to a single `_concepts_to_label_map` helper. Each call site passes the same argument it did before → behavior unchanged (standard-mode golden char tests stay green; the concept blocks are a pure extract-method).

## Deliberately NOT a strategy pattern
The plan floated a `TrainingMode` strategy. On inspection the remaining `training_mode` branches (`__init__` kwargs, the two output-splits, the loss call) each do **genuinely different** work and are already localized to one method — a `Protocol` + 3 subclasses would be speculative structure for a closed 3-mode set. The only real duplication was the postprocess chain; that's all this removes. (Escalate later only if a real need appears.)

## ⚠️ Bug found while here (fixed in the stacked follow-up, not this PR)
`batch_predict` fed **raw logits** to postprocess while `batch_predict_loss` fed **sigmoid probabilities** — so eval/inference and the train/val loop could produce different concept→label maps for the same model. This PR **preserves** that behavior (it's a pure dedup); the fix lands in the next stacked PR.

## Safety
Full suite: 200 passed; same 4 pre-existing base failures, no new ones. `ruff` + pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)