### PR TITLE
feat(experiment): YAML-first experiment config — offline validate + Experiment loader/dry-run

### DIFF
--- a/mermaidseg/dataset_reconciliation/label_mapping.py
+++ b/mermaidseg/dataset_reconciliation/label_mapping.py
@@ -25,6 +25,19 @@ _CORALNET_SNAPSHOT_PATH = (
 )
 
 
+def load_coralnet_snapshot() -> dict[str, str | None]:
+    """Load the committed CoralNet ``provider_id`` -> target snapshot with no network
+    call.
+
+    The snapshot (``configs/coralnet_to_mermaid_mapping.json``) is the offline fallback
+    for :func:`fetch_coralnet_to_mermaid`. Exposing it lets offline tooling (e.g.
+    experiment-config validation) enumerate known target names without hitting the
+    MERMAID API.
+    """
+    with open(_CORALNET_SNAPSHOT_PATH) as f:
+        return json.load(f)
+
+
 def fetch_mermaid_target_labels(
     benthicattributes_url: str = "https://api.datamermaid.org/v1/benthicattributes/",
 ) -> list[str]:
@@ -88,8 +101,7 @@ def fetch_coralnet_to_mermaid(
             exc,
             _CORALNET_SNAPSHOT_PATH.name,
         )
-        with open(_CORALNET_SNAPSHOT_PATH) as f:
-            return json.load(f)
+        return load_coralnet_snapshot()
 
 
 def fetch_catlin_seaview_to_mermaid() -> dict[str, str]:

--- a/mermaidseg/experiment.py
+++ b/mermaidseg/experiment.py
@@ -1,0 +1,379 @@
+"""YAML-first experiment definition — schema-validate a SageMaker run YAML offline.
+
+An "experiment" is the seg ``config:`` block of a run YAML: the four split-config paths
+(``config_data`` / ``config_model`` / ``config_training`` / ``config_logger``) plus a set of
+CLI ``overrides:``. That block was previously an *unmodeled* raw dict, consumed only by
+``scripts/sagemaker_train_entrypoint.py`` which forwards it to ``scripts/train.py`` as CLI flags
+— so a typo'd ``metric-of-interest``, a missing config file, or a dataset section
+``_run_training`` cannot handle would only surface once a (paid) job was already running.
+
+:class:`ExperimentSpec` models that block; :meth:`Experiment.validate` runs a set of fully
+**offline** checks (no torch model build, no ``SourceLabelRegistry``, no AWS/HF/API call) so a run
+YAML can be checked on a laptop or in CI before launch. The full loader + ``dry-run`` (which
+assemble the real datasets/registry/model) land in a follow-up change.
+
+CLI::
+
+    python -m mermaidseg.experiment validate sagemaker/runs/issue_12_dinov3_baseline.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from mermaidseg.datasets import DATASET_REGISTRY
+from mermaidseg.io import setup_config
+from mermaidseg.model.metric_policy import canonical_metric_name
+from mermaidseg.sagemaker.launcher_config import parse_run_config
+
+# A split value of ``None`` or the literal string ``"None"`` disables that split — this mirrors
+# the skip condition in ``scripts/train.py::_run_training`` (``if split_cfg is None or == "None"``).
+_DISABLED_SPLITS = (None, "None")
+
+
+def _hyphenate(name: str) -> str:
+    """CLI-flag alias for an override field: ``metric_of_interest`` -> ``metric-of-
+    interest``."""
+    return name.replace("_", "-")
+
+
+class Overrides(BaseModel):
+    """The ``overrides:`` sub-block — a typed view of the ``scripts/train.py`` CLI
+    flags.
+
+    Field names are snake_case; each also accepts its hyphenated CLI-flag alias
+    (``run_name`` <-> ``run-name``), because that is how the run YAML and
+    ``scripts/sagemaker_train_entrypoint.py`` spell them. ``extra="forbid"`` turns a
+    mistyped flag (e.g. ``epoch:`` for ``epochs:``) into a validation error instead of a
+    silently-ignored key. Defaults mirror ``_build_parser`` in ``scripts/train.py``.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, alias_generator=_hyphenate)
+
+    run_name: str | None = None
+    experiment_name: str | None = None
+    model: str | None = None
+    model_checkpoint: str | None = None
+    epochs: int | None = None
+    batch_size: int | None = None
+    lr: float | None = None
+    iterations_per_train_epoch: int | None = None
+    iterations_per_val_epoch: int | None = None
+    log_epochs: int | None = None
+    seed: int = 42
+    num_workers: int = 0
+    metric_of_interest: str = "miou"
+    early_stopping: bool = False
+    early_stopping_patience: int = 10
+    early_stopping_min_delta: float = 0.0
+    per_class_metrics: bool | None = None
+    dry_run: bool = False
+    auto_shutdown: bool = False
+    log_dir: str = "logs"
+    failure_report_path: str | None = None
+
+    @field_validator("metric_of_interest")
+    @classmethod
+    def _known_metric(cls, value: str) -> str:
+        # Raises ValueError (-> pydantic ValidationError) for anything not in SUPPORTED_METRIC_NAMES.
+        canonical_metric_name(value)
+        return value
+
+
+class ExperimentSpec(BaseModel):
+    """The seg ``config:`` block of a run YAML — the validatable experiment identity.
+
+    Config-path defaults match ``scripts/sagemaker_train_entrypoint.py`` so validation
+    reflects what the entrypoint would actually run when a path is omitted.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    config_data: str = "configs/data_config.yaml"
+    config_model: str = "configs/model_config_cbm.yaml"
+    config_training: str = "configs/training_config_cbm.yaml"
+    config_logger: str = "configs/logger_config.yaml"
+    overrides: Overrides = Field(default_factory=Overrides)
+
+    # Data-release + mapping identity. Optional and additive: existing run YAMLs pin the CoralNet
+    # corpus via ``job.env.MERMAID_CORALNET_ANNOTATIONS_PATH`` and do not set these, so they keep
+    # validating. The env var remains the runtime source of truth until a later change threads
+    # ``annotations_path`` through the loader.
+    annotations_path: str | None = None
+    mapping_source: Literal["remote", "frozen"] = "remote"
+
+    @property
+    def config_paths(self) -> dict[str, str]:
+        return {
+            "data": self.config_data,
+            "model": self.config_model,
+            "training": self.config_training,
+            "logger": self.config_logger,
+        }
+
+
+@dataclass
+class ValidationReport:
+    """Result of :meth:`Experiment.validate`.
+
+    ``ok`` is true iff there are no hard ``errors``; ``warnings`` are best-effort
+    advisories that do not block a launch. ``summary`` is the resolved experiment
+    (datasets, cohort, metric, ...).
+    """
+
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    summary: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def _format_validation_error(exc: ValidationError) -> str:
+    lines = []
+    for err in exc.errors():
+        loc = ".".join(str(part) for part in err["loc"]) or "(root)"
+        lines.append(f"    - {loc}: {err['msg']}")
+    return "\n".join(lines)
+
+
+def _split_active(split_cfg: Any) -> bool:
+    """Mirror ``_run_training``: a split is active unless it is ``None`` or the string
+    ``"None"``."""
+    return split_cfg not in _DISABLED_SPLITS
+
+
+def offline_target_universe() -> set[str]:
+    """Lowercased MERMAID target names known **without any network call** — the
+    committed CoralNet snapshot plus the static per-source maps.
+
+    Best-effort: names produced only via benthic-hierarchy roll-up are absent (the hierarchy is
+    fetched live), so callers treat misses as warnings rather than errors.
+    """
+    from mermaidseg.dataset_reconciliation import label_mapping as lm
+
+    universe: set[str] = set()
+    static_maps = (
+        lm.load_coralnet_snapshot,
+        lm.fetch_catlin_seaview_to_mermaid,
+        lm.fetch_moorea_labeled_corals_to_mermaid,
+        lm.fetch_pacific_labeled_corals_to_mermaid,
+        lm.fetch_benthos_yuval_to_mermaid,
+        lm.fetch_ucsd_mosaics_to_mermaid,
+        lm.coralscapes_to_mermaid,
+        lm.coralscapes_v2_to_mermaid,
+    )
+    for build_map in static_maps:
+        try:
+            universe |= {value.lower() for value in build_map().values() if value}
+        except Exception:  # noqa: BLE001 — a committed/static map must never break validation
+            continue
+    return universe
+
+
+def _coralnet_cohort(coralnet: Any) -> dict[str, int] | None:
+    """Summarize the CoralNet source cohort (whitelist/blacklist sizes) for the
+    report."""
+    if not isinstance(coralnet, Mapping):
+        return None
+    cohort: dict[str, int] = {}
+    for split in ("train", "val"):
+        split_cfg = coralnet.get(split)
+        if not isinstance(split_cfg, Mapping):
+            continue
+        for key in ("whitelist_sources", "blacklist_sources"):
+            values = split_cfg.get(key)
+            if isinstance(values, (list, tuple)):
+                cohort[f"{split}.{key}"] = len(values)
+    return cohort or None
+
+
+def _build_summary(spec: ExperimentSpec, cfg: Mapping[str, Any]) -> dict[str, Any]:
+    data_block = cfg.get("data") or {}
+    enabled: dict[str, list[str]] = {}
+    for name, splits in data_block.items():
+        if not isinstance(splits, Mapping):
+            continue
+        active = [split for split in ("train", "val") if _split_active(splits.get(split))]
+        if active:
+            enabled[name] = active
+
+    training = cfg.get("training") or {}
+    overrides = spec.overrides
+    return {
+        "config_paths": spec.config_paths,
+        "training_mode": training.get("training_mode"),
+        "datasets_enabled": enabled,
+        "num_class_subset": len(training.get("class_subset") or []) or None,
+        "metric_of_interest": overrides.metric_of_interest,
+        "epochs": overrides.epochs if overrides.epochs is not None else training.get("epochs"),
+        "early_stopping": overrides.early_stopping,
+        "mapping_source": spec.mapping_source,
+        "annotations_path": spec.annotations_path,
+        "coralnet_cohort": _coralnet_cohort(data_block.get("coralnet")),
+    }
+
+
+class Experiment:
+    """A YAML-first experiment.
+
+    For now it carries the validated :class:`ExperimentSpec`; the dataset/registry/model
+    loader and ``dry_run`` (which assemble the real objects) land in a follow-up change.
+    """
+
+    def __init__(self, spec: ExperimentSpec):
+        self.spec = spec
+
+    @classmethod
+    def validate(cls, run_yaml: str | os.PathLike[str]) -> ValidationReport:
+        """Offline-validate a run YAML's ``config:`` block (and its ``job:`` block if
+        present).
+
+        Runs no torch/registry/AWS/API code: parses the YAML, schema-checks the spec,
+        confirms the four config files exist and merge, checks dataset sections against
+        ``DATASET_REGISTRY``, and flags ``class_subset`` names not in the committed
+        mapping universe. Returns a :class:`ValidationReport`; never raises for an
+        invalid config.
+        """
+        report = ValidationReport()
+        path = Path(run_yaml)
+
+        try:
+            text = path.read_text()
+        except OSError as exc:
+            report.errors.append(f"cannot read {path}: {exc}")
+            return report
+        try:
+            raw = yaml.safe_load(os.path.expandvars(text))
+        except yaml.YAMLError as exc:
+            report.errors.append(f"invalid YAML in {path}: {exc}")
+            return report
+        if not isinstance(raw, Mapping):
+            report.errors.append(f"{path}: top level must be a mapping")
+            return report
+
+        # Job block (optional): reuse the launcher's schema so `validate` covers the whole run YAML.
+        if "job" in raw:
+            try:
+                parse_run_config(text, kind="training", strict=False)
+            except ValidationError as exc:
+                report.errors.append("job: block is invalid:\n" + _format_validation_error(exc))
+
+        config_block = raw.get("config")
+        if config_block is None:
+            report.errors.append("run YAML is missing the top-level `config:` block")
+            return report
+
+        try:
+            spec = ExperimentSpec.model_validate(config_block)
+        except ValidationError as exc:
+            report.errors.append("config: block is invalid:\n" + _format_validation_error(exc))
+            return report
+
+        # Do the referenced config files exist?
+        missing = {sect: p for sect, p in spec.config_paths.items() if not Path(p).is_file()}
+        for sect, path_str in missing.items():
+            report.errors.append(f"{sect} config file not found: {path_str}")
+        if missing:
+            return report
+
+        # Load + merge them (offline: YAML + albumentations compile only).
+        try:
+            cfg = setup_config(spec.config_paths)
+        except Exception as exc:  # noqa: BLE001 — surface any load/merge failure as a clean error
+            report.errors.append(f"failed to load/merge config files: {exc}")
+            return report
+
+        _check_datasets(cfg, report)
+        _check_class_subset(cfg, report)
+
+        report.summary = _build_summary(spec, cfg)
+        return report
+
+
+def _check_datasets(cfg: Mapping[str, Any], report: ValidationReport) -> None:
+    """Dataset sections must match ``DATASET_REGISTRY`` exactly.
+
+    ``_run_training`` iterates the full registry and does ``cfg.data[name]``, so a
+    missing key would ``KeyError`` at runtime and an extra key is a silently-ignored
+    typo.
+    """
+    data_block = cfg.get("data") or {}
+    declared = set(data_block)
+    registry = set(DATASET_REGISTRY)
+    for name in sorted(registry - declared):
+        report.errors.append(
+            f"data config missing dataset '{name}' (the training run iterates DATASET_REGISTRY in "
+            "full and would KeyError). Declare it, disabling splits with None."
+        )
+    for name in sorted(declared - registry):
+        report.errors.append(
+            f"data config has unknown dataset '{name}' (not in DATASET_REGISTRY; it would be "
+            "silently ignored). Likely a typo."
+        )
+
+
+def _check_class_subset(cfg: Mapping[str, Any], report: ValidationReport) -> None:
+    training = cfg.get("training") or {}
+    class_subset = training.get("class_subset") or []
+    if not class_subset:
+        return
+    universe = offline_target_universe()
+    unknown = [name for name in class_subset if str(name).lower() not in universe]
+    if unknown:
+        report.warnings.append(
+            f"{len(unknown)} class_subset name(s) not found in the committed mapping universe "
+            "(they may be produced via label roll-up — confirm with `dry-run`): "
+            + ", ".join(map(str, unknown))
+        )
+
+
+def _render_report(path: Path, report: ValidationReport) -> str:
+    lines = [f"[{'OK' if report.ok else 'INVALID'}] {path}"]
+    for err in report.errors:
+        lines.append(f"  ERROR: {err}")
+    for warn in report.warnings:
+        lines.append(f"  warning: {warn}")
+    if report.summary:
+        lines.append("  summary:")
+        for key, value in report.summary.items():
+            lines.append(f"    {key}: {value}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m mermaidseg.experiment",
+        description="Validate a SageMaker run YAML's experiment (`config:`) block.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    validate_parser = subparsers.add_parser(
+        "validate", help="offline schema + static checks (no AWS/HF/network)"
+    )
+    validate_parser.add_argument(
+        "run_yaml", type=Path, nargs="+", help="run YAML file(s) to validate"
+    )
+    args = parser.parse_args(argv)
+
+    if args.command == "validate":
+        all_ok = True
+        for path in args.run_yaml:
+            report = Experiment.validate(path)
+            print(_render_report(Path(path), report))
+            all_ok = all_ok and report.ok
+        return 0 if all_ok else 1
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mermaidseg/experiment.py
+++ b/mermaidseg/experiment.py
@@ -1,20 +1,25 @@
-"""YAML-first experiment definition — schema-validate a SageMaker run YAML offline.
+"""YAML-first experiment definition — validate, load, and dry-run a SageMaker run YAML.
 
 An "experiment" is the seg ``config:`` block of a run YAML: the four split-config paths
-(``config_data`` / ``config_model`` / ``config_training`` / ``config_logger``) plus a set of
-CLI ``overrides:``. That block was previously an *unmodeled* raw dict, consumed only by
-``scripts/sagemaker_train_entrypoint.py`` which forwards it to ``scripts/train.py`` as CLI flags
-— so a typo'd ``metric-of-interest``, a missing config file, or a dataset section
-``_run_training`` cannot handle would only surface once a (paid) job was already running.
+(``config_data`` / ``config_model`` / ``config_training`` / ``config_logger``) plus a set of CLI
+``overrides:``. That block was previously an *unmodeled* raw dict, consumed only by
+``scripts/sagemaker_train_entrypoint.py`` which forwards it to ``scripts/train.py`` as CLI flags —
+so a typo'd ``metric-of-interest``, a missing config file, or a dataset section ``_run_training``
+cannot handle would only surface once a (paid) job was already running.
 
-:class:`ExperimentSpec` models that block; :meth:`Experiment.validate` runs a set of fully
-**offline** checks (no torch model build, no ``SourceLabelRegistry``, no AWS/HF/API call) so a run
-YAML can be checked on a laptop or in CI before launch. The full loader + ``dry-run`` (which
-assemble the real datasets/registry/model) land in a follow-up change.
+This module gives that block one owner:
+
+- :class:`ExperimentSpec` models it (pydantic).
+- :meth:`Experiment.validate` runs fully **offline** checks (no torch/registry/AWS/API) so a run
+  YAML can be checked on a laptop or in CI before launch.
+- :class:`Experiment` also owns the run assembly (datasets -> registry -> model -> evaluator) that
+  ``scripts/train.py`` used to inline, so the CLI, a notebook, and :meth:`Experiment.dry_run` all
+  build the same objects the same way instead of re-deriving them.
 
 CLI::
 
     python -m mermaidseg.experiment validate sagemaker/runs/issue_12_dinov3_baseline.yaml
+    python -m mermaidseg.experiment dry-run  sagemaker/runs/issue_12_dinov3_baseline.yaml
 """
 
 from __future__ import annotations
@@ -27,11 +32,22 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
+import torch
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from torch.utils.data import ConcatDataset, DataLoader
 
-from mermaidseg.datasets import DATASET_REGISTRY
-from mermaidseg.io import setup_config
+from mermaidseg.dataset_reconciliation import (
+    ConceptSchema,
+    SourceLabelRegistry,
+    attach_registry,
+    prepare_splits_for_registry,
+)
+from mermaidseg.datasets import DATASET_REGISTRY, BaseCoralDataset, worker_init_fn
+from mermaidseg.io import ConfigDict as RunConfigDict
+from mermaidseg.io import setup_config, update_config_with_args
+from mermaidseg.model.eval import Evaluator
+from mermaidseg.model.meta import MetaModel
 from mermaidseg.model.metric_policy import canonical_metric_name
 from mermaidseg.sagemaker.launcher_config import parse_run_config
 
@@ -57,7 +73,12 @@ class Overrides(BaseModel):
     silently-ignored key. Defaults mirror ``_build_parser`` in ``scripts/train.py``.
     """
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True, alias_generator=_hyphenate)
+    model_config = ConfigDict(
+        extra="forbid",
+        populate_by_name=True,
+        alias_generator=_hyphenate,
+        protected_namespaces=(),
+    )
 
     run_name: str | None = None
     experiment_name: str | None = None
@@ -137,6 +158,344 @@ class ValidationReport:
     @property
     def ok(self) -> bool:
         return not self.errors
+
+
+def _spec_from_args(args: argparse.Namespace) -> ExperimentSpec:
+    """Build an :class:`ExperimentSpec` from ``scripts/train.py`` argparse args.
+
+    Uses ``getattr`` defaults matching ``_build_parser`` so a partial ``Namespace``
+    (e.g. from a test) still resolves; the resulting spec drives the same config merge
+    the CLI always used.
+    """
+
+    def g(name: str, default: Any = None) -> Any:
+        return getattr(args, name, default)
+
+    overrides = Overrides(
+        run_name=g("run_name"),
+        experiment_name=g("experiment_name"),
+        model=g("model"),
+        model_checkpoint=g("model_checkpoint"),
+        epochs=g("epochs"),
+        batch_size=g("batch_size"),
+        lr=g("lr"),
+        iterations_per_train_epoch=g("iterations_per_train_epoch"),
+        iterations_per_val_epoch=g("iterations_per_val_epoch"),
+        log_epochs=g("log_epochs"),
+        seed=g("seed", 42),
+        num_workers=g("num_workers", 0),
+        metric_of_interest=g("metric_of_interest", "miou"),
+        early_stopping=g("early_stopping", False),
+        early_stopping_patience=g("early_stopping_patience", 10),
+        early_stopping_min_delta=g("early_stopping_min_delta", 0.0),
+        per_class_metrics=g("per_class_metrics"),
+        dry_run=g("dry_run", False),
+        auto_shutdown=g("auto_shutdown", False),
+        log_dir=g("log_dir", "logs"),
+        failure_report_path=g("failure_report_path"),
+    )
+    return ExperimentSpec(
+        config_data=g("config_data", "configs/data_config.yaml"),
+        config_model=g("config_model", "configs/model_config_cbm.yaml"),
+        config_training=g("config_training", "configs/training_config_cbm.yaml"),
+        config_logger=g("config_logger", "configs/logger_config.yaml"),
+        overrides=overrides,
+    )
+
+
+def _apply_overrides_to_config(cfg: RunConfigDict, overrides: Overrides) -> RunConfigDict:
+    """Merge overrides into the config via the SAME path the CLI always used.
+
+    Reuses ``mermaidseg.io.update_config_with_args`` (which reads snake_case attributes)
+    by handing it a ``Namespace`` of the override values, so ``Experiment.from_args`` is
+    byte-identical to the legacy ``setup_config(...) + update_config_with_args(cfg,
+    args)`` and the notebook/YAML path merges the same way.
+    """
+    return update_config_with_args(cfg, argparse.Namespace(**overrides.model_dump()))
+
+
+def load_spec(run_yaml: str | os.PathLike[str]) -> ExperimentSpec:
+    """Parse a run YAML's ``config:`` block into an :class:`ExperimentSpec` (ignores
+    ``job:``)."""
+    raw = yaml.safe_load(os.path.expandvars(Path(run_yaml).read_text()))
+    if not isinstance(raw, Mapping) or raw.get("config") is None:
+        raise ValueError(f"{run_yaml}: missing top-level `config:` block")
+    return ExperimentSpec.model_validate(raw["config"])
+
+
+class Experiment:
+    """A YAML-first experiment: a validated spec plus the run assembly built from it.
+
+    The assembly (dataset construction -> :class:`SourceLabelRegistry` -> :class:`MetaModel` ->
+    :class:`Evaluator`) is the code ``scripts/train.py::_run_training`` used to inline. Concentrating
+    it here lets the CLI, notebooks, and :meth:`dry_run` build identical objects. Heavy pieces are
+    built lazily and cached, so constructing an ``Experiment`` (or calling :meth:`validate`) touches
+    no S3/GPU until you ask for datasets/registry/model.
+    """
+
+    def __init__(
+        self,
+        spec: ExperimentSpec,
+        config: RunConfigDict,
+        *,
+        device: torch.device | None = None,
+    ):
+        self.spec = spec
+        self.config = config
+        self.device = device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self._dataset_dict: dict[tuple[str, str], object] | None = None
+        self._registry: SourceLabelRegistry | None = None
+        self._schema: ConceptSchema | None = None
+        self._compute_concepts = False
+        self.train_dataset: ConcatDataset | None = None
+        self.val_dataset: ConcatDataset | None = None
+
+    # -- construction --------------------------------------------------------------------------
+
+    @classmethod
+    def from_spec(cls, spec: ExperimentSpec, *, device: torch.device | None = None) -> Experiment:
+        cfg = setup_config(spec.config_paths)
+        _apply_overrides_to_config(cfg, spec.overrides)
+        return cls(spec, cfg, device=device)
+
+    @classmethod
+    def from_args(
+        cls, args: argparse.Namespace, *, device: torch.device | None = None
+    ) -> Experiment:
+        """CLI constructor.
+
+        Behaviorally identical to the legacy setup_config + override merge.
+        """
+        return cls.from_spec(_spec_from_args(args), device=device)
+
+    @classmethod
+    def from_run_yaml(
+        cls, run_yaml: str | os.PathLike[str], *, device: torch.device | None = None
+    ) -> Experiment:
+        """Notebook/entrypoint constructor: load the ``config:`` block, ignore
+        ``job:``."""
+        return cls.from_spec(load_spec(run_yaml), device=device)
+
+    @property
+    def overrides(self) -> Overrides:
+        return self.spec.overrides
+
+    # -- assembly ------------------------------------------------------------------------------
+
+    def datasets(self) -> dict[tuple[str, str], object]:
+        """The ``(name, split) -> dataset`` map, built once from
+        ``DATASET_REGISTRY``."""
+        if self._dataset_dict is None:
+            cfg = self.config
+            dataset_dict: dict[tuple[str, str], object] = {}
+            for name in DATASET_REGISTRY:
+                for split, split_cfg in cfg.data[name].items():
+                    if split_cfg is None or split_cfg == "None":
+                        continue
+                    dataset_dict[(name, split)] = DATASET_REGISTRY[name](
+                        **split_cfg, padding=cfg.training.padding
+                    )
+                    print(
+                        f"{name:>24s} - {split:<5s}: {len(dataset_dict[(name, split)]):>7d} samples"
+                    )
+            self._dataset_dict = dataset_dict
+        return self._dataset_dict
+
+    @property
+    def registry(self) -> SourceLabelRegistry:
+        """The :class:`SourceLabelRegistry`, built once and attached to every dataset
+        instance."""
+        if self._registry is None:
+            cfg = self.config
+            dataset_dict = self.datasets()
+            concept_mapping_path = cfg.training.get("concept_mapping_path")
+            _, registry_datasets = prepare_splits_for_registry(dataset_dict)
+            run_sources = {ds.SOURCE_NAME for ds in registry_datasets}
+
+            # Standard (non-CBM) mode trains only the segmentation head, so it needs neither a
+            # ConceptSchema nor a concept_mapping_path; building the schema here would crash on
+            # ConceptSchema.from_csv(None, ...). Guard both on training_mode.
+            self._compute_concepts = cfg.training.training_mode != "standard"
+            self._schema = (
+                ConceptSchema.from_csv(concept_mapping_path, sources=run_sources)
+                if self._compute_concepts
+                else None
+            )
+            registry = SourceLabelRegistry(
+                registry_datasets,
+                target_label_subset=cfg.training.class_subset,
+                compute_concepts=self._compute_concepts,
+                concept_mapping_path=concept_mapping_path,
+                concept_schema=self._schema,
+                label_roll_up=cfg.training.get("label_roll_up", False),
+            ).to(self.device)
+            attach_registry(registry, dataset_dict.values())
+            self._registry = registry
+        return self._registry
+
+    def dataloaders(self) -> tuple[DataLoader, DataLoader]:
+        """Build the ``(train, val)`` loaders (ConcatDataset over the active splits)."""
+        cfg = self.config
+        dataset_dict = self.datasets()
+        registry = self.registry  # ensure attach_registry ran before any __getitem__
+
+        loader_kwargs: dict[str, Any] = {
+            "batch_size": cfg.training.batch_size,
+            "num_workers": self.overrides.num_workers,
+            "pin_memory": torch.cuda.is_available(),
+            "drop_last": True,
+            # Drop the (None, None) placeholders BaseCoralDataset returns on load failures so one
+            # bad image leaves the batch instead of crashing default_collate.
+            "collate_fn": BaseCoralDataset.collate_fn,
+        }
+        if self.overrides.num_workers > 0:
+            loader_kwargs["persistent_workers"] = True
+            loader_kwargs["worker_init_fn"] = worker_init_fn
+
+        train_datasets = [ds for (_, split), ds in dataset_dict.items() if split == "train"]
+        val_datasets = [ds for (_, split), ds in dataset_dict.items() if split == "val"]
+        self.train_dataset = ConcatDataset(train_datasets)
+        self.val_dataset = ConcatDataset(val_datasets)
+        train_loader = DataLoader(self.train_dataset, shuffle=True, **loader_kwargs)
+        val_loader = DataLoader(self.val_dataset, shuffle=True, **loader_kwargs)
+
+        print(f"train batches: {len(train_loader)}   val batches: {len(val_loader)}")
+        if self._compute_concepts:
+            assert registry.num_concepts == self._schema.num_channels
+        return train_loader, val_loader
+
+    def meta_model(self) -> MetaModel:
+        """Construct the :class:`MetaModel` from the registry's derived lookups."""
+        cfg = self.config
+        registry = self.registry
+        return MetaModel(
+            run_name=cfg.run_name,
+            num_classes=registry.num_target_classes,
+            num_concepts=registry.num_concepts or None,
+            device=self.device,
+            model_kwargs=cfg.model.copy(),
+            training_kwargs=cfg.training.copy(),
+            source_to_target_lookup=registry.source_to_target,
+            source_to_concepts_lookup=registry.source_to_concepts,
+            concept_matrix=registry.concept_matrix,
+            conceptid2labelid=registry.conceptid2labelid(),
+            concept_value2id=registry.concept_value2id,
+        )
+
+    def evaluator(self) -> Evaluator:
+        """Construct the stock :class:`Evaluator` (per-class default keyed off
+        training_mode)."""
+        cfg = self.config
+        registry = self.registry
+        per_class_metrics = self.overrides.per_class_metrics
+        if per_class_metrics is None:
+            # On for standard segmentation; off for concept/concept-bottleneck, where taxonomic
+            # ranks carry many values and would flood MLflow's metric list by default.
+            per_class_metrics = cfg.training.training_mode == "standard"
+        return Evaluator(
+            num_classes=registry.num_target_classes,
+            device=self.device,
+            calculate_concept_metrics=cfg.training.training_mode != "standard",
+            concept_value2id=registry.concept_value2id,
+            per_class_metrics=per_class_metrics,
+        )
+
+    def dry_run(self) -> dict[str, Any]:
+        """Assemble the full run (datasets -> registry -> model -> evaluator) and pull
+        one batch to confirm the data path, WITHOUT training.
+
+        Uses S3/HF/API exactly as a real run would, so it catches registry-offset,
+        model-channel, and checkpoint-load errors an offline :meth:`validate` cannot.
+        Returns a summary dict.
+        """
+        train_loader, val_loader = self.dataloaders()
+        registry = self.registry
+        self.meta_model()  # constructs the model — raises on wiring/shape errors
+        self.evaluator()
+
+        summary: dict[str, Any] = {
+            "datasets": sorted({name for (name, _) in self.datasets()}),
+            "num_target_classes": registry.num_target_classes,
+            "num_concepts": registry.num_concepts,
+            "train_batches": len(train_loader),
+            "val_batches": len(val_loader),
+            "metric_of_interest": self.overrides.metric_of_interest,
+        }
+        try:
+            images, labels = next(iter(train_loader))
+            summary["train_batch_image_shape"] = tuple(images.shape)
+            summary["train_batch_label_shape"] = tuple(labels.shape)
+        except StopIteration:
+            summary["train_batch"] = "empty (no non-failed samples in the first batch)"
+        return summary
+
+    # -- offline validation --------------------------------------------------------------------
+
+    @classmethod
+    def validate(cls, run_yaml: str | os.PathLike[str]) -> ValidationReport:
+        """Offline-validate a run YAML's ``config:`` block (and its ``job:`` block if
+        present).
+
+        Runs no torch/registry/AWS/API code: parses the YAML, schema-checks the spec,
+        confirms the four config files exist and merge, checks dataset sections against
+        ``DATASET_REGISTRY``, and flags ``class_subset`` names not in the committed
+        mapping universe. Returns a :class:`ValidationReport`; never raises for an
+        invalid config.
+        """
+        report = ValidationReport()
+        path = Path(run_yaml)
+
+        try:
+            text = path.read_text()
+        except OSError as exc:
+            report.errors.append(f"cannot read {path}: {exc}")
+            return report
+        try:
+            raw = yaml.safe_load(os.path.expandvars(text))
+        except yaml.YAMLError as exc:
+            report.errors.append(f"invalid YAML in {path}: {exc}")
+            return report
+        if not isinstance(raw, Mapping):
+            report.errors.append(f"{path}: top level must be a mapping")
+            return report
+
+        # Job block (optional): reuse the launcher's schema so `validate` covers the whole run YAML.
+        if "job" in raw:
+            try:
+                parse_run_config(text, kind="training", strict=False)
+            except ValidationError as exc:
+                report.errors.append("job: block is invalid:\n" + _format_validation_error(exc))
+
+        config_block = raw.get("config")
+        if config_block is None:
+            report.errors.append("run YAML is missing the top-level `config:` block")
+            return report
+
+        try:
+            spec = ExperimentSpec.model_validate(config_block)
+        except ValidationError as exc:
+            report.errors.append("config: block is invalid:\n" + _format_validation_error(exc))
+            return report
+
+        # Do the referenced config files exist?
+        missing = {sect: p for sect, p in spec.config_paths.items() if not Path(p).is_file()}
+        for sect, path_str in missing.items():
+            report.errors.append(f"{sect} config file not found: {path_str}")
+        if missing:
+            return report
+
+        # Load + merge them (offline: YAML + albumentations compile only).
+        try:
+            cfg = setup_config(spec.config_paths)
+        except Exception as exc:  # noqa: BLE001 — surface any load/merge failure as a clean error
+            report.errors.append(f"failed to load/merge config files: {exc}")
+            return report
+
+        _check_datasets(cfg, report)
+        _check_class_subset(cfg, report)
+
+        report.summary = _build_summary(spec, cfg)
+        return report
 
 
 def _format_validation_error(exc: ValidationError) -> str:
@@ -224,83 +583,6 @@ def _build_summary(spec: ExperimentSpec, cfg: Mapping[str, Any]) -> dict[str, An
     }
 
 
-class Experiment:
-    """A YAML-first experiment.
-
-    For now it carries the validated :class:`ExperimentSpec`; the dataset/registry/model
-    loader and ``dry_run`` (which assemble the real objects) land in a follow-up change.
-    """
-
-    def __init__(self, spec: ExperimentSpec):
-        self.spec = spec
-
-    @classmethod
-    def validate(cls, run_yaml: str | os.PathLike[str]) -> ValidationReport:
-        """Offline-validate a run YAML's ``config:`` block (and its ``job:`` block if
-        present).
-
-        Runs no torch/registry/AWS/API code: parses the YAML, schema-checks the spec,
-        confirms the four config files exist and merge, checks dataset sections against
-        ``DATASET_REGISTRY``, and flags ``class_subset`` names not in the committed
-        mapping universe. Returns a :class:`ValidationReport`; never raises for an
-        invalid config.
-        """
-        report = ValidationReport()
-        path = Path(run_yaml)
-
-        try:
-            text = path.read_text()
-        except OSError as exc:
-            report.errors.append(f"cannot read {path}: {exc}")
-            return report
-        try:
-            raw = yaml.safe_load(os.path.expandvars(text))
-        except yaml.YAMLError as exc:
-            report.errors.append(f"invalid YAML in {path}: {exc}")
-            return report
-        if not isinstance(raw, Mapping):
-            report.errors.append(f"{path}: top level must be a mapping")
-            return report
-
-        # Job block (optional): reuse the launcher's schema so `validate` covers the whole run YAML.
-        if "job" in raw:
-            try:
-                parse_run_config(text, kind="training", strict=False)
-            except ValidationError as exc:
-                report.errors.append("job: block is invalid:\n" + _format_validation_error(exc))
-
-        config_block = raw.get("config")
-        if config_block is None:
-            report.errors.append("run YAML is missing the top-level `config:` block")
-            return report
-
-        try:
-            spec = ExperimentSpec.model_validate(config_block)
-        except ValidationError as exc:
-            report.errors.append("config: block is invalid:\n" + _format_validation_error(exc))
-            return report
-
-        # Do the referenced config files exist?
-        missing = {sect: p for sect, p in spec.config_paths.items() if not Path(p).is_file()}
-        for sect, path_str in missing.items():
-            report.errors.append(f"{sect} config file not found: {path_str}")
-        if missing:
-            return report
-
-        # Load + merge them (offline: YAML + albumentations compile only).
-        try:
-            cfg = setup_config(spec.config_paths)
-        except Exception as exc:  # noqa: BLE001 — surface any load/merge failure as a clean error
-            report.errors.append(f"failed to load/merge config files: {exc}")
-            return report
-
-        _check_datasets(cfg, report)
-        _check_class_subset(cfg, report)
-
-        report.summary = _build_summary(spec, cfg)
-        return report
-
-
 def _check_datasets(cfg: Mapping[str, Any], report: ValidationReport) -> None:
     """Dataset sections must match ``DATASET_REGISTRY`` exactly.
 
@@ -351,10 +633,37 @@ def _render_report(path: Path, report: ValidationReport) -> str:
     return "\n".join(lines)
 
 
+def _cmd_validate(paths: list[Path]) -> int:
+    all_ok = True
+    for path in paths:
+        report = Experiment.validate(path)
+        print(_render_report(Path(path), report))
+        all_ok = all_ok and report.ok
+    return 0 if all_ok else 1
+
+
+def _cmd_dry_run(path: Path) -> int:
+    # Offline schema/static checks first — fail fast without spinning up S3/HF.
+    report = Experiment.validate(path)
+    print(_render_report(path, report))
+    if not report.ok:
+        return 1
+    print(f"[dry-run] assembling {path} (datasets -> registry -> model -> evaluator) ...")
+    try:
+        summary = Experiment.from_run_yaml(path).dry_run()
+    except Exception as exc:  # noqa: BLE001 — report assembly failure as the dry-run result
+        print(f"[FAILED] {type(exc).__name__}: {exc}")
+        return 1
+    print("[OK] assembled:")
+    for key, value in summary.items():
+        print(f"    {key}: {value}")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="python -m mermaidseg.experiment",
-        description="Validate a SageMaker run YAML's experiment (`config:`) block.",
+        description="Validate or dry-run a SageMaker run YAML's experiment (`config:`) block.",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
     validate_parser = subparsers.add_parser(
@@ -363,15 +672,16 @@ def main(argv: list[str] | None = None) -> int:
     validate_parser.add_argument(
         "run_yaml", type=Path, nargs="+", help="run YAML file(s) to validate"
     )
+    dry_run_parser = subparsers.add_parser(
+        "dry-run", help="validate, then assemble the run (needs S3/HF/creds); no training"
+    )
+    dry_run_parser.add_argument("run_yaml", type=Path, help="run YAML file to assemble")
     args = parser.parse_args(argv)
 
     if args.command == "validate":
-        all_ok = True
-        for path in args.run_yaml:
-            report = Experiment.validate(path)
-            print(_render_report(Path(path), report))
-            all_ok = all_ok and report.ok
-        return 0 if all_ok else 1
+        return _cmd_validate(args.run_yaml)
+    if args.command == "dry-run":
+        return _cmd_dry_run(args.run_yaml)
     return 2
 
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -46,23 +46,10 @@ from datetime import datetime
 from pathlib import Path
 
 import torch
-from torch.utils.data import ConcatDataset, DataLoader
 
-from mermaidseg.dataset_reconciliation import (
-    ConceptSchema,
-    SourceLabelRegistry,
-    attach_registry,
-    prepare_splits_for_registry,
-)
-from mermaidseg.datasets import (
-    DATASET_REGISTRY,
-    BaseCoralDataset,
-    worker_init_fn,
-)
-from mermaidseg.io import get_parser, setup_config, update_config_with_args
+from mermaidseg.experiment import Experiment
+from mermaidseg.io import get_parser
 from mermaidseg.logger import Logger
-from mermaidseg.model.eval import Evaluator
-from mermaidseg.model.meta import MetaModel
 from mermaidseg.model.metric_policy import SUPPORTED_METRIC_NAMES
 from mermaidseg.model.train import train_model
 
@@ -339,92 +326,28 @@ def _run_training(args: argparse.Namespace) -> None:
             '    export MLFLOW_TRACKING_URI="arn:aws:sagemaker:us-east-1:ACCOUNT:mlflow-app/APP-ID"'
         )
 
-    cfg = setup_config(
-        {
-            "data": args.config_data,
-            "training": args.config_training,
-            "model": args.config_model,
-            "logger": args.config_logger,
-        }
-    )
-
-    cfg = update_config_with_args(cfg, args)
+    # The Experiment owns config loading, the override merge, and the dataset -> registry -> model
+    # -> evaluator assembly that used to be inlined here (so notebooks and `dry-run` build the same
+    # objects the same way). Process concerns — seeding, dry-run truncation, failure reports, the
+    # Logger/provenance context, and the training loop — stay in this CLI adapter.
+    experiment = Experiment.from_args(args)
+    cfg = experiment.config
     cfg_logger = copy.deepcopy(cfg)
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = experiment.device
     logging.info("Device: %s", device)
 
-    seed = args.seed
+    seed = experiment.overrides.seed
     torch.manual_seed(seed)
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(seed)
     logging.info("Seed: %d", seed)
 
-    # Every dataset constructor accepts ``padding`` (point-annotation datasets use it;
-    # dense/HF datasets accept and ignore it), so instantiation is uniform.
-    dataset_dict: dict[tuple[str, str], object] = {}
-    for name in DATASET_REGISTRY:
-        for split, split_cfg in cfg.data[name].items():
-            if split_cfg is None or split_cfg == "None":
-                continue
-            dataset_dict[(name, split)] = DATASET_REGISTRY[name](
-                **split_cfg, padding=cfg.training.padding
-            )
-            print(f"{name:>24s} - {split:<5s}: {len(dataset_dict[(name, split)]):>7d} samples")
-
-    loader_kwargs = {
-        "batch_size": cfg.training.batch_size,
-        "num_workers": args.num_workers,
-        "pin_memory": torch.cuda.is_available(),
-        "drop_last": True,
-        # Drop the (None, None) placeholders BaseCoralDataset.__getitem__ returns on load
-        # failures (e.g. a missing/renamed S3 object) so one bad image leaves the batch instead
-        # of crashing default_collate — otherwise a single unreadable image kills the whole run.
-        "collate_fn": BaseCoralDataset.collate_fn,
-    }
-    if args.num_workers > 0:
-        loader_kwargs["persistent_workers"] = True
-        loader_kwargs["worker_init_fn"] = worker_init_fn
-
-    concept_mapping_path = cfg.training.get("concept_mapping_path")
-
-    _, registry_datasets = prepare_splits_for_registry(dataset_dict)
-
-    run_sources = {ds.SOURCE_NAME for ds in registry_datasets}
-
-    # Standard (non-CBM) mode trains only the segmentation head — no concept bottleneck — so it
-    # needs neither a ConceptSchema nor a concept_mapping_path. Building the schema here would call
-    # ConceptSchema.from_csv(None, ...) and crash, and the num_concepts assertion below is only
-    # meaningful when concepts are computed. Guard both on training_mode.
-    compute_concepts = cfg.training.training_mode != "standard"
-    schema = (
-        ConceptSchema.from_csv(concept_mapping_path, sources=run_sources)
-        if compute_concepts
-        else None
-    )
-
-    registry = SourceLabelRegistry(
-        registry_datasets,
-        target_label_subset=cfg.training.class_subset,
-        compute_concepts=compute_concepts,
-        concept_mapping_path=concept_mapping_path,
-        concept_schema=schema,
-        label_roll_up=cfg.training.get("label_roll_up", False),
-    ).to(device)
-
-    attach_registry(registry, dataset_dict.values())
-
-    train_datasets = [ds for (_, split), ds in dataset_dict.items() if split == "train"]
-    val_datasets = [ds for (_, split), ds in dataset_dict.items() if split == "val"]
-
-    train_dataset_combined = ConcatDataset(train_datasets)
-    val_dataset_combined = ConcatDataset(val_datasets)
-    train_loader = DataLoader(train_dataset_combined, shuffle=True, **loader_kwargs)
-    val_loader = DataLoader(val_dataset_combined, shuffle=True, **loader_kwargs)
-
-    print(f"train batches: {len(train_loader)}   val batches: {len(val_loader)}")
-    if compute_concepts:
-        assert registry.num_concepts == schema.num_channels
+    train_loader, val_loader = experiment.dataloaders()
+    dataset_dict = experiment.datasets()
+    registry = experiment.registry
+    train_dataset_combined = experiment.train_dataset
+    val_dataset_combined = experiment.val_dataset
 
     logging.info(
         "Dataset: %s (%d samples)",
@@ -440,12 +363,12 @@ def _run_training(args: argparse.Namespace) -> None:
             return
         paths = _save_failure_reports_if_available(
             dataset_dict=dataset_dict,
-            log_dir=Path(args.log_dir),
-            explicit_output_path=args.failure_report_path,
+            log_dir=Path(experiment.overrides.log_dir),
+            explicit_output_path=experiment.overrides.failure_report_path,
         )
         report_written = bool(paths)
 
-    if args.dry_run:
+    if experiment.overrides.dry_run:
         max_dry_epochs = 3
         actual_epochs = cfg.training.epochs
         if actual_epochs > max_dry_epochs:
@@ -459,40 +382,14 @@ def _run_training(args: argparse.Namespace) -> None:
             _write_failure_reports_once()
             raise
 
-    meta_model = MetaModel(
-        run_name=cfg.run_name,
-        num_classes=registry.num_target_classes,
-        num_concepts=registry.num_concepts or None,
-        device=device,
-        model_kwargs=cfg.model.copy(),
-        training_kwargs=cfg.training.copy(),
-        source_to_target_lookup=registry.source_to_target,
-        source_to_concepts_lookup=registry.source_to_concepts,
-        concept_matrix=registry.concept_matrix,
-        conceptid2labelid=registry.conceptid2labelid(),
-        concept_value2id=registry.concept_value2id,
-    )
-
-    per_class_metrics = args.per_class_metrics
-    if per_class_metrics is None:
-        # Default on for standard segmentation (modest class cardinality); off for
-        # concept/concept-bottleneck, where taxonomic ranks (e.g. genus) can carry
-        # far more distinct values and would flood MLflow's metric list by default.
-        per_class_metrics = cfg.training.training_mode == "standard"
-
-    evaluator = Evaluator(
-        num_classes=registry.num_target_classes,
-        device=device,
-        calculate_concept_metrics=cfg.training.training_mode != "standard",
-        concept_value2id=registry.concept_value2id,
-        per_class_metrics=per_class_metrics,
-    )
+    meta_model = experiment.meta_model()
+    evaluator = experiment.evaluator()
 
     # Route the run to an MLflow experiment. --experiment-name (or the run YAML override)
     # wins; otherwise fall back to whatever the logger config declares.
-    if args.experiment_name:
-        cfg.logger.experiment_name = args.experiment_name
-        cfg_logger.logger.experiment_name = args.experiment_name
+    if experiment.overrides.experiment_name:
+        cfg.logger.experiment_name = experiment.overrides.experiment_name
+        cfg_logger.logger.experiment_name = experiment.overrides.experiment_name
 
     with Logger(
         config=cfg_logger,
@@ -527,10 +424,10 @@ def _run_training(args: argparse.Namespace) -> None:
                 val_loader=val_loader,
                 test_loader=None,
                 logger=logger,
-                metric_of_interest=args.metric_of_interest,
-                early_stopping=args.early_stopping,
-                early_stopping_patience=args.early_stopping_patience,
-                early_stopping_min_delta=args.early_stopping_min_delta,
+                metric_of_interest=experiment.overrides.metric_of_interest,
+                early_stopping=experiment.overrides.early_stopping,
+                early_stopping_patience=experiment.overrides.early_stopping_patience,
+                early_stopping_min_delta=experiment.overrides.early_stopping_min_delta,
             )
         finally:
             _write_failure_reports_once()

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,9 +1,13 @@
-"""Tests for offline experiment-config validation (``mermaidseg.experiment``)."""
+"""Tests for the experiment module (``mermaidseg.experiment``): offline validation, the
+config-loading equivalence with the legacy CLI merge, and offline dry-run assembly."""
 
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
+from unittest.mock import patch
 
+import torch
 import yaml
 
 from mermaidseg.experiment import (
@@ -11,6 +15,7 @@ from mermaidseg.experiment import (
     ExperimentSpec,
     offline_target_universe,
 )
+from mermaidseg.io import setup_config, update_config_with_args
 
 REPO = Path(__file__).resolve().parents[1]
 CONFIGS = REPO / "configs"
@@ -186,3 +191,141 @@ def test_offline_universe_is_nonempty_and_has_snapshot_names():
     universe = offline_target_universe()
     assert "acropora" in universe  # from the committed CoralNet snapshot
     assert all(name == name.lower() for name in universe)
+
+
+# --------------------------------------------------------------------------------------
+# Loader: config-merge equivalence, YAML loading, and offline dry-run assembly.
+# --------------------------------------------------------------------------------------
+
+
+def test_from_args_config_matches_legacy_merge(monkeypatch):
+    """Experiment.from_args must produce the same merged config as the legacy CLI path
+    (setup_config + update_config_with_args) — the behavior-preservation guarantee for
+    PR 2."""
+    monkeypatch.chdir(REPO)
+    args = argparse.Namespace(
+        config_data="configs/data_config_coralnet_mermaid.yaml",
+        config_model="configs/model_config.yaml",
+        config_training="configs/training_config_dinov3_linear.yaml",
+        config_logger="configs/logger_config.yaml",
+        run_name="rn",
+        experiment_name="baselines",
+        epochs=7,
+        batch_size=16,
+        lr=0.002,
+        seed=123,
+        num_workers=4,
+        metric_of_interest="miou_weighted",
+        early_stopping=True,
+        early_stopping_patience=5,
+        early_stopping_min_delta=0.01,
+        per_class_metrics=None,
+        dry_run=False,
+        auto_shutdown=False,
+        log_dir="logs",
+        failure_report_path=None,
+        model=None,
+        model_checkpoint=None,
+        iterations_per_train_epoch=None,
+        iterations_per_val_epoch=None,
+        log_epochs=None,
+    )
+    exp = Experiment.from_args(args)
+    legacy = update_config_with_args(
+        setup_config(
+            {
+                "data": args.config_data,
+                "training": args.config_training,
+                "model": args.config_model,
+                "logger": args.config_logger,
+            }
+        ),
+        args,
+    )
+    # Every override-affected field matches the legacy merge.
+    assert exp.config.run_name == legacy.run_name == "rn"
+    assert exp.config.training.epochs == legacy.training.epochs == 7
+    assert exp.config.training.batch_size == legacy.training.batch_size == 16
+    assert exp.config.training.optimizer.lr == legacy.training.optimizer.lr == 0.002
+    # Run-params (not in cfg today) are surfaced on the unified override object.
+    assert exp.overrides.seed == 123
+    assert exp.overrides.metric_of_interest == "miou_weighted"
+    assert exp.overrides.early_stopping is True
+
+
+def test_from_run_yaml_loads_spec_and_applies_overrides(monkeypatch):
+    monkeypatch.chdir(REPO)
+    exp = Experiment.from_run_yaml("sagemaker/runs/issue_12_dinov3_baseline.yaml")
+    assert exp.spec.overrides.metric_of_interest == "miou"
+    assert exp.spec.overrides.early_stopping is True
+    assert exp.config.training.epochs == 200  # override merged into the config
+    assert exp.config.training.training_mode == "standard"
+
+
+class _SyntheticDataset:
+    """Minimal dataset matching the SourceLabelRegistry / DataLoader interface (no
+    S3)."""
+
+    def __init__(self, name: str, num_samples: int = 8, **_ignored):
+        self.SOURCE_NAME = name
+        self._num_samples = num_samples
+        self.source_id2name = {0: "background", 1: "coral"}
+        self.source_name2id = {"background": 0, "coral": 1}
+        self.num_source_classes = 2
+        self._global_offset = 0
+
+    def __len__(self) -> int:
+        return self._num_samples
+
+    def __getitem__(self, _idx: int):
+        return torch.zeros(3, 512, 512), torch.zeros(512, 512, dtype=torch.long)
+
+    def set_global_offset(self, offset: int) -> None:
+        self._global_offset = offset
+
+    def num_load_failures(self) -> int:
+        return 0
+
+
+def test_dry_run_assembles_offline(tmp_path, monkeypatch):
+    """dry_run() assembles datasets -> registry -> (mocked) model -> evaluator and pulls
+    one batch, offline: only MERMAID is active (identity mapping, no live API),
+    label_roll_up off."""
+    monkeypatch.chdir(REPO)
+    data_doc = {"data": {name: {"train": "None", "val": "None"} for name in _ALL_REGISTRY_DATASETS}}
+    data_doc["data"]["mermaid"] = {
+        "train": {},
+        "val": {},
+    }  # both splits active (ConcatDataset needs val)
+    data_cfg = _write(tmp_path, data_doc, name="data.yaml")
+    training_cfg = _write(
+        tmp_path,
+        {
+            "training": {
+                "training_mode": "standard",
+                "padding": 3,
+                "batch_size": 4,
+                "label_roll_up": False,
+                "class_subset": ["coral"],  # MERMAID's identity map emits "coral"
+            }
+        },
+        name="training.yaml",
+    )
+    spec = ExperimentSpec(
+        config_data=str(data_cfg),
+        config_model=str(MODEL),
+        config_training=str(training_cfg),
+        config_logger=str(LOGGER),
+        overrides={"run_name": "dry-run-test"},  # meta_model() reads cfg.run_name
+    )
+    override = {"mermaid": lambda **kw: _SyntheticDataset("mermaid")}
+    with (
+        patch.dict("mermaidseg.experiment.DATASET_REGISTRY", override),
+        patch("mermaidseg.experiment.MetaModel"),
+    ):
+        experiment = Experiment.from_spec(spec, device=torch.device("cpu"))
+        summary = experiment.dry_run()
+
+    assert summary["datasets"] == ["mermaid"]
+    assert summary["train_batches"] == 2  # 8 synthetic samples / batch 4, drop_last
+    assert summary["train_batch_image_shape"] == (4, 3, 512, 512)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,0 +1,188 @@
+"""Tests for offline experiment-config validation (``mermaidseg.experiment``)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from mermaidseg.experiment import (
+    Experiment,
+    ExperimentSpec,
+    offline_target_universe,
+)
+
+REPO = Path(__file__).resolve().parents[1]
+CONFIGS = REPO / "configs"
+
+# Real committed configs used as valid fixtures for the tmp-run-YAML tests.
+DATA = CONFIGS / "data_config_coralnet_mermaid.yaml"
+MODEL = CONFIGS / "model_config.yaml"
+TRAINING = CONFIGS / "training_config_dinov3_linear.yaml"
+LOGGER = CONFIGS / "logger_config.yaml"
+
+_ALL_REGISTRY_DATASETS = (
+    "pacific_labeled_corals",
+    "moorea_labeled_corals",
+    "catlin_seaview",
+    "mermaid",
+    "coralnet",
+    "coralscapes",
+    "coralscapes_v2",
+    "benthos_yuval",
+)
+
+
+def _write(tmp_path: Path, doc: dict, name: str = "run.yaml") -> Path:
+    path = tmp_path / name
+    path.write_text(yaml.safe_dump(doc, sort_keys=False))
+    return path
+
+
+def _config_block(**overrides_and_paths) -> dict:
+    """A `config:` block pointing at the real committed configs, with optional
+    path/override subs."""
+    overrides = overrides_and_paths.pop("overrides", {})
+    block = {
+        "config_data": overrides_and_paths.pop("config_data", str(DATA)),
+        "config_model": overrides_and_paths.pop("config_model", str(MODEL)),
+        "config_training": overrides_and_paths.pop("config_training", str(TRAINING)),
+        "config_logger": overrides_and_paths.pop("config_logger", str(LOGGER)),
+    }
+    if overrides:
+        block["overrides"] = overrides
+    assert not overrides_and_paths, f"unused kwargs: {overrides_and_paths}"
+    return block
+
+
+# --------------------------------------------------------------------------------------
+# Happy path — the committed run YAMLs validate (run from the repo root for relative paths).
+# --------------------------------------------------------------------------------------
+
+
+def test_issue12_run_yaml_validates(monkeypatch):
+    monkeypatch.chdir(REPO)
+    report = Experiment.validate(REPO / "sagemaker/runs/issue_12_dinov3_baseline.yaml")
+    assert report.ok, report.errors
+    assert report.summary["metric_of_interest"] == "miou"
+    assert report.summary["datasets_enabled"].get("coralnet") == ["train", "val"]
+    assert report.summary["datasets_enabled"].get("mermaid") == ["train"]
+
+
+def test_example_run_yaml_validates(monkeypatch):
+    monkeypatch.chdir(REPO)
+    report = Experiment.validate(REPO / "sagemaker/configs/example/run.yaml")
+    assert report.ok, report.errors
+
+
+# --------------------------------------------------------------------------------------
+# Schema errors (caught before any config file is opened).
+# --------------------------------------------------------------------------------------
+
+
+def test_unknown_metric_is_error(tmp_path):
+    run = _write(tmp_path, {"config": _config_block(overrides={"metric-of-interest": "nope"})})
+    report = Experiment.validate(run)
+    assert not report.ok
+    assert any("metric_of_interest" in err for err in report.errors)
+
+
+def test_typo_override_key_is_error(tmp_path):
+    # `epoch` instead of `epochs` — extra="forbid" turns it into an error, not a silent no-op.
+    run = _write(tmp_path, {"config": _config_block(overrides={"epoch": 1})})
+    report = Experiment.validate(run)
+    assert not report.ok
+    assert any("epoch" in err for err in report.errors)
+
+
+def test_missing_config_block_is_error(tmp_path):
+    run = _write(tmp_path, {"job": {"name_prefix": "x"}})
+    report = Experiment.validate(run)
+    assert not report.ok
+    assert any("config:" in err for err in report.errors)
+
+
+# --------------------------------------------------------------------------------------
+# Static semantic errors (need the merged config).
+# --------------------------------------------------------------------------------------
+
+
+def test_missing_config_file_is_error(tmp_path):
+    run = _write(
+        tmp_path,
+        {"config": _config_block(config_data=str(tmp_path / "does_not_exist.yaml"))},
+    )
+    report = Experiment.validate(run)
+    assert not report.ok
+    assert any("data config file not found" in err for err in report.errors)
+
+
+def test_unknown_dataset_is_error(tmp_path):
+    data_cfg = _write(
+        tmp_path,
+        {"data": {name: {} for name in (*_ALL_REGISTRY_DATASETS, "bogus_ds")}},
+        name="data.yaml",
+    )
+    run = _write(tmp_path, {"config": _config_block(config_data=str(data_cfg))})
+    report = Experiment.validate(run)
+    assert not report.ok
+    assert any("unknown dataset 'bogus_ds'" in err for err in report.errors)
+
+
+def test_missing_dataset_is_error(tmp_path):
+    # Declare only two of the eight registry datasets — _run_training would KeyError on the rest.
+    data_cfg = _write(tmp_path, {"data": {"coralnet": {}, "mermaid": {}}}, name="data.yaml")
+    run = _write(tmp_path, {"config": _config_block(config_data=str(data_cfg))})
+    report = Experiment.validate(run)
+    assert not report.ok
+    assert any("missing dataset 'benthos_yuval'" in err for err in report.errors)
+
+
+def test_bad_class_subset_name_is_warning_not_error(tmp_path):
+    training_cfg = _write(
+        tmp_path,
+        {
+            "training": {
+                "training_mode": "standard",
+                "padding": 3,
+                "class_subset": ["Acropora", "ZZZ_NOT_A_REAL_LABEL"],
+            }
+        },
+        name="training.yaml",
+    )
+    run = _write(tmp_path, {"config": _config_block(config_training=str(training_cfg))})
+    report = Experiment.validate(run)
+    assert report.ok, report.errors  # an unknown class name is advisory, not fatal
+    assert any("ZZZ_NOT_A_REAL_LABEL" in warn for warn in report.warnings)
+
+
+# --------------------------------------------------------------------------------------
+# Units.
+# --------------------------------------------------------------------------------------
+
+
+def test_spec_parses_hyphenated_override_aliases():
+    spec = ExperimentSpec.model_validate(
+        {
+            "config_data": "d",
+            "config_model": "m",
+            "config_training": "t",
+            "overrides": {
+                "metric-of-interest": "miou",
+                "early-stopping": True,
+                "early-stopping-patience": 20,
+                "num-workers": 8,
+            },
+        }
+    )
+    assert spec.overrides.metric_of_interest == "miou"
+    assert spec.overrides.early_stopping is True
+    assert spec.overrides.early_stopping_patience == 20
+    assert spec.overrides.num_workers == 8
+    assert spec.mapping_source == "remote"  # additive default
+
+
+def test_offline_universe_is_nonempty_and_has_snapshot_names():
+    universe = offline_target_universe()
+    assert "acropora" in universe  # from the committed CoralNet snapshot
+    assert all(name == name.lower() for name in universe)

--- a/tests/test_standard_pipeline_smoke.py
+++ b/tests/test_standard_pipeline_smoke.py
@@ -77,9 +77,9 @@ def test_standard_mode_training_pipeline_smoke(tmp_path, monkeypatch):
         concept_schema_calls.append((args, kwargs))
         return original_from_csv(*args, **kwargs)
 
-    # Datasets are built via scripts.train.DATASET_REGISTRY[name](...); override its entries.
-    # The standard baseline uses only coralnet + mermaid — every other source has None splits
-    # in the config and must never be instantiated (side_effect guards that).
+    # Datasets are built via mermaidseg.experiment.DATASET_REGISTRY[name](...); override its
+    # entries. The standard baseline uses only coralnet + mermaid — every other source has None
+    # splits in the config and must never be instantiated (side_effect guards that).
     registry_override = {
         "mermaid": MagicMock(return_value=synthetic_mermaid),
         "coralnet": MagicMock(return_value=synthetic_coralnet),
@@ -97,9 +97,9 @@ def test_standard_mode_training_pipeline_smoke(tmp_path, monkeypatch):
     }
 
     patches = [
-        patch.dict("scripts.train.DATASET_REGISTRY", registry_override),
-        patch("scripts.train.ConceptSchema.from_csv", side_effect=tracked_from_csv),
-        patch("scripts.train.MetaModel"),
+        patch.dict("mermaidseg.experiment.DATASET_REGISTRY", registry_override),
+        patch("mermaidseg.experiment.ConceptSchema.from_csv", side_effect=tracked_from_csv),
+        patch("mermaidseg.experiment.MetaModel"),
     ]
 
     with contextlib.ExitStack() as stack:


### PR DESCRIPTION
## Summary

Introduces `mermaidseg/experiment.py` — one owner for the run-YAML `config:` block, which was previously an **unmodeled raw dict** consumed only by `scripts/sagemaker_train_entrypoint.py`. Two commits:

1. **`ExperimentSpec` + offline `validate`** — pydantic schema for the `config:` block (+ hyphen-aliased `overrides`). `python -m mermaidseg.experiment validate <run.yaml>` runs **fully offline** (no torch/registry/AWS/API) and catches a typo'd `metric-of-interest`, a missing config file, and missing/unknown dataset sections *before a paid job launches*; `class_subset` names are checked best-effort against the committed mapping universe. Also adds `load_coralnet_snapshot()`.

2. **`Experiment` loader + `dry-run`** — extracts the dataset→registry→model→evaluator assembly out of `scripts/train.py::_run_training` into `Experiment` (`from_args`/`from_spec`/`from_run_yaml`, `dataloaders`/`registry`/`meta_model`/`evaluator`). `_run_training` now builds an `Experiment` and consumes it — **behavior-preserving**: `from_args` routes through the existing `update_config_with_args`, so the CLI config merge is byte-identical. Adds `python -m mermaidseg.experiment dry-run` (assemble the full run, no training) and lets notebooks `Experiment.from_run_yaml(...)`.

## Testing

- New `tests/test_experiment.py`: validate accept/reject cases, config-merge equivalence with the legacy CLI path, offline dry-run assembly.
- Full suite green: **406 non-integration + 11 integration** pass. Smoke test updated (patch targets moved to `mermaidseg.experiment.*`).

## Notes

- Foundation for YAML-first experiments; **PR3** (de-dup the run YAML) and **PR4** (notebook adapter) follow.
- Overlaps #191 on `scripts/train.py` + `tests/test_standard_pipeline_smoke.py` — intended to land **first** so #191 rebases onto the `Experiment` seam (its per-source `dataset_val_loaders` folds into `Experiment.dataloaders()`).
- Touches the training path → needs `/ml-training-review`.
