### PR TITLE
refactor(datasets): single DATASET_REGISTRY + uniform constructor interface

### DIFF
--- a/mermaidseg/datasets/__init__.py
+++ b/mermaidseg/datasets/__init__.py
@@ -1,7 +1,7 @@
 """Per-source PyTorch datasets.
 
-Each subpackage exposes a dataset that emits labels in its own source label space. Cross-dataset
-label/concept mapping lives in :mod:`mermaidseg.dataset_reconciliation`.
+Each subpackage exposes a dataset that emits labels in its own source label space.
+Cross-dataset label/concept mapping lives in :mod:`mermaidseg.dataset_reconciliation`.
 """
 
 from mermaidseg.datasets.base_dataset import BaseCoralDataset, worker_init_fn
@@ -15,7 +15,25 @@ from mermaidseg.datasets.moorea_labeled_corals import MooreaLabeledCoralsDataset
 from mermaidseg.datasets.pacific_labeled_corals import PacificLabeledCoralsDataset
 from mermaidseg.datasets.ucsd_mosaics import UCSDMosaicsDataset
 
+# Single source of truth mapping a config ``SOURCE_NAME`` to its dataset class, used by the
+# training entrypoint to instantiate datasets from ``cfg.data``. Add a training-wired dataset
+# here. UCSDMosaicsDataset is exported (above) but intentionally omitted — it is not currently
+# wired into training.
+# NOTE: not annotated as ``type[BaseCoralDataset]`` because Coralscapes(_v2) currently
+# subclasses ``torch.utils.data.Dataset`` directly rather than ``BaseCoralDataset``.
+DATASET_REGISTRY: dict[str, type] = {
+    "coralnet": CoralNetDataset,
+    "mermaid": MermaidDataset,
+    "catlin_seaview": CatlinSeaviewDataset,
+    "moorea_labeled_corals": MooreaLabeledCoralsDataset,
+    "pacific_labeled_corals": PacificLabeledCoralsDataset,
+    "benthos_yuval": BenthosYuvalCoralsDataset,
+    "coralscapes": CoralscapesDataset,
+    "coralscapes_v2": CoralscapesV2Dataset,
+}
+
 __all__ = [
+    "DATASET_REGISTRY",
     "BaseCoralDataset",
     "BenthosYuvalCoralsDataset",
     "CatlinSeaviewDataset",

--- a/mermaidseg/datasets/__init__.py
+++ b/mermaidseg/datasets/__init__.py
@@ -21,15 +21,18 @@ from mermaidseg.datasets.ucsd_mosaics import UCSDMosaicsDataset
 # wired into training.
 # NOTE: not annotated as ``type[BaseCoralDataset]`` because Coralscapes(_v2) currently
 # subclasses ``torch.utils.data.Dataset`` directly rather than ``BaseCoralDataset``.
+# Order matters: it flows through dataset_dict → ConcatDataset member order → the
+# index-to-sample mapping the seeded DataLoader shuffles over, so it must match the prior
+# hardcoded DATASET_CLASSES order to keep the same seed reproducing the same run.
 DATASET_REGISTRY: dict[str, type] = {
-    "coralnet": CoralNetDataset,
-    "mermaid": MermaidDataset,
-    "catlin_seaview": CatlinSeaviewDataset,
-    "moorea_labeled_corals": MooreaLabeledCoralsDataset,
     "pacific_labeled_corals": PacificLabeledCoralsDataset,
-    "benthos_yuval": BenthosYuvalCoralsDataset,
+    "moorea_labeled_corals": MooreaLabeledCoralsDataset,
+    "catlin_seaview": CatlinSeaviewDataset,
+    "mermaid": MermaidDataset,
+    "coralnet": CoralNetDataset,
     "coralscapes": CoralscapesDataset,
     "coralscapes_v2": CoralscapesV2Dataset,
+    "benthos_yuval": BenthosYuvalCoralsDataset,
 }
 
 __all__ = [

--- a/mermaidseg/datasets/coralscapes/coralscapes_dataset.py
+++ b/mermaidseg/datasets/coralscapes/coralscapes_dataset.py
@@ -102,12 +102,16 @@ class CoralscapesDataset(Dataset[tuple[torch.Tensor | NDArray[Any], Any]]):
         split: str | None = None,
         transform: A.BasicTransform | None = None,
         class_subset: list[str] | None = None,
+        padding: int | None = None,
     ):
         from datasets import concatenate_datasets, load_dataset
 
         self.split = split
         self.transform = transform
         self.class_subset = class_subset
+        # Accepted for a uniform dataset constructor interface; unused here — Coralscapes
+        # carries dense HF masks, not point annotations, so there is nothing to pad.
+        self.padding = padding
         self._global_offset = 0
 
         self.dataset = load_dataset("EPFL-ECEO/coralscapes")
@@ -135,7 +139,8 @@ class CoralscapesDataset(Dataset[tuple[torch.Tensor | NDArray[Any], Any]]):
     def _build_native_to_local(self) -> np.ndarray:
         """Build a vectorized lookup from native Coralscapes IDs to local source IDs.
 
-        Native ID ``0`` and any class not present in ``class_subset`` map to ``0`` (background).
+        Native ID ``0`` and any class not present in ``class_subset`` map to ``0``
+        (background).
         """
         native_id2name = CORALSCAPES_ID2NAME
         max_native = max(native_id2name) + 1
@@ -180,9 +185,10 @@ class CoralscapesDataset(Dataset[tuple[torch.Tensor | NDArray[Any], Any]]):
     def __getitem__(self, idx: int) -> tuple[torch.Tensor | NDArray[Any], Any]:
         """Return ``(image, source_labels)`` for ``idx``.
 
-        On any internal load/transform error we emit a warning to logger + stdout + stderr and
-        return ``(None, None)``. :meth:`collate_fn` filters out these placeholders, so a failed item
-        drops out of the batch instead of crashing the loader.
+        On any internal load/transform error we emit a warning to logger + stdout +
+        stderr and return ``(None, None)``. :meth:`collate_fn` filters out these
+        placeholders, so a failed item drops out of the batch instead of crashing the
+        loader.
         """
         try:
             return self._load_item(idx)
@@ -208,10 +214,12 @@ class CoralscapesDataset(Dataset[tuple[torch.Tensor | NDArray[Any], Any]]):
         return image, mask
 
     def collate_fn(self, batch: list) -> tuple[torch.Tensor, torch.Tensor]:
-        """Filter out ``(None, None)`` items (failed loads) and stack into batched tensors.
+        """Filter out ``(None, None)`` items (failed loads) and stack into batched
+        tensors.
 
-        :meth:`__getitem__` returns ``(None, None)`` for items it fails to load; this filter drops
-        them so a failed item simply leaves the batch instead of crashing the loader.
+        :meth:`__getitem__` returns ``(None, None)`` for items it fails to load; this
+        filter drops them so a failed item simply leaves the batch instead of crashing
+        the loader.
         """
         batch_size = len(batch)
         filtered = [(img, msk) for img, msk in batch if img is not None and msk is not None]

--- a/mermaidseg/datasets/coralscapes_v2/coralscapes_v2_dataset.py
+++ b/mermaidseg/datasets/coralscapes_v2/coralscapes_v2_dataset.py
@@ -161,12 +161,16 @@ class CoralscapesV2Dataset(Dataset[tuple[torch.Tensor | NDArray[Any], Any]]):
         split: str | list[str] | None = None,
         transform: A.BasicTransform | None = None,
         class_subset: list[str] | None = None,
+        padding: int | None = None,
     ):
         from datasets import concatenate_datasets, load_dataset
 
         self.split = split
         self.transform = transform
         self.class_subset = class_subset
+        # Accepted for a uniform dataset constructor interface; unused here — Coralscapes
+        # carries dense HF masks, not point annotations, so there is nothing to pad.
+        self.padding = padding
         self._global_offset = 0
 
         hf_dataset = load_dataset(CORALSCAPES_V2_HF_REPO)
@@ -196,7 +200,8 @@ class CoralscapesV2Dataset(Dataset[tuple[torch.Tensor | NDArray[Any], Any]]):
     def _build_native_to_local(self) -> np.ndarray:
         """Build a vectorized lookup from native Coralscapes V2 IDs to local source IDs.
 
-        Native ID ``0`` and any class not present in ``class_subset`` map to ``0`` (background).
+        Native ID ``0`` and any class not present in ``class_subset`` map to ``0``
+        (background).
         """
         native_id2name = CORALSCAPES_V2_ID2NAME
         max_native = max(native_id2name) + 1
@@ -241,9 +246,10 @@ class CoralscapesV2Dataset(Dataset[tuple[torch.Tensor | NDArray[Any], Any]]):
     def __getitem__(self, idx: int) -> tuple[torch.Tensor | NDArray[Any], Any]:
         """Return ``(image, source_labels)`` for ``idx``.
 
-        On any internal load/transform error we emit a warning to logger + stdout + stderr and
-        return ``(None, None)``. :meth:`collate_fn` filters out these placeholders, so a failed item
-        drops out of the batch instead of crashing the loader.
+        On any internal load/transform error we emit a warning to logger + stdout +
+        stderr and return ``(None, None)``. :meth:`collate_fn` filters out these
+        placeholders, so a failed item drops out of the batch instead of crashing the
+        loader.
         """
         try:
             return self._load_item(idx)
@@ -271,10 +277,12 @@ class CoralscapesV2Dataset(Dataset[tuple[torch.Tensor | NDArray[Any], Any]]):
         return image, mask
 
     def collate_fn(self, batch: list) -> tuple[torch.Tensor, torch.Tensor]:
-        """Filter out ``(None, None)`` items (failed loads) and stack into batched tensors.
+        """Filter out ``(None, None)`` items (failed loads) and stack into batched
+        tensors.
 
-        :meth:`__getitem__` returns ``(None, None)`` for items it fails to load; this filter drops
-        them so a failed item simply leaves the batch instead of crashing the loader.
+        :meth:`__getitem__` returns ``(None, None)`` for items it fails to load; this
+        filter drops them so a failed item simply leaves the batch instead of crashing
+        the loader.
         """
         batch_size = len(batch)
         filtered = [(img, msk) for img, msk in batch if img is not None and msk is not None]

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -55,15 +55,8 @@ from mermaidseg.dataset_reconciliation import (
     prepare_splits_for_registry,
 )
 from mermaidseg.datasets import (
+    DATASET_REGISTRY,
     BaseCoralDataset,
-    BenthosYuvalCoralsDataset,
-    CatlinSeaviewDataset,
-    CoralNetDataset,
-    CoralscapesDataset,
-    CoralscapesV2Dataset,
-    MermaidDataset,
-    MooreaLabeledCoralsDataset,
-    PacificLabeledCoralsDataset,
     worker_init_fn,
 )
 from mermaidseg.io import get_parser, setup_config, update_config_with_args
@@ -367,30 +360,16 @@ def _run_training(args: argparse.Namespace) -> None:
         torch.cuda.manual_seed_all(seed)
     logging.info("Seed: %d", seed)
 
-    DATASET_CLASSES = {
-        "pacific_labeled_corals": PacificLabeledCoralsDataset,
-        "moorea_labeled_corals": MooreaLabeledCoralsDataset,
-        "catlin_seaview": CatlinSeaviewDataset,
-        "mermaid": MermaidDataset,
-        "coralnet": CoralNetDataset,
-        "coralscapes": CoralscapesDataset,
-        "coralscapes_v2": CoralscapesV2Dataset,
-        "benthos_yuval": BenthosYuvalCoralsDataset,
-    }
-
-    # coralscapes uses a different signature (no `padding`)
-    def _build(name, split_cfg):
-        cls = DATASET_CLASSES[name]
-        if name in ("coralscapes", "coralscapes_v2", "benthos_yuval"):
-            return cls(**split_cfg)
-        return cls(**split_cfg, padding=cfg.training.padding)
-
+    # Every dataset constructor accepts ``padding`` (point-annotation datasets use it;
+    # dense/HF datasets accept and ignore it), so instantiation is uniform.
     dataset_dict: dict[tuple[str, str], object] = {}
-    for name in DATASET_CLASSES:
+    for name in DATASET_REGISTRY:
         for split, split_cfg in cfg.data[name].items():
             if split_cfg is None or split_cfg == "None":
                 continue
-            dataset_dict[(name, split)] = _build(name, split_cfg)
+            dataset_dict[(name, split)] = DATASET_REGISTRY[name](
+                **split_cfg, padding=cfg.training.padding
+            )
             print(f"{name:>24s} - {split:<5s}: {len(dataset_dict[(name, split)]):>7d} samples")
 
     loader_kwargs = {

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -9,20 +9,30 @@ import inspect
 from mermaidseg import datasets as ds_pkg
 from mermaidseg.datasets import DATASET_REGISTRY
 
-_EXPECTED = {
-    "coralnet": "CoralNetDataset",
-    "mermaid": "MermaidDataset",
-    "catlin_seaview": "CatlinSeaviewDataset",
-    "moorea_labeled_corals": "MooreaLabeledCoralsDataset",
-    "pacific_labeled_corals": "PacificLabeledCoralsDataset",
-    "benthos_yuval": "BenthosYuvalCoralsDataset",
-    "coralscapes": "CoralscapesDataset",
-    "coralscapes_v2": "CoralscapesV2Dataset",
-}
+# The canonical order — must match the pre-registry hardcoded DATASET_CLASSES order in
+# scripts/train.py, because iteration order flows into ConcatDataset member order and thus
+# the seeded DataLoader's shuffled sample sequence. Reordering silently changes what a given
+# seed trains on, breaking baseline reproducibility — so it is asserted, not just the mapping.
+_EXPECTED_ORDER = [
+    ("pacific_labeled_corals", "PacificLabeledCoralsDataset"),
+    ("moorea_labeled_corals", "MooreaLabeledCoralsDataset"),
+    ("catlin_seaview", "CatlinSeaviewDataset"),
+    ("mermaid", "MermaidDataset"),
+    ("coralnet", "CoralNetDataset"),
+    ("coralscapes", "CoralscapesDataset"),
+    ("coralscapes_v2", "CoralscapesV2Dataset"),
+    ("benthos_yuval", "BenthosYuvalCoralsDataset"),
+]
 
 
 def test_registry_maps_expected_names_to_classes():
-    assert {name: cls.__name__ for name, cls in DATASET_REGISTRY.items()} == _EXPECTED
+    assert {name: cls.__name__ for name, cls in DATASET_REGISTRY.items()} == dict(_EXPECTED_ORDER)
+
+
+def test_registry_preserves_canonical_order():
+    """Order is behavior-affecting (ConcatDataset order → seeded shuffle sequence), so
+    it must match the pre-registry DATASET_CLASSES order for seed-reproducible runs."""
+    assert [(name, cls.__name__) for name, cls in DATASET_REGISTRY.items()] == _EXPECTED_ORDER
 
 
 def test_registry_excludes_unwired_ucsd_mosaics():

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -1,0 +1,47 @@
+"""Guards for the DATASET_REGISTRY single-source-of-truth and the uniform dataset
+constructor interface that lets the training entrypoint instantiate every dataset the
+same way (`cls(**split_cfg, padding=...)`), with no per-dataset special-casing."""
+
+from __future__ import annotations
+
+import inspect
+
+from mermaidseg import datasets as ds_pkg
+from mermaidseg.datasets import DATASET_REGISTRY
+
+_EXPECTED = {
+    "coralnet": "CoralNetDataset",
+    "mermaid": "MermaidDataset",
+    "catlin_seaview": "CatlinSeaviewDataset",
+    "moorea_labeled_corals": "MooreaLabeledCoralsDataset",
+    "pacific_labeled_corals": "PacificLabeledCoralsDataset",
+    "benthos_yuval": "BenthosYuvalCoralsDataset",
+    "coralscapes": "CoralscapesDataset",
+    "coralscapes_v2": "CoralscapesV2Dataset",
+}
+
+
+def test_registry_maps_expected_names_to_classes():
+    assert {name: cls.__name__ for name, cls in DATASET_REGISTRY.items()} == _EXPECTED
+
+
+def test_registry_excludes_unwired_ucsd_mosaics():
+    """UCSDMosaicsDataset is exported but not wired into training — keep it out of the
+    registry until it is (documents the intentional omission)."""
+    assert "ucsd_mosaics" not in DATASET_REGISTRY
+    assert hasattr(ds_pkg, "UCSDMosaicsDataset")  # still exported
+
+
+def test_every_registered_dataset_accepts_padding():
+    """The entrypoint calls ``cls(**split_cfg, padding=...)`` for every dataset, so each
+    constructor must accept ``padding`` — either explicitly or via ``**kwargs``
+    forwarded to BaseCoralDataset.
+
+    Signature-only (no network/S3 construction).
+    """
+    for name, cls in DATASET_REGISTRY.items():
+        params = inspect.signature(cls.__init__).parameters.values()
+        accepts_padding = any(
+            p.name == "padding" or p.kind is inspect.Parameter.VAR_KEYWORD for p in params
+        )
+        assert accepts_padding, f"{name} ({cls.__name__}) constructor cannot accept padding"

--- a/tests/test_standard_pipeline_smoke.py
+++ b/tests/test_standard_pipeline_smoke.py
@@ -77,42 +77,34 @@ def test_standard_mode_training_pipeline_smoke(tmp_path, monkeypatch):
         concept_schema_calls.append((args, kwargs))
         return original_from_csv(*args, **kwargs)
 
+    # Datasets are built via scripts.train.DATASET_REGISTRY[name](...); override its entries.
+    # The standard baseline uses only coralnet + mermaid — every other source has None splits
+    # in the config and must never be instantiated (side_effect guards that).
+    registry_override = {
+        "mermaid": MagicMock(return_value=synthetic_mermaid),
+        "coralnet": MagicMock(return_value=synthetic_coralnet),
+        **{
+            name: MagicMock(side_effect=ValueError("Should not be called in standard baseline"))
+            for name in (
+                "benthos_yuval",
+                "catlin_seaview",
+                "coralscapes",
+                "coralscapes_v2",
+                "moorea_labeled_corals",
+                "pacific_labeled_corals",
+            )
+        },
+    }
+
     patches = [
-        patch("scripts.train.MermaidDataset", return_value=synthetic_mermaid),
-        patch("scripts.train.CoralNetDataset", return_value=synthetic_coralnet),
-        patch("scripts.train.BenthosYuvalCoralsDataset"),
-        patch("scripts.train.CatlinSeaviewDataset"),
-        patch("scripts.train.CoralscapesDataset"),
-        patch("scripts.train.CoralscapesV2Dataset"),
-        patch("scripts.train.MooreaLabeledCoralsDataset"),
-        patch("scripts.train.PacificLabeledCoralsDataset"),
+        patch.dict("scripts.train.DATASET_REGISTRY", registry_override),
         patch("scripts.train.ConceptSchema.from_csv", side_effect=tracked_from_csv),
         patch("scripts.train.MetaModel"),
     ]
 
     with contextlib.ExitStack() as stack:
         mocks = [stack.enter_context(p) for p in patches]
-        (
-            mock_benthos,
-            mock_catlin,
-            mock_coralscapes,
-            mock_coralscapes_v2,
-            mock_moorea,
-            mock_pacific,
-            _,
-            mock_meta_model,
-        ) = mocks[2:10]
-
-        for mock in [
-            mock_benthos,
-            mock_catlin,
-            mock_coralscapes,
-            mock_coralscapes_v2,
-            mock_moorea,
-            mock_pacific,
-        ]:
-            mock.side_effect = ValueError("Should not be called in standard baseline")
-
+        mock_meta_model = mocks[2]
         mock_meta_model.return_value = MagicMock(
             model=MagicMock(),
             optimizer=MagicMock(),


### PR DESCRIPTION
Part of #166. Second half of "de-hardcode the dataset catalog" (PR A was #181, the registry fetcher table).

## Problem
Adding a dataset to training meant editing multiple hardcoded catalogs. On the training-entry side, `scripts/train.py` re-listed all 8 dataset classes in **both** an import block **and** a local `DATASET_CLASSES` dict, plus a `_build` special-case because `Coralscapes`/`CoralscapesV2` constructors didn't accept `padding` (a leaky, non-uniform constructor interface).

## Change
- Add **`DATASET_REGISTRY`** (`name -> class`) to `mermaidseg/datasets/__init__.py` as the single source of truth; `scripts/train.py` imports it and iterates it.
- Give `Coralscapes` / `CoralscapesV2` constructors a `padding` param (accepted, stored, unused — dense HF masks have no point annotations to pad). **Every** dataset ctor now accepts `padding`, so the entrypoint instantiates uniformly: `cls(**split_cfg, padding=...)` — the `_build` special-case is gone.
- `UCSDMosaicsDataset` stays exported but is intentionally kept out of the registry (not training-wired); documented inline + asserted in a test.

## Behavior-preserving
Same 8 sources instantiated from the same config with the same `padding`. Point-annotation datasets use `padding` as before; dense/HF datasets ignore it (benthos already did — it flowed through `**base_kwargs` unused).

## Tests
- `+tests/test_dataset_registry.py`: registry maps the expected 8 names, excludes `ucsd_mosaics`, and every registered ctor accepts `padding` (signature-only, no network).
- `test_standard_pipeline_smoke`: repointed its patches from the removed `scripts.train.<Class>` names to `scripts.train.DATASET_REGISTRY` entries; same intent.
- Full suite: 204 passed (only the 2 pre-existing `test_integration` `meta.loss`-tuple failures).

## Scope
Does **not** include migrating `Coralscapes`/`CoralscapesV2` onto `BaseCoralDataset` (they still subclass `torch.utils.data.Dataset` directly and re-implement `set_global_offset`/`collate_fn`/`_load_item`) — that's the separate remaining dataset-dedup item under #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)