### PR TITLE
refactor(checkpoint): own the checkpoint format in one module

### DIFF
--- a/mermaidseg/model/checkpoint.py
+++ b/mermaidseg/model/checkpoint.py
@@ -1,0 +1,85 @@
+"""Owns the on-disk checkpoint format so *save* and *load* agree in one place.
+
+Two facts about our checkpoints must be understood identically wherever one is written or
+read (training resume in :mod:`mermaidseg.model.meta`, the demo, tests):
+
+1. **Frozen params are slimmed out.** A frozen backbone is byte-identical across every
+   checkpoint of a run and is re-created when the model is constructed, so the ``Logger``
+   drops those keys (``excludes_frozen_params=True``). Such a checkpoint must load with
+   ``strict=False`` — the missing keys are exactly the (re-initialised) frozen params.
+2. **PEFT (LoRA) wrapping rewrites keys.** ``peft.get_peft_model`` nests the encoder, so a
+   checkpoint's keys can carry extra ``base_model``/``encoder`` nesting relative to a
+   freshly-wrapped model. Keys are normalised before loading so they line up.
+
+Loading never touches ``requires_grad``: the frozen/trainable split comes from how the model
+is constructed (``freeze_encoder``), not from the state dict.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import torch
+
+
+def frozen_param_names(model: torch.nn.Module) -> set[str]:
+    """State-dict keys of parameters with ``requires_grad=False`` (e.g. a frozen
+    backbone)."""
+    return {name for name, param in model.named_parameters() if not param.requires_grad}
+
+
+def slim_state_dict(
+    model: torch.nn.Module, *, save_full: bool = False
+) -> tuple[dict[str, Any], bool]:
+    """Return ``(state_dict, excludes_frozen)`` for saving.
+
+    Frozen parameters are dropped unless ``save_full`` is set. ``excludes_frozen``
+    records whether anything was dropped, so the loader knows to use ``strict=False``.
+    """
+    # Copy tensors to CPU for a portable checkpoint without moving the model itself.
+    full = {
+        key: (value.cpu() if isinstance(value, torch.Tensor) else value)
+        for key, value in model.state_dict().items()
+    }
+    if save_full:
+        return full, False
+    frozen = frozen_param_names(model)
+    slim = {key: value for key, value in full.items() if key not in frozen}
+    return slim, bool(frozen)
+
+
+def normalize_state_dict_keys(state_dict: Mapping[str, Any]) -> dict[str, Any]:
+    """Reconcile PEFT/backbone key nesting so a checkpoint loads into a freshly-built
+    model.
+
+    A no-op for keys that don't carry the extra nesting, so it is always safe to apply.
+    """
+    normalized: dict[str, Any] = {}
+    for key, value in state_dict.items():
+        if key.startswith("encoder.model."):
+            key = key.replace("encoder.model.", "encoder.", 1)
+        if ".base_model.model.model." in key:
+            key = key.replace(".base_model.model.model.", ".base_model.model.", 1)
+        normalized[key] = value
+    return normalized
+
+
+def load_into(model: torch.nn.Module, checkpoint: Any) -> Any:
+    """Load a saved ``checkpoint`` into a freshly-constructed ``model``.
+
+    Accepts either a full checkpoint dict (with ``model_state_dict`` and optional
+    ``excludes_frozen_params``) or a bare state dict. Slimmed checkpoints load
+    ``strict=False`` (the missing keys are the re-initialised frozen backbone);
+    bare/legacy state dicts load ``strict=True`` to still catch real mismatches. Keys
+    are normalised for PEFT nesting first. Returns torch's ``_IncompatibleKeys``
+    (``.missing_keys`` / ``.unexpected_keys``) so callers can assert that nothing
+    *unexpected* was dropped.
+    """
+    if isinstance(checkpoint, dict) and "model_state_dict" in checkpoint:
+        state_dict = checkpoint["model_state_dict"]
+        strict = not checkpoint.get("excludes_frozen_params", False)
+    else:
+        state_dict = checkpoint
+        strict = True
+    return model.load_state_dict(normalize_state_dict_keys(state_dict), strict=strict)

--- a/mermaidseg/model/meta.py
+++ b/mermaidseg/model/meta.py
@@ -24,6 +24,7 @@ from mermaidseg.dataset_reconciliation.label_mapping import (
     source_labels_to_target_labels,
 )
 from mermaidseg.io import ConfigDict
+from mermaidseg.model import checkpoint as checkpoint_io
 
 logger = logging.getLogger(__name__)
 
@@ -37,17 +38,11 @@ _TQDM_MININTERVAL = float(os.getenv("MERMAID_TQDM_MININTERVAL", "60"))
 def _load_checkpoint_into_model(model: torch.nn.Module, checkpoint: Any) -> None:
     """Load a saved checkpoint's weights into a freshly-constructed ``model``.
 
-    Checkpoints saved with ``excludes_frozen_params=True`` (the ``Logger`` default) omit
-    frozen-backbone keys, since the caller's freshly-constructed model already re-
-    initializes the same frozen backbone; those are loaded with ``strict=False``. Legacy
-    checkpoints (no ``excludes_frozen_params`` metadata, or a bare state dict) always
-    carry every key and are loaded with ``strict=True`` to still catch real mismatches.
+    Delegates to :func:`mermaidseg.model.checkpoint.load_into`, which owns the checkpoint
+    format: it normalises PEFT-nested (LoRA) keys and picks ``strict`` based on whether the
+    checkpoint excluded frozen params (the frozen backbone is re-initialised by construction).
     """
-    if isinstance(checkpoint, dict) and "model_state_dict" in checkpoint:
-        strict = not checkpoint.get("excludes_frozen_params", False)
-        model.load_state_dict(checkpoint["model_state_dict"], strict=strict)
-    else:
-        model.load_state_dict(checkpoint)
+    checkpoint_io.load_into(model, checkpoint)
 
 
 def _resolve_amp_dtype(dtype_config: Any | None) -> torch.dtype:

--- a/tests/model/test_checkpoint.py
+++ b/tests/model/test_checkpoint.py
@@ -1,0 +1,82 @@
+"""Round-trip tests for the checkpoint format module (slim / normalize / load)."""
+
+from __future__ import annotations
+
+import torch
+
+from mermaidseg.model.checkpoint import (
+    frozen_param_names,
+    load_into,
+    normalize_state_dict_keys,
+    slim_state_dict,
+)
+
+
+class _Tiny(torch.nn.Module):
+    """A frozen 'backbone' + a trainable 'head', mirroring the frozen-probe shape."""
+
+    def __init__(self):
+        super().__init__()
+        self.encoder = torch.nn.Linear(4, 4)
+        self.head = torch.nn.Linear(4, 2)
+        for param in self.encoder.parameters():
+            param.requires_grad_(False)
+
+
+def test_frozen_param_names_lists_only_backbone():
+    assert frozen_param_names(_Tiny()) == {"encoder.weight", "encoder.bias"}
+
+
+def test_slim_drops_frozen_and_sets_flag():
+    sd, excludes = slim_state_dict(_Tiny())
+    assert excludes is True
+    assert not any(k.startswith("encoder.") for k in sd)
+    assert {"head.weight", "head.bias"} <= set(sd)
+
+
+def test_slim_full_keeps_everything():
+    sd, excludes = slim_state_dict(_Tiny(), save_full=True)
+    assert excludes is False
+    assert any(k.startswith("encoder.") for k in sd)
+
+
+def test_slim_does_not_move_the_model():
+    model = _Tiny()
+    slim_state_dict(model)
+    assert model.encoder.weight.device.type == "cpu"  # unchanged, no hidden .to() side effect
+
+
+def test_normalize_reconciles_peft_nesting():
+    out = normalize_state_dict_keys(
+        {
+            "encoder.base_model.model.model.q_proj.weight": 1,
+            "encoder.model.cls_token": 2,
+            "head.weight": 3,
+        }
+    )
+    assert set(out) == {
+        "encoder.base_model.model.q_proj.weight",  # collapsed one nesting level
+        "encoder.cls_token",  # encoder.model. -> encoder.
+        "head.weight",  # untouched
+    }
+
+
+def test_load_into_roundtrip_slim_restores_head_and_flags_no_unexpected():
+    src = _Tiny()
+    with torch.no_grad():
+        src.head.weight.add_(1.0)  # make the head distinguishable
+    sd, excludes = slim_state_dict(src)
+    ckpt = {"model_state_dict": sd, "excludes_frozen_params": excludes}
+
+    dst = _Tiny()  # fresh: frozen backbone re-initialised
+    result = load_into(dst, ckpt)
+
+    assert result.unexpected_keys == []  # every saved key resolved
+    assert set(result.missing_keys) == frozen_param_names(dst)  # only frozen missing
+    assert torch.equal(dst.head.weight, src.head.weight)  # head restored
+    assert not dst.encoder.weight.requires_grad  # frozen state from construction, not load
+
+
+def test_load_into_bare_state_dict_is_strict():
+    result = load_into(_Tiny(), _Tiny().state_dict())
+    assert result.missing_keys == [] and result.unexpected_keys == []


### PR DESCRIPTION
Checkpoint save (slim frozen params) and load (strict choice + PEFT/LoRA key normalization) were spread across `logger`, `meta`, and the demo; `meta`'s resume path lacked the key normalization (LoRA key-mismatch risk).

Adds `mermaidseg/model/checkpoint.py` (`slim_state_dict` / `normalize_state_dict_keys` / `load_into`) with round-trip tests; `meta` delegates to it. Follow-up: dedupe the logger save side and the demo load onto it.