### PR TITLE
feat(eval): frequency-weighted mIoU + fix broken train-step tests

### DIFF
--- a/mermaidseg/model/eval.py
+++ b/mermaidseg/model/eval.py
@@ -72,6 +72,14 @@ class Evaluator:
                 # informative segmentation metric than pixel accuracy, which is dominated by
                 # majority classes (e.g. background) in class-imbalanced coral reef data.
                 "miou": JaccardIndex(**shared_kwargs, average="macro").to(device),
+                # `miou` (macro) weights every *present* class equally — a rare class counts as
+                # much as a common one (torchmetrics macro already excludes classes absent from
+                # the target). `miou_weighted` weights each class's IoU by its support, so comparing
+                # the two shows whether a change helps rare vs common classes. It is a scalar (like
+                # accuracy/miou) and MUST always be produced when classification metrics are on:
+                # metric_policy advertises it as a selectable metric_of_interest, so gating it (e.g.
+                # behind per_class_metrics) would crash checkpoint/early-stopping when it's selected.
+                "miou_weighted": JaccardIndex(**shared_kwargs, average="weighted").to(device),
             }
             if per_class_metrics:
                 # average="none" returns a per-class vector instead of a scalar; Logger
@@ -166,8 +174,9 @@ class Evaluator:
             return
         if preds.ndim > 3:
             preds = preds.argmax(dim=1)
+        preds = preds.detach()
         for metric in self.metric_dict.values():
-            metric.update(preds.detach(), targets)
+            metric.update(preds, targets)
 
     def compute_and_reset(
         self, include_concepts: bool = False

--- a/mermaidseg/model/metric_policy.py
+++ b/mermaidseg/model/metric_policy.py
@@ -10,6 +10,7 @@ METRIC_POLICY = {
     "loss": "min",
     "accuracy": "max",
     "miou": "max",
+    "miou_weighted": "max",
     "f1-score": "max",
 }
 

--- a/tests/model/test_eval.py
+++ b/tests/model/test_eval.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 import torch
 
 from mermaidseg.model.eval import Evaluator
+from mermaidseg.model.metric_policy import extract_metric_value
 
 NUM_CLASSES = 4
 
@@ -38,12 +40,16 @@ class TestPerClassMetricsToggle:
         evaluator = Evaluator(num_classes=NUM_CLASSES, device="cpu")
         assert "f1_per_class" not in evaluator.metric_dict
         assert "iou_per_class" not in evaluator.metric_dict
-        assert set(evaluator.metric_dict) == {"accuracy", "miou"}
+        # miou_weighted is a scalar aggregate produced whenever classification metrics are on
+        # (it is selectable as metric_of_interest), independent of the per-class vectors.
+        assert set(evaluator.metric_dict) == {"accuracy", "miou", "miou_weighted"}
 
     def test_enabled_adds_per_class_metrics(self):
         evaluator = Evaluator(num_classes=NUM_CLASSES, device="cpu", per_class_metrics=True)
         assert "f1_per_class" in evaluator.metric_dict
         assert "iou_per_class" in evaluator.metric_dict
+        # miou_weighted is always present (a scalar); the per-class vectors are the per_class add-on.
+        assert "miou_weighted" in evaluator.metric_dict
 
     def test_no_op_when_classification_disabled(self):
         """per_class_metrics should not resurrect classification metrics on its own."""
@@ -90,3 +96,39 @@ class TestPerClassMetricsComputation:
 
         np.testing.assert_allclose(results["f1_per_class"], np.ones(NUM_CLASSES))
         np.testing.assert_allclose(results["iou_per_class"], np.ones(NUM_CLASSES))
+
+
+class TestMiouAggregates:
+    """`miou_weighted` (support-weighted) is a distinct, complementary view of macro
+    `miou`."""
+
+    def test_weighted_differs_from_macro_which_excludes_absent(self):
+        # 4 classes, class 0 ignored (default). Target uses class 1 (support 6) and class 2
+        # (support 2); class 3 is absent. class-1 IoU = 6/7, class-2 IoU = 1/2.
+        evaluator = Evaluator(num_classes=NUM_CLASSES, device="cpu", per_class_metrics=True)
+        targets = torch.tensor([[1, 1, 1, 1, 1, 1, 2, 2]])
+        preds = torch.tensor([[1, 1, 1, 1, 1, 1, 2, 1]])
+        results = evaluator.evaluate_model(_make_dataloader(targets), _StubMetaModel([preds]))
+
+        iou1, iou2 = 6 / 7, 1 / 2
+        macro = (iou1 + iou2) / 2  # torchmetrics macro excludes the absent class 3
+        weighted = (6 * iou1 + 2 * iou2) / 8  # support-weighted (class 1 dominates)
+
+        assert results["miou"] == pytest.approx(macro, abs=1e-4)
+        assert results["miou_weighted"] == pytest.approx(weighted, abs=1e-4)
+        # Distinct signal: prevalence weighting != equal-per-class weighting.
+        assert abs(results["miou_weighted"] - results["miou"]) > 1e-3
+
+    def test_weighted_present_and_selectable_without_per_class_metrics(self):
+        # Regression: miou_weighted is a selectable metric_of_interest, so it must be produced
+        # even with per_class_metrics off (concept/CBM default, or --no-per-class-metrics) —
+        # otherwise checkpoint/early-stopping crash when it's chosen.
+        evaluator = Evaluator(num_classes=NUM_CLASSES, device="cpu")  # per_class_metrics=False
+        targets = torch.tensor([[1, 1, 2, 2]])
+        results = evaluator.evaluate_model(
+            _make_dataloader(targets), _StubMetaModel([targets.clone()])
+        )
+        assert "miou_weighted" in results
+        assert extract_metric_value("miou_weighted", 0.0, results) == pytest.approx(
+            results["miou_weighted"]
+        )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -57,7 +57,7 @@ def test_one_train_step_forward_backward(minimal_config, tiny_loader, make_meta_
     assert hasattr(outputs, "logits")
     assert outputs.logits.shape[-2:] == IMAGE_SIZE
 
-    loss = meta.loss(outputs.logits, masks)
+    loss, _ = meta.loss(outputs.logits, masks)
     assert torch.isfinite(loss), f"Loss is not finite: {loss}"
 
     loss.backward()
@@ -78,7 +78,7 @@ def test_one_train_step_updates_model_weights(minimal_config, tiny_loader, make_
         pre_weights[name] = param.clone()
 
     outputs = meta.model(images)
-    loss = meta.loss(outputs.logits, masks)
+    loss, _ = meta.loss(outputs.logits, masks)
     loss.backward()
     meta.optimizer.step()
     meta.optimizer.zero_grad()

--- a/tests/test_metric_policy.py
+++ b/tests/test_metric_policy.py
@@ -29,7 +29,7 @@ class TestCanonicalMetricName:
             canonical_metric_name("precision")
 
     def test_supported_names_are_canonical_only(self):
-        assert SUPPORTED_METRIC_NAMES == ("accuracy", "f1-score", "loss", "miou")
+        assert SUPPORTED_METRIC_NAMES == ("accuracy", "f1-score", "loss", "miou", "miou_weighted")
 
 
 class TestMetricDirection:


### PR DESCRIPTION
Phase-A eval tech-debt.

- `fix(tests)`: the train-step integration tests called `.backward()` on the loss `(loss, components)` tuple — broken, and invisible in CI (`-m "not integration"`). Unpacked.
- `feat(eval)`: add `miou_weighted` (support-weighted mIoU) beside macro `miou`; the two together show whether a change helps rare vs common classes. Always produced when classification metrics are on and selectable as `metric_of_interest` (not gated behind `per_class_metrics`). Present-class mIoU omitted — torchmetrics macro already excludes absent classes.