### PR TITLE
perf: data-loading efficiency (O(1) annotation lookup, frozen-encoder no_grad, batch 8->32)

### DIFF
--- a/configs/training_config_dinov3_linear.yaml
+++ b/configs/training_config_dinov3_linear.yaml
@@ -30,8 +30,8 @@ training:
     # Bumped 8 -> 32: the issue-12 baseline run (MLflow f1cf7811) used only 2.85 GB of the 24 GB
     # GPU at batch 8, so there is large headroom (32 ~= 11 GB est.). NOTE: lr (1e-3) may want
     # scaling for the larger batch (~sqrt rule -> ~2e-3) — leave as an explicit experiment choice.
-    # Going higher (64+) is gated on running the frozen LinearDINOv3 encoder under torch.no_grad
-    # (it currently builds the autograd graph over the frozen backbone, wasting activation memory).
+    # The frozen LinearDINOv3 encoder now runs under torch.no_grad (frees activation memory), so 64
+    # is worth trying once verified on the target GPU.
     batch_size: 32
     # Target-class whitelist (SourceLabelRegistry target_label_subset). Ids 1..N are assigned
     # alphabetically; id 0 is the unmapped/ignore slot (ignore_index: 0). Names must match the

--- a/configs/training_config_dinov3_linear.yaml
+++ b/configs/training_config_dinov3_linear.yaml
@@ -27,7 +27,12 @@ training:
         warmup_iters: 0
     iterations_per_train_epoch: 1000
     iterations_per_val_epoch: 200
-    batch_size: 8
+    # Bumped 8 -> 32: the issue-12 baseline run (MLflow f1cf7811) used only 2.85 GB of the 24 GB
+    # GPU at batch 8, so there is large headroom (32 ~= 11 GB est.). NOTE: lr (1e-3) may want
+    # scaling for the larger batch (~sqrt rule -> ~2e-3) — leave as an explicit experiment choice.
+    # Going higher (64+) is gated on running the frozen LinearDINOv3 encoder under torch.no_grad
+    # (it currently builds the autograd graph over the frozen backbone, wasting activation memory).
+    batch_size: 32
     # Target-class whitelist (SourceLabelRegistry target_label_subset). Ids 1..N are assigned
     # alphabetically; id 0 is the unmapped/ignore slot (ignore_index: 0). Names must match the
     # produced targets (CoralNet->MERMAID map values + MERMAID benthic-attribute hierarchy)

--- a/mermaidseg/datasets/base_dataset.py
+++ b/mermaidseg/datasets/base_dataset.py
@@ -85,6 +85,7 @@ class BaseCoralDataset(Dataset[tuple[torch.Tensor | NDArray[Any], Any]]):
     _load_failures: list[dict[str, Any]]
     _annotation_count_by_image: dict[str, int]
     _annotation_labels_by_image: dict[str, str]
+    _annotation_positions_by_image: dict[Any, np.ndarray]
 
     def __init__(
         self,
@@ -122,11 +123,17 @@ class BaseCoralDataset(Dataset[tuple[torch.Tensor | NDArray[Any], Any]]):
         self.num_source_classes = len(self.source_id2name) + 1  # +1 for background
 
         self._annotation_count_by_image = self.df_annotations["image_id"].value_counts().to_dict()
+        grouped_by_image = self.df_annotations.groupby("image_id")
         self._annotation_labels_by_image = (
-            self.df_annotations.groupby("image_id")["source_label_name"]
+            grouped_by_image["source_label_name"]
             .apply(lambda values: ",".join(sorted({str(v) for v in values if pd.notna(v)})))
             .to_dict()
         )
+        # Positional indices of each image's annotation rows, computed once, so __getitem__
+        # slices annotations in O(1) instead of scanning the whole (multi-million row)
+        # annotations frame with a boolean mask on every sample. Values are numpy position
+        # arrays suitable for DataFrame.iloc.
+        self._annotation_positions_by_image = grouped_by_image.indices
         self._load_failures = []
 
     def _derive_df_images_from_annotations(self, df_annotations: pd.DataFrame) -> pd.DataFrame:
@@ -218,10 +225,11 @@ class BaseCoralDataset(Dataset[tuple[torch.Tensor | NDArray[Any], Any]]):
 
         image = self.read_image(**row_kwargs)
 
-        annotations = self.df_annotations.loc[
-            self.df_annotations["image_id"] == image_id,
-            ["row", "col", "source_label_name"],
-        ]
+        positions = self._annotation_positions_by_image.get(image_id)
+        if positions is None:
+            annotations = self.df_annotations.iloc[:0][["row", "col", "source_label_name"]]
+        else:
+            annotations = self.df_annotations.iloc[positions][["row", "col", "source_label_name"]]
 
         local_mask = create_annotation_mask(
             annotations, image.shape, self.source_name2id, padding=self.padding

--- a/mermaidseg/model/models.py
+++ b/mermaidseg/model/models.py
@@ -162,6 +162,10 @@ class LinearDINOv3(torch.nn.Module):
         self.token_width = input_size[1] // patch_size
         self.token_height = input_size[0] // patch_size
         self.head = LinearClassifier(hidden_size, self.token_width, self.token_height, num_classes)
+        # Gates the encoder forward under no_grad when the backbone is frozen (set by
+        # freeze_encoder). Mirrors _DPTDINOv3Base so a frozen probe doesn't build the autograd
+        # graph over the backbone or hold its activations.
+        self._encoder_frozen = False
 
     def forward(self, x: torch.Tensor, labels=None, **kwargs: Any) -> SemanticSegmenterOutput:
         """Run encoder + linear head and upsample to input resolution.
@@ -172,7 +176,13 @@ class LinearDINOv3(torch.nn.Module):
         Returns:
             SemanticSegmenterOutput: `.logits` has shape (B, num_classes, H, W).
         """
-        outputs = self.encoder(x, **kwargs)
+        if self._encoder_frozen:
+            # Frozen probe: skip building the autograd graph over the backbone (saves activation
+            # memory and backward compute; only the head trains).
+            with torch.no_grad():
+                outputs = self.encoder(x, **kwargs)
+        else:
+            outputs = self.encoder(x, **kwargs)
         # Skip the 5 DINOv3 prefix tokens (CLS + 4 register tokens)
         patch_embeddings = outputs.last_hidden_state[:, 5:, :]
 
@@ -193,23 +203,22 @@ class LinearDINOv3(torch.nn.Module):
         return SemanticSegmenterOutput(loss=loss, logits=logits)
 
     def freeze_encoder(self) -> None:
-        """Freezes the encoder layers of the model by setting the `requires_grad`
-        attribute of their parameters to `False`.
+        """Freeze the backbone: set encoder ``requires_grad`` to ``False`` and run its
+        forward under ``torch.no_grad`` so a frozen probe never builds the autograd
+        graph over it.
 
-        This prevents the encoder layers from being updated during training, effectively
-        making them static while allowing other parts of the model to be trained.
+        Only the head keeps training.
         """
         for param in self.encoder.parameters():
             param.requires_grad = False
+        self._encoder_frozen = True
 
     def unfreeze_encoder(self) -> None:
-        """Unfreezes the encoder layers of the model by setting the `requires_grad`
-        attribute of all parameters in the encoder to True.
-
-        This allows these layers to be trainable during the training process.
-        """
+        """Unfreeze the backbone: restore encoder ``requires_grad`` to ``True`` and run
+        its forward with gradients again (full fine-tune)."""
         for param in self.encoder.parameters():
             param.requires_grad = True
+        self._encoder_frozen = False
 
 
 class ConceptBottleneckDINOv3(torch.nn.Module):

--- a/mermaidseg/model/models.py
+++ b/mermaidseg/model/models.py
@@ -19,8 +19,8 @@ DEFAULT_LORA_TARGET_MODULES = ("q_proj", "k_proj", "v_proj", "o_proj")
 class ConceptBottleneckOutput(SemanticSegmenterOutput):
     """Segmenter output for concept-bottleneck models.
 
-    Both ``concept_outputs`` and ``concept_logits`` are retained intentionally:
-    logits feed the training loss; activations feed the class head and inference.
+    Both ``concept_outputs`` and ``concept_logits`` are retained intentionally: logits
+    feed the training loss; activations feed the class head and inference.
     ``hidden_states`` is unused (left ``None``) so activations are not overloaded.
     """
 
@@ -29,7 +29,8 @@ class ConceptBottleneckOutput(SemanticSegmenterOutput):
 
 
 class LinearClassifier(torch.nn.Module):
-    """A linear classifier module that performs pixel-wise classification on reshaped embeddings.
+    """A linear classifier module that performs pixel-wise classification on reshaped
+    embeddings.
 
     This module takes input embeddings, reshapes them to a 2D spatial format, and applies
     a 1x1 convolution to perform classification. It's commonly used as a classification
@@ -81,8 +82,8 @@ class LinearClassifier(torch.nn.Module):
 
 
 class ConceptHead(torch.nn.Module):
-    """A concept classification head module that performs pixel-wise classification on reshaped
-    embeddings.
+    """A concept classification head module that performs pixel-wise classification on
+    reshaped embeddings.
 
     This module takes input embeddings, reshapes them to a 2D spatial format, and
     applies a 1x1 convolution to perform classification. It's commonly used as a classification
@@ -192,18 +193,18 @@ class LinearDINOv3(torch.nn.Module):
         return SemanticSegmenterOutput(loss=loss, logits=logits)
 
     def freeze_encoder(self) -> None:
-        """Freezes the encoder layers of the model by setting the `requires_grad` attribute of their
-        parameters to `False`.
+        """Freezes the encoder layers of the model by setting the `requires_grad`
+        attribute of their parameters to `False`.
 
-        This prevents the encoder layers from being updated during training, effectively making them
-        static while allowing other parts of the model to be trained.
+        This prevents the encoder layers from being updated during training, effectively
+        making them static while allowing other parts of the model to be trained.
         """
         for param in self.encoder.parameters():
             param.requires_grad = False
 
     def unfreeze_encoder(self) -> None:
-        """Unfreezes the encoder layers of the model by setting the `requires_grad` attribute of all
-        parameters in the encoder to True.
+        """Unfreezes the encoder layers of the model by setting the `requires_grad`
+        attribute of all parameters in the encoder to True.
 
         This allows these layers to be trainable during the training process.
         """
@@ -310,18 +311,18 @@ class ConceptBottleneckDINOv3(torch.nn.Module):
         )
 
     def freeze_encoder(self) -> None:
-        """Freezes the encoder layers of the model by setting the `requires_grad` attribute of their
-        parameters to `False`.
+        """Freezes the encoder layers of the model by setting the `requires_grad`
+        attribute of their parameters to `False`.
 
-        This prevents the encoder layers from being updated during training, effectively making them
-        static while allowing other parts of the model to be trained.
+        This prevents the encoder layers from being updated during training, effectively
+        making them static while allowing other parts of the model to be trained.
         """
         for param in self.encoder.parameters():
             param.requires_grad = False
 
     def unfreeze_encoder(self) -> None:
-        """Unfreezes the encoder layers of the model by setting the `requires_grad` attribute of all
-        parameters in the encoder to True.
+        """Unfreezes the encoder layers of the model by setting the `requires_grad`
+        attribute of all parameters in the encoder to True.
 
         This allows these layers to be trainable during the training process.
         """
@@ -353,9 +354,9 @@ def _wrap_encoder_with_lora(
 ) -> torch.nn.Module:
     """Wrap a DINOv3 encoder with PEFT LoRA adapters.
 
-    The pretrained backbone weights are frozen and only the injected low-rank adapter matrices
-    remain trainable, which keeps the parameter/optimizer footprint small while still adapting the
-    attention projections.
+    The pretrained backbone weights are frozen and only the injected low-rank adapter
+    matrices remain trainable, which keeps the parameter/optimizer footprint small while
+    still adapting the attention projections.
     """
     lora_config = LoraConfig(
         r=lora_r,
@@ -450,8 +451,8 @@ class DPTHead(torch.nn.Module):
         """Resolve the (height, width) patch grid for ``num_patch_tokens``.
 
         Uses the configured token grid when it matches; otherwise reshapes
-        ``num_patch_tokens`` while preserving the configured aspect ratio (which
-        handles square and non-square inputs at arbitrary resolutions).
+        ``num_patch_tokens`` while preserving the configured aspect ratio (which handles
+        square and non-square inputs at arbitrary resolutions).
         """
         if num_patch_tokens == self.token_height * self.token_width:
             return self.token_height, self.token_width
@@ -471,9 +472,9 @@ class DPTHead(torch.nn.Module):
 class _DPTDINOv3Base(torch.nn.Module):
     """Shared backbone/head wiring for the DPT DINOv3 models.
 
-    The encoder can either be adapted with PEFT LoRA (``use_lora=True``) or used as a plain frozen
-    backbone (``use_lora=False``), in which case only the DPT head (and any downstream concept
-    layers) is trained.
+    The encoder can either be adapted with PEFT LoRA (``use_lora=True``) or used as a
+    plain frozen backbone (``use_lora=False``), in which case only the DPT head (and any
+    downstream concept layers) is trained.
     """
 
     def __init__(
@@ -555,8 +556,9 @@ class _DPTDINOv3Base(torch.nn.Module):
     def _encode(self, x: torch.Tensor, **kwargs: Any) -> list[torch.Tensor]:
         """Run the encoder and return the selected hidden states (CLS + patches).
 
-        When the (non-LoRA) backbone is frozen the encoder pass runs under ``torch.no_grad`` to save
-        memory; the LoRA path always keeps gradients so the adapters can learn.
+        When the (non-LoRA) backbone is frozen the encoder pass runs under
+        ``torch.no_grad`` to save memory; the LoRA path always keeps gradients so the
+        adapters can learn.
         """
         if self._encoder_frozen:
             with torch.no_grad():

--- a/tests/model/test_linear_dinov3_frozen.py
+++ b/tests/model/test_linear_dinov3_frozen.py
@@ -1,0 +1,88 @@
+"""Frozen-encoder no_grad gating for LinearDINOv3.
+
+Freezing a probe should not just stop encoder gradients (requires_grad=False) — it
+should also run the backbone forward under ``torch.no_grad`` so no autograd graph /
+activations are held. These tests use a tiny mock encoder with a real parameter so we
+can prove the gate: with the frozen gate on, a gradient must NOT reach the encoder
+parameter even if its ``requires_grad`` is left True.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from mermaidseg.model import models as models_mod
+
+
+class _ParamEncoder(torch.nn.Module):
+    """Minimal stand-in for the DINOv3 encoder whose output depends on a trainable
+    parameter."""
+
+    def __init__(self, hidden_size: int = 64, patch_size: int = 16):
+        super().__init__()
+        self.config = SimpleNamespace(hidden_size=hidden_size, patch_size=patch_size)
+        self.scale = torch.nn.Parameter(torch.ones(hidden_size))
+
+    def forward(self, pixel_values: torch.Tensor, **_):
+        b, _c, h, w = pixel_values.shape
+        seq = 5 + (h // self.config.patch_size) * (w // self.config.patch_size)  # 5 prefix tokens
+        base = torch.ones(
+            b, seq, self.config.hidden_size, device=pixel_values.device, dtype=pixel_values.dtype
+        )
+        return SimpleNamespace(last_hidden_state=base * self.scale)
+
+
+@pytest.fixture
+def model(monkeypatch):
+    """LinearDINOv3 backed by the param encoder, sized so a 32x32 input yields a 2x2
+    token grid."""
+    encoder = _ParamEncoder(hidden_size=64, patch_size=16)
+    mock_auto = MagicMock()
+    mock_auto.from_pretrained = lambda *_a, **_k: encoder
+    monkeypatch.setattr(models_mod, "AutoModel", mock_auto)
+    return models_mod.LinearDINOv3(num_classes=3, input_size=(32, 32))
+
+
+def _forward(model):
+    return model(torch.randn(2, 3, 32, 32)).logits
+
+
+def test_freeze_unfreeze_toggles_flag_and_requires_grad(model):
+    assert model._encoder_frozen is False
+    model.freeze_encoder()
+    assert model._encoder_frozen is True
+    assert all(not p.requires_grad for p in model.encoder.parameters())
+    model.unfreeze_encoder()
+    assert model._encoder_frozen is False
+    assert all(p.requires_grad for p in model.encoder.parameters())
+
+
+def test_frozen_forward_shape(model):
+    model.freeze_encoder()
+    logits = _forward(model)
+    assert logits.shape == (2, 3, 32, 32)
+
+
+def test_frozen_gate_keeps_backbone_out_of_the_graph(model):
+    """With the frozen gate on, no gradient reaches the encoder param even if
+    requires_grad=True."""
+    model.freeze_encoder()
+    # Isolate the no_grad gate from the requires_grad=False freeze: re-enable grad on the param.
+    for p in model.encoder.parameters():
+        p.requires_grad_(True)
+    _forward(model).sum().backward()
+    assert model.encoder.scale.grad is None  # no_grad gate skipped the backbone graph
+    assert model.head.classifier.weight.grad is not None  # the head still trains
+
+
+def test_unfrozen_forward_tracks_the_backbone(model):
+    """The contrast: unfrozen, the same forward builds the graph through the encoder
+    param."""
+    assert model._encoder_frozen is False
+    _forward(model).sum().backward()
+    assert model.encoder.scale.grad is not None
+    assert model.head.classifier.weight.grad is not None

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -95,7 +95,8 @@ def test_create_annotation_mask_with_padding():
 
 
 def test_create_annotation_mask_padding_bounds_clamped():
-    """Large padding at image corners must clamp to bounds without raising IndexError."""
+    """Large padding at image corners must clamp to bounds without raising
+    IndexError."""
     annotations = _make_annotations([0, 19], [0, 19], ["Coral", "Coral"])
     mask = create_annotation_mask(annotations, (20, 20), {"Coral": 1}, padding=5)
 
@@ -156,7 +157,8 @@ def test_base_dataset_set_global_offset_validates_negative(minimal_dataset):
 
 
 def test_base_dataset_set_global_offset_shifts_mask_via_helper():
-    """Verify offset arithmetic on the helper directly: offset=10 → values become 11/12."""
+    """Verify offset arithmetic on the helper directly: offset=10 → values become
+    11/12."""
     minimal_mask = np.array([[0, 1, 2], [2, 0, 1]], dtype=np.int64)
     offset = 10
     shifted = np.where(minimal_mask > 0, minimal_mask + offset, minimal_mask)
@@ -252,3 +254,69 @@ def test_base_dataset_saves_failure_report_as_parquet(single_image_annotations, 
     saved_df = pd.read_parquet(output_path)
     assert len(saved_df) == 1
     assert saved_df.iloc[0]["image_id"] == "img1"
+
+
+# --- BaseCoralDataset O(1) annotation lookup (Ticket 1b) ---
+
+
+class _StubImageDataset(BaseCoralDataset):
+    """Minimal subclass returning a fixed blank image so _load_item runs offline."""
+
+    def read_image(self, **row_kwargs: Any) -> np.ndarray:
+        return np.zeros((32, 32, 3), dtype=np.uint8)
+
+
+@pytest.fixture
+def multi_annotation_dataset() -> _StubImageDataset:
+    """Dataset with a multi-annotation image, a single-annotation image, and an image
+    that has no annotations at all (present only in df_images)."""
+    df_annotations = pd.DataFrame(
+        {
+            "image_id": ["img1", "img1", "img2"],
+            "source_label_name": ["Coral", "Sand", "Coral"],
+            "row": [1, 5, 9],
+            "col": [2, 6, 10],
+        }
+    )
+    df_images = pd.DataFrame({"image_id": ["img1", "img2", "img3_empty"]})
+    return _StubImageDataset(df_annotations=df_annotations, df_images=df_images)
+
+
+def test_annotation_positions_match_boolean_scan(multi_annotation_dataset):
+    """The O(1) positional index reproduces the old O(N) boolean-scan selection
+    exactly."""
+    ds = multi_annotation_dataset
+    cols = ["row", "col", "source_label_name"]
+    for image_id in ("img1", "img2"):
+        expected = ds.df_annotations.loc[ds.df_annotations["image_id"] == image_id, cols]
+        positions = ds._annotation_positions_by_image[image_id]
+        got = ds.df_annotations.iloc[positions][cols]
+        pd.testing.assert_frame_equal(got.reset_index(drop=True), expected.reset_index(drop=True))
+
+
+def test_annotation_positions_absent_for_unannotated_image(multi_annotation_dataset):
+    """Images with no annotations are simply absent from the lookup (→ empty mask)."""
+    assert multi_annotation_dataset._annotation_positions_by_image.get("img3_empty") is None
+
+
+def test_load_item_paints_all_annotations_of_target_image(multi_annotation_dataset):
+    """_load_item builds a mask from every annotation of the looked-up image, and
+    nothing else."""
+    ds = multi_annotation_dataset
+    idx = int(ds.df_images.index[ds.df_images["image_id"] == "img1"][0])
+    _image, mask = ds._load_item(idx)
+    assert mask.shape == (32, 32)
+    assert mask[1, 2] == ds.source_name2id["Coral"]
+    assert mask[5, 6] == ds.source_name2id["Sand"]
+    # img2's annotation must not leak into img1's mask; unannotated pixels stay background.
+    assert mask[9, 10] == 0
+    assert mask[0, 0] == 0
+
+
+def test_load_item_empty_image_yields_zero_mask(multi_annotation_dataset):
+    """An image with no annotations produces an all-background mask, not a crash."""
+    ds = multi_annotation_dataset
+    idx = int(ds.df_images.index[ds.df_images["image_id"] == "img3_empty"][0])
+    _image, mask = ds._load_item(idx)
+    assert mask.shape == (32, 32)
+    assert int(mask.sum()) == 0


### PR DESCRIPTION
## Why

The issue-12 DINOv3 linear-probe baseline (MLflow run `f1cf7811…`) was **~85% data-loading-bound** at `3.25 samples/s`, with the GPU using only **2.85 GB of 24 GB**. This branch takes the **code/model** levers to cut that tax. The ETL-side lever (a smaller image tier) is intentionally **deferred** — this phase is model development only.

## Changes (4 commits)

- **`perf(datasets)` (`d440389`)** — O(1) per-image annotation lookup in `BaseCoralDataset`. `_load_item` filtered annotations with `df_annotations["image_id"] == image_id`, an O(N) boolean scan over the full 24.4M-row frame **per sample, per worker**. Now reuses the `groupby("image_id").indices` already built at init and slices by position. Behavior is unchanged (equivalence + empty-image tests added).
- **`chore(config)` (`38eb574`)** — `batch_size` 8 → 32 (large GPU headroom). LR scaling left as an explicit experiment choice (commented).
- **`style(model)` (`c2f1396`)** — docformatter docstring sweep of `models.py`, split out so the next commit's logic stays clean/reviewable.
- **`perf(model)` (`9fcc4b5`)** — run the **frozen** `LinearDINOv3` encoder under `torch.no_grad()` (adds `_encoder_frozen`, mirroring `_DPTDINOv3Base`). It was building the autograd graph over the frozen backbone (why batch 8 used 2.85 GB); gating it frees activation memory (enables batch 64+) and skips backward work through the backbone. **Numerics unchanged** — a frozen backbone already produced no encoder gradients.

## Testing

- `tests/test_datasets.py` (incl. 4 new), `tests/test_dataset_stats.py`, `tests/datasets/` (CoralNet, **168**), `tests/model/` (incl. **4 new** frozen-encoder tests) — all green.
- The frozen-encoder tests prove the *gate* (not just the freeze): with a mock encoder holding a real parameter, a frozen forward leaves that param's grad `None` even with `requires_grad=True`; unfrozen, it populates.
- Micro-benchmark: **6.10 ms → 0.06 ms** per annotation lookup at 2M rows (~96×).

## Not included / follow-ups

- The **~768 px image tier** (the biggest download+decode win) is ETL work — **deferred this phase**.
- Pre-existing (unrelated): two train-step tests in `tests/test_integration.py` call `.backward()` on the loss wrapper's `(loss, components)` tuple — flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
