### PR TITLE
refactor(registry): collapse per-source fetcher ladder into a table

### DIFF
--- a/mermaidseg/dataset_reconciliation/registry.py
+++ b/mermaidseg/dataset_reconciliation/registry.py
@@ -62,6 +62,18 @@ _BUILTIN_DEFAULT_FETCHERS = {
     "coralscapes_v2": lambda ds: _static_source_to_target(coralscapes_v2_to_mermaid(), ds),
 }
 
+# Sources whose source->target map is fetched remotely (CoralNet API / published label
+# files); these require ``fetch_remote=True`` (or an explicit ``source_to_target_name_maps``
+# entry). Add a new remote source here.
+_REMOTE_FETCHERS = {
+    "coralnet": fetch_coralnet_to_mermaid,
+    "catlin_seaview": fetch_catlin_seaview_to_mermaid,
+    "moorea_labeled_corals": fetch_moorea_labeled_corals_to_mermaid,
+    "pacific_labeled_corals": fetch_pacific_labeled_corals_to_mermaid,
+    "benthos_yuval": fetch_benthos_yuval_to_mermaid,
+    "ucsd_mosaics": fetch_ucsd_mosaics_to_mermaid,
+}
+
 
 def roll_up_label(label: str, benthic_hierarchy: dict[str, str], subset: set[str]) -> str | None:
     if label in subset:
@@ -254,92 +266,25 @@ class SourceLabelRegistry:
             ds_names_lower = {n.lower() for n in ds.source_name2id}
             if name in provided:
                 resolved[name] = provided[name]
-                continue
-            if name == "coralnet":
+            elif name in _REMOTE_FETCHERS:
                 if not fetch_remote:
                     raise ValueError(
-                        "coralnet source-to-target mapping requires fetch_remote=True or "
+                        f"{name} source-to-target mapping requires fetch_remote=True or "
                         "an explicit entry in source_to_target_name_maps"
                     )
-                coralnet_id_to_target = fetch_coralnet_to_mermaid()
+                fetched = _REMOTE_FETCHERS[name]()
                 resolved[name] = {
                     src: tgt
-                    for src, tgt in coralnet_id_to_target.items()
+                    for src, tgt in fetched.items()
                     if tgt is not None and src.lower() in ds_names_lower
                 }
-                continue
-            if name == "catlin_seaview":
-                if not fetch_remote:
-                    raise ValueError(
-                        "catlin_seaview source-to-target mapping requires fetch_remote=True or "
-                        "an explicit entry in source_to_target_name_maps"
-                    )
-                catlin_to_target = fetch_catlin_seaview_to_mermaid()
-                resolved[name] = {
-                    src: tgt
-                    for src, tgt in catlin_to_target.items()
-                    if tgt is not None and src.lower() in ds_names_lower
-                }
-                continue
-            if name == "moorea_labeled_corals":
-                if not fetch_remote:
-                    raise ValueError(
-                        "moorea_labeled_corals source-to-target mapping requires "
-                        "fetch_remote=True or an explicit entry in source_to_target_name_maps"
-                    )
-                moorea_to_target = fetch_moorea_labeled_corals_to_mermaid()
-                resolved[name] = {
-                    src: tgt
-                    for src, tgt in moorea_to_target.items()
-                    if tgt is not None and src.lower() in ds_names_lower
-                }
-                continue
-            if name == "pacific_labeled_corals":
-                if not fetch_remote:
-                    raise ValueError(
-                        "pacific_labeled_corals source-to-target mapping requires "
-                        "fetch_remote=True or an explicit entry in source_to_target_name_maps"
-                    )
-                pacific_to_target = fetch_pacific_labeled_corals_to_mermaid()
-                resolved[name] = {
-                    src: tgt
-                    for src, tgt in pacific_to_target.items()
-                    if tgt is not None and src.lower() in ds_names_lower
-                }
-                continue
-            if name == "benthos_yuval":
-                if not fetch_remote:
-                    raise ValueError(
-                        "benthos_yuval source-to-target mapping requires "
-                        "fetch_remote=True or an explicit entry in source_to_target_name_maps"
-                    )
-                benthos_to_target = fetch_benthos_yuval_to_mermaid()
-                resolved[name] = {
-                    src: tgt
-                    for src, tgt in benthos_to_target.items()
-                    if tgt is not None and src.lower() in ds_names_lower
-                }
-                continue
-            if name == "ucsd_mosaics":
-                if not fetch_remote:
-                    raise ValueError(
-                        "ucsd_mosaics source-to-target mapping requires "
-                        "fetch_remote=True or an explicit entry in source_to_target_name_maps"
-                    )
-                ucsd_to_target = fetch_ucsd_mosaics_to_mermaid()
-                resolved[name] = {
-                    src: tgt
-                    for src, tgt in ucsd_to_target.items()
-                    if tgt is not None and src.lower() in ds_names_lower
-                }
-                continue
-            if name in _BUILTIN_DEFAULT_FETCHERS:
+            elif name in _BUILTIN_DEFAULT_FETCHERS:
                 resolved[name] = _BUILTIN_DEFAULT_FETCHERS[name](ds)
-                continue
-            raise ValueError(
-                f"No default source-to-target mapping for SOURCE_NAME='{name}'. "
-                "Pass an explicit entry in source_to_target_name_maps."
-            )
+            else:
+                raise ValueError(
+                    f"No default source-to-target mapping for SOURCE_NAME='{name}'. "
+                    "Pass an explicit entry in source_to_target_name_maps."
+                )
         return {
             src_name: {k.lower(): v.lower() for k, v in m.items()}
             for src_name, m in resolved.items()

--- a/tests/test_registry_source_target_dispatch.py
+++ b/tests/test_registry_source_target_dispatch.py
@@ -1,0 +1,70 @@
+"""Characterization tests for SourceLabelRegistry._resolve_source_to_target_maps.
+
+Lock the source->target dispatch behavior before collapsing the per-source if-ladder
+into a table: the fetch_remote guard for remote sources, the provided-map short-circuit,
+the built-in identity/static path, unknown-source errors, and output lowercasing. Pure
+dispatch — no network, exercised via the unbound method with a stub `self`.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from mermaidseg.dataset_reconciliation.registry import SourceLabelRegistry
+
+
+class _StubDS:
+    """Minimal dataset surface used by _resolve_source_to_target_maps."""
+
+    def __init__(self, source_name: str, names: list[str]):
+        self.SOURCE_NAME = source_name
+        self.source_name2id = {n: i + 1 for i, n in enumerate(names)}
+
+
+def _resolve(datasets, provided=None, fetch_remote=True):
+    fake_self = SimpleNamespace(datasets=datasets)
+    return SourceLabelRegistry._resolve_source_to_target_maps(
+        fake_self, provided or {}, fetch_remote
+    )
+
+
+def test_provided_map_short_circuits_without_network():
+    """An explicit provided map is used verbatim (lowercased) — no fetcher call, even
+    for a remote source with fetch_remote=False."""
+    ds = _StubDS("coralnet", ["1", "2"])
+    result = _resolve([ds], provided={"coralnet": {"1": "Coral", "2": "Sand"}}, fetch_remote=False)
+    assert result["coralnet"] == {"1": "coral", "2": "sand"}
+
+
+def test_remote_source_without_fetch_remote_raises():
+    """A remote source with no provided map requires fetch_remote=True."""
+    ds = _StubDS("coralnet", ["1"])
+    with pytest.raises(ValueError, match="coralnet"):
+        _resolve([ds], fetch_remote=False)
+
+
+def test_builtin_identity_source_resolves_without_network():
+    """The built-in 'mermaid' identity map resolves without needing fetch_remote."""
+    ds = _StubDS("mermaid", ["Coral", "Sand"])
+    result = _resolve([ds], fetch_remote=False)
+    assert result["mermaid"] == {"coral": "coral", "sand": "sand"}
+
+
+def test_unknown_source_raises():
+    """A SOURCE_NAME with no provided map, no fetcher, and no built-in entry errors."""
+    ds = _StubDS("totally_unknown_dataset", ["x"])
+    with pytest.raises(ValueError, match="No default source-to-target mapping"):
+        _resolve([ds], fetch_remote=True)
+
+
+def test_multiple_sources_resolve_independently():
+    """A provided remote source and a built-in source resolve together, each keyed by
+    SOURCE_NAME."""
+    coralnet = _StubDS("coralnet", ["1"])
+    mermaid = _StubDS("mermaid", ["Coral"])
+    result = _resolve(
+        [coralnet, mermaid], provided={"coralnet": {"1": "Coral"}}, fetch_remote=False
+    )
+    assert result == {"coralnet": {"1": "coral"}, "mermaid": {"coral": "coral"}}


### PR DESCRIPTION
Part of the "de-hardcode the dataset catalog" cleanup (architecture-review item #2, PR A).

## Problem
`SourceLabelRegistry._resolve_source_to_target_maps` had a **6-branch `if name == "..."` ladder** (coralnet, catlin_seaview, moorea_labeled_corals, pacific_labeled_corals, benthos_yuval, ucsd_mosaics). Every block was byte-identical modulo the fetcher name and the `SOURCE_NAME` in its error string — while the *other* 3 sources (mermaid, coralscapes, coralscapes_v2) were already handled cleanly by the `_BUILTIN_DEFAULT_FETCHERS` table right above it. Adding a remote source meant pasting another ~13-line branch.

## Change
- Add a parallel `_REMOTE_FETCHERS` table (`SOURCE_NAME -> fetcher`).
- Dispatch collapses to: `provided → _REMOTE_FETCHERS (fetch_remote guard + name/None filter) → _BUILTIN_DEFAULT_FETCHERS → raise`.
- Adding a remote source is now **one table entry**, not a new branch.

Method body: **77 lines → 22**.

## Behavior-preserving
- The `fetch_remote=False` guard, the `tgt is not None and src.lower() in ds_names_lower` filter, and the final output lowercasing are all unchanged.
- The only intentional change is cosmetic: the guard's error message is now generically keyed on the source name (`f"{name} source-to-target mapping requires fetch_remote=True ..."`) instead of six near-identical hardcoded strings.

## Tests
- New `tests/test_registry_source_target_dispatch.py` — characterization of the dispatch control flow (provided short-circuit, `fetch_remote` guard, built-in identity, unknown-source error, multi-source), written **green against the old ladder first**, still green after. No network.
- Existing `test_split_wiring` / `test_coralnet_label_mapping` stay green. Full suite: 206 passed (only the 2 pre-existing `test_integration` `meta.loss`-tuple failures remain, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)