### PR TITLE
feat(mermaid): rare-aware region-blocked train/val holdout

### DIFF
--- a/configs/data_config.yaml
+++ b/configs/data_config.yaml
@@ -37,7 +37,14 @@ data:
                           6968, 7116]
 
   mermaid:
-    val: None # We currently have no validation data for the mermaid dataset, so we set this to None to avoid speculation.
+    train:
+      holdout_fraction: 0.1
+      holdout_seed: 42
+      holdout_role: train
+    val:
+      holdout_fraction: 0.1
+      holdout_seed: 42
+      holdout_role: val
 
   coralscapes:
     train: None

--- a/configs/data_config_coralnet_mermaid.yaml
+++ b/configs/data_config_coralnet_mermaid.yaml
@@ -1,14 +1,12 @@
-# Data config for the issue #12 LinearDINOv3 baseline: CoralNet + MERMAID only.
+# Data config for the issue #12 LinearDINOv3 baseline: CoralNet + MERMAID.
 #
-# Unlike configs/data_config.yaml (which trains on a hand-picked 36-source CoralNet
-# whitelist), this baseline uses the FULL CoralNet corpus. Every source is used; the
-# only partitioning is a source-disjoint validation holdout so there is no image/source
-# leakage between train and val:
+# CoralNet uses the FULL corpus with a source-disjoint validation holdout:
 #   - train: all CoralNet sources EXCEPT the val holdout (blacklist_sources)
 #   - val:   the holdout sources (whitelist_sources)
-# The 20 val sources are the vetted holdout carried over from configs/data_config.yaml.
-# MERMAID contributes train only (no confirmed MERMAID validation data yet), consistent
-# with configs/data_config.yaml. All other datasets are disabled for this baseline.
+# MERMAID uses a deterministic 10% image-level holdout (same fraction+seed on
+# train/val so the splits are complements). Checkpointing uses the *combined*
+# CoralNet+MERMAID val loader; MLflow also logs validation/mermaid/* and
+# validation/coralnet/* separately.
 data:
   default:
     train:
@@ -47,7 +45,14 @@ data:
                           6968, 7116]
 
   mermaid:
-    val: None # No confirmed MERMAID validation data; MERMAID contributes train only.
+    train:
+      holdout_fraction: 0.1
+      holdout_seed: 42
+      holdout_role: train
+    val:
+      holdout_fraction: 0.1
+      holdout_seed: 42
+      holdout_role: val
 
   coralscapes:
     train: None

--- a/mermaidseg/datasets/mermaid/mermaid_dataset.py
+++ b/mermaidseg/datasets/mermaid/mermaid_dataset.py
@@ -7,7 +7,8 @@ benthic attribute label space — the canonical target space for this project.
 
 from __future__ import annotations
 
-from typing import Any
+import functools
+from typing import Any, Literal
 
 import boto3
 import numpy as np
@@ -17,24 +18,393 @@ from numpy.typing import NDArray
 from mermaidseg.datasets.base_dataset import BaseCoralDataset
 from mermaidseg.datasets.utils import get_image_s3
 
+RARE_IMAGE_THRESHOLD = 10
+DEFAULT_HOLDOUT_FRACTION = 0.1
+DEFAULT_HOLDOUT_SEED = 42
+DEFAULT_HOLDOUT_ROLE: Literal["train", "val"] = "train"
+_HOLDOUT_MISSING = "__missing__"
+_STRATIFY_COLS = ("benthic_attribute_name", "benthic_attribute_id", "growth_form_name")
+_INVALID_GROWTH_FORMS = frozenset({"", "none", "nan", "<na>", "null"})
+
+
+@functools.lru_cache(maxsize=8)
+def _read_annotations_cached(annotations_path: str) -> pd.DataFrame:
+    """Read the MERMAID annotations parquet once per path and share it.
+
+    Train- and val-role ``MermaidDataset`` instances in the same run both need to split
+    the *identical* annotation set to avoid drifting apart; caching the read (rather
+    than the pure split function) means both roles see the same object without either
+    mutating it in place.
+    """
+    return pd.read_parquet(annotations_path)
+
+
+def mermaid_region_key_series(df_annotations: pd.DataFrame) -> pd.Series:
+    """Return a string region key per annotation row (name with id fallback)."""
+    if "region_name" in df_annotations.columns:
+        names = df_annotations["region_name"].astype(str)
+        if "region_id" in df_annotations.columns:
+            missing = names.isna() | (names.str.lower().isin(["nan", "none", ""]))
+            ids = df_annotations["region_id"].astype(str)
+            names = names.where(~missing, ids)
+        return names
+    if "region_id" in df_annotations.columns:
+        return df_annotations["region_id"].astype(str)
+    raise ValueError("MERMAID holdout requires region_name or region_id columns.")
+
+
+def _prepare_holdout_df(df_annotations: pd.DataFrame) -> pd.DataFrame:
+    df = df_annotations.copy()
+    if "benthic_attribute_name" not in df.columns and "source_label_name" in df.columns:
+        df = df.rename(columns={"source_label_name": "benthic_attribute_name"})
+    df["image_id"] = df["image_id"].astype(str)
+    df["region_name"] = mermaid_region_key_series(df).astype(str)
+    df["benthic_attribute_name"] = df["benthic_attribute_name"].astype(str)
+    if "growth_form_name" in df.columns:
+        df["growth_form_name"] = df["growth_form_name"].astype(str)
+    return df
+
+
+def _is_valid_growth_form(value: object) -> bool:
+    if pd.isna(value):
+        return False
+    return str(value).strip().lower() not in _INVALID_GROWTH_FORMS
+
+
+def _image_label_sets(df_annotations: pd.DataFrame) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    growth_col = "growth_form_name" if "growth_form_name" in df_annotations.columns else None
+    for image_id, group in df_annotations.groupby("image_id", sort=False):
+        growth: set[str] = set()
+        if growth_col is not None:
+            growth = {str(value) for value in group[growth_col] if _is_valid_growth_form(value)}
+        rows.append(
+            {
+                "image_id": str(image_id),
+                "region_name": str(group["region_name"].iloc[0]),
+                "benthic_attribute_names": frozenset(group["benthic_attribute_name"].astype(str)),
+                "growth_form_names": frozenset(growth),
+            }
+        )
+    # Canonical row order regardless of input row order — see _fill_regional_quota,
+    # which iterates images/regions in an order derived from this DataFrame while
+    # consuming a shared RNG, so its output would otherwise depend on annotation
+    # row order rather than only on the seed.
+    return pd.DataFrame(rows).sort_values("image_id").reset_index(drop=True)
+
+
+def _pair_image_index(
+    image_sets: pd.DataFrame,
+    labels_col: Literal["benthic_attribute_names", "growth_form_names"],
+) -> dict[tuple[str, str], list[str]]:
+    index: dict[tuple[str, str], list[str]] = {}
+    for row in image_sets.itertuples(index=False):
+        region = row.region_name
+        for label in getattr(row, labels_col):
+            key = (region, label)
+            index.setdefault(key, []).append(row.image_id)
+    return {key: sorted(set(ids)) for key, ids in index.items()}
+
+
+def _pick_coverage_image(
+    candidate_ids: list[str],
+    val_ids: set[str],
+    val_load: dict[str, int],
+    rng: np.random.Generator,
+) -> str:
+    pool = [image_id for image_id in candidate_ids if image_id not in val_ids] or list(
+        candidate_ids
+    )
+    min_load = min(val_load.get(image_id, 0) for image_id in pool)
+    tied = sorted(image_id for image_id in pool if val_load.get(image_id, 0) == min_load)
+    return str(rng.choice(tied))
+
+
+def _rare_pair_keys(
+    index: dict[tuple[str, str], list[str]],
+) -> list[tuple[int, tuple[str, str], list[str]]]:
+    pairs = [
+        (len(ids), key, ids) for key, ids in index.items() if 2 <= len(ids) < RARE_IMAGE_THRESHOLD
+    ]
+    pairs.sort(key=lambda item: (item[0], item[1][0], item[1][1]))
+    return pairs
+
+
+def _pair_covered(
+    val_ids: set[str],
+    image_lookup: dict[str, Any],
+    region: str,
+    label: str,
+    labels_col: Literal["benthic_attribute_names", "growth_form_names"],
+) -> bool:
+    for image_id in val_ids:
+        row = image_lookup[image_id]
+        if row.region_name == region and label in getattr(row, labels_col):
+            return True
+    return False
+
+
+def _assign_rare_coverage(
+    index: dict[tuple[str, str], list[str]],
+    labels_col: Literal["benthic_attribute_names", "growth_form_names"],
+    image_lookup: dict[str, Any],
+    val_ids: set[str],
+    val_load: dict[str, int],
+    rng: np.random.Generator,
+) -> None:
+    for _, key, candidate_ids in _rare_pair_keys(index):
+        region, label = key
+        if _pair_covered(val_ids, image_lookup, region, label, labels_col):
+            continue
+        chosen = _pick_coverage_image(candidate_ids, val_ids, val_load, rng)
+        val_ids.add(chosen)
+        val_load[chosen] = val_load.get(chosen, 0) + 1
+
+
+def _dominant_benthic_name(group: pd.DataFrame) -> str:
+    return str(group["benthic_attribute_name"].value_counts().index[0])
+
+
+def _fill_regional_quota(
+    df_annotations: pd.DataFrame,
+    image_sets: pd.DataFrame,
+    val_ids: set[str],
+    holdout_fraction: float,
+    rng: np.random.Generator,
+) -> None:
+    dominant = (
+        df_annotations.groupby("image_id", sort=True)
+        .apply(_dominant_benthic_name, include_groups=False)
+        .rename("dominant_benthic_attribute_name")
+        .reset_index()
+    )
+    image_sets = image_sets.merge(dominant, on="image_id", how="left")
+
+    # sort=True is load-bearing: each region below consumes draws from one shared
+    # `rng`, so visiting regions in a canonical (not input-row-order) sequence is
+    # what makes the resulting split depend only on `holdout_seed`.
+    for _region, region_df in image_sets.groupby("region_name", sort=True):
+        region_ids = sorted(region_df["image_id"].astype(str).unique())
+        n = len(region_ids)
+        if n <= 1:
+            continue
+        target = max(1, int(round(n * holdout_fraction)))
+        target = min(target, n - 1)
+        need = target - sum(1 for image_id in region_ids if image_id in val_ids)
+        if need <= 0:
+            continue
+
+        pool = region_df.loc[~region_df["image_id"].isin(val_ids)].copy()
+        if pool.empty:
+            continue
+
+        chosen: list[str] = []
+        by_class = pool.groupby("dominant_benthic_attribute_name", sort=True)
+        class_ids = {
+            str(label): sorted(map(str, ids))
+            for label, ids in by_class["image_id"].apply(list).items()
+        }
+        remaining = need
+        active = {label: ids for label, ids in class_ids.items() if ids}
+        while remaining > 0 and active:
+            for label in sorted(active):
+                if remaining <= 0:
+                    break
+                ids = active[label]
+                if not ids:
+                    continue
+                pick = str(rng.choice(ids))
+                ids.remove(pick)
+                chosen.append(pick)
+                remaining -= 1
+                if not ids:
+                    del active[label]
+            active = {label: ids for label, ids in active.items() if ids}
+
+        val_ids.update(chosen)
+
+
+def select_stratified_holdout_image_ids(
+    df_annotations: pd.DataFrame,
+    *,
+    holdout_fraction: float,
+    holdout_seed: int,
+) -> set[str]:
+    """Rare-aware region-blocked holdout using full per-image label sets."""
+    if not 0.0 < holdout_fraction < 1.0:
+        raise ValueError(f"holdout_fraction must be in (0, 1); got {holdout_fraction}")
+
+    df = _prepare_holdout_df(df_annotations)
+    if df.empty:
+        return set()
+
+    image_sets = _image_label_sets(df)
+    if image_sets.empty:
+        return set()
+
+    image_lookup = {row.image_id: row for row in image_sets.itertuples(index=False)}
+    benthic_index = _pair_image_index(image_sets, "benthic_attribute_names")
+    growth_index = _pair_image_index(image_sets, "growth_form_names")
+
+    rng = np.random.default_rng(holdout_seed)
+    val_ids: set[str] = set()
+    val_load: dict[str, int] = {}
+
+    _assign_rare_coverage(
+        benthic_index, "benthic_attribute_names", image_lookup, val_ids, val_load, rng
+    )
+    _assign_rare_coverage(growth_index, "growth_form_names", image_lookup, val_ids, val_load, rng)
+    _fill_regional_quota(df, image_sets, val_ids, holdout_fraction, rng)
+    return val_ids
+
+
+def _mode_or_missing(series: pd.Series) -> str:
+    values = series.dropna()
+    if values.empty:
+        return _HOLDOUT_MISSING
+    mode = values.astype(str).mode()
+    return str(mode.iloc[0]) if not mode.empty else _HOLDOUT_MISSING
+
+
+def build_image_holdout_features(df_annotations: pd.DataFrame) -> pd.DataFrame:
+    """One row per image with region and mode label features (legacy composite
+    strata)."""
+    df = _prepare_holdout_df(df_annotations)
+    for col in _STRATIFY_COLS:
+        if col not in df.columns:
+            df[col] = _HOLDOUT_MISSING
+
+    rows: list[dict[str, str]] = []
+    for image_id, group in df.groupby("image_id", sort=False):
+        rows.append(
+            {
+                "image_id": str(image_id),
+                "region_name": str(group["region_name"].iloc[0]),
+                "benthic_attribute_name": _mode_or_missing(group["benthic_attribute_name"]),
+                "benthic_attribute_id": _mode_or_missing(group["benthic_attribute_id"]),
+                "growth_form_name": _mode_or_missing(group["growth_form_name"]),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def select_composite_holdout_image_ids(
+    df_annotations: pd.DataFrame,
+    *,
+    holdout_fraction: float,
+    holdout_seed: int,
+) -> set[str]:
+    """Legacy mode-based composite-stratum holdout (for before/after comparisons)."""
+    if not 0.0 < holdout_fraction < 1.0:
+        raise ValueError(f"holdout_fraction must be in (0, 1); got {holdout_fraction}")
+    features = build_image_holdout_features(df_annotations)
+    if features.empty:
+        return set()
+
+    rng = np.random.default_rng(holdout_seed)
+    holdout_ids: set[str] = set()
+    group_cols = ["region_name", *_STRATIFY_COLS]
+    for _, stratum in features.groupby(group_cols, sort=False):
+        ids = sorted(stratum["image_id"].astype(str).tolist())
+        n = len(ids)
+        if n <= 1:
+            continue
+        n_holdout = max(1, int(round(n * holdout_fraction)))
+        n_holdout = min(n_holdout, n - 1)
+        chosen = rng.choice(ids, size=n_holdout, replace=False)
+        holdout_ids.update(str(x) for x in chosen)
+    return holdout_ids
+
+
+def compute_split_quality(
+    df_annotations: pd.DataFrame,
+    val_ids: set[str],
+    *,
+    holdout_fraction: float,
+    rare_image_threshold: int = RARE_IMAGE_THRESHOLD,
+) -> dict[str, Any]:
+    """Summarize rare-class coverage and regional val balance for a holdout split."""
+    df = _prepare_holdout_df(df_annotations)
+    image_sets = _image_label_sets(df)
+    image_lookup = {row.image_id: row for row in image_sets.itertuples(index=False)}
+
+    benthic_index = _pair_image_index(image_sets, "benthic_attribute_names")
+    growth_index = _pair_image_index(image_sets, "growth_form_names")
+
+    def rare_coverage(index: dict[tuple[str, str], list[str]], labels_col: str) -> float:
+        rare_keys = [key for key, ids in index.items() if 2 <= len(ids) < rare_image_threshold]
+        if not rare_keys:
+            return 1.0
+        covered = sum(
+            1
+            for key in rare_keys
+            if _pair_covered(val_ids, image_lookup, key[0], key[1], labels_col)
+        )
+        return covered / len(rare_keys)
+
+    region_stats: list[dict[str, Any]] = []
+    for region, region_df in image_sets.groupby("region_name", sort=False):
+        region_ids = sorted(region_df["image_id"].astype(str).unique())
+        n = len(region_ids)
+        val_n = sum(1 for image_id in region_ids if image_id in val_ids)
+        region_stats.append(
+            {
+                "region_name": region,
+                "images": n,
+                "val_images": val_n,
+                "val_fraction": val_n / n if n else 0.0,
+                "target_fraction": holdout_fraction,
+            }
+        )
+
+    all_images = set(image_sets["image_id"].astype(str))
+    train_ids = all_images - val_ids
+
+    def split_label_sets(split_ids: set[str], labels_col: str) -> set[str]:
+        labels: set[str] = set()
+        for image_id in split_ids:
+            labels.update(getattr(image_lookup[image_id], labels_col))
+        return labels
+
+    val_benthic = split_label_sets(val_ids, "benthic_attribute_names")
+    train_benthic = split_label_sets(train_ids, "benthic_attribute_names")
+
+    missing_rare_rows: list[dict[str, str]] = []
+    for key, ids in benthic_index.items():
+        if not (2 <= len(ids) < rare_image_threshold):
+            continue
+        if not _pair_covered(val_ids, image_lookup, key[0], key[1], "benthic_attribute_names"):
+            missing_rare_rows.append(
+                {
+                    "region_name": key[0],
+                    "benthic_attribute_name": key[1],
+                    "images": str(len(ids)),
+                }
+            )
+
+    return {
+        "rare_class_val_coverage": rare_coverage(benthic_index, "benthic_attribute_names"),
+        "rare_growth_form_val_coverage": rare_coverage(growth_index, "growth_form_names"),
+        "val_share_by_region": pd.DataFrame(region_stats),
+        "classes_val_only": sorted(val_benthic - train_benthic),
+        "classes_train_only": sorted(train_benthic - val_benthic),
+        "missing_rare_class_pairs": pd.DataFrame(missing_rare_rows),
+    }
+
 
 class MermaidDataset(BaseCoralDataset):
-    """A PyTorch Dataset for loading MERMAID annotated coral reef images from a Parquet file stored
-    on S3.
+    """A PyTorch Dataset for loading MERMAID annotated coral reef images from a Parquet
+    file stored on S3.
 
     Each item returned is a tuple ``(image, source_labels)`` where
     ``source_labels`` is an integer mask in the MERMAID benthic-attribute label
     space (or in the joint global space, if the dataset has been registered
     with a :class:`SourceLabelRegistry`).
 
-    Attributes:
-        annotations_path (str): Path to the Parquet file containing image annotations.
-        source_bucket (str): S3 bucket name containing the dataset files.
-        s3 (boto3.client): Boto3 S3 client for accessing images.
-    Args:
-        annotations_path (str, optional): S3 path to the Parquet file with annotations.
-        source_bucket (str, optional): S3 bucket name containing the dataset files.
-        **base_kwargs: Forwarded to :class:`BaseCoralDataset`.
+    Split controls:
+        - ``holdout_fraction`` + ``holdout_role``: rare-aware region-blocked holdout
+          (default 10% val, seed 42, train role). Pass ``holdout_fraction=None`` and
+          ``holdout_role=None`` to load the full corpus without splitting.
     """
 
     SOURCE_NAME = "mermaid"
@@ -42,41 +412,72 @@ class MermaidDataset(BaseCoralDataset):
     annotations_path: str
     source_bucket: str
     s3: boto3.client
+    holdout_fraction: float | None
+    holdout_seed: int
+    holdout_role: Literal["train", "val"] | None
 
     def __init__(
         self,
         annotations_path: str = "s3://coral-reef-training/mermaid/mermaid_confirmed_annotations.parquet",
         source_bucket: str = "coral-reef-training",
+        holdout_fraction: float | None = DEFAULT_HOLDOUT_FRACTION,
+        holdout_seed: int = DEFAULT_HOLDOUT_SEED,
+        holdout_role: Literal["train", "val"] | None = DEFAULT_HOLDOUT_ROLE,
         **base_kwargs: Any,
     ):
+        if holdout_fraction is not None and holdout_role not in ("train", "val"):
+            raise ValueError("holdout_role must be 'train' or 'val' when holdout_fraction is set.")
+        if holdout_role is not None and holdout_fraction is None:
+            raise ValueError("holdout_fraction is required when holdout_role is set.")
+
         self.annotations_path = annotations_path
         self.source_bucket = source_bucket
         self.s3 = boto3.client("s3")
+        self.holdout_fraction = holdout_fraction
+        self.holdout_seed = holdout_seed
+        self.holdout_role = holdout_role
 
         df_annotations, df_images = self.load_annotations(self.annotations_path)
-        super().__init__(df_annotations=df_annotations, df_images=df_images, **base_kwargs)
+        super().__init__(
+            df_annotations=df_annotations,
+            df_images=df_images,
+            split=holdout_role,
+            **base_kwargs,
+        )
 
     def load_annotations(self, annotations_path: str) -> tuple[pd.DataFrame, pd.DataFrame]:
-        """Load annotations from a Parquet file on S3.
-
-        For MERMAID, the source-space label name *is* the canonical
-        ``benthic_attribute_name`` field. This helper renames the column to the
-        unified ``source_label_name`` convention used by
-        :class:`BaseCoralDataset`.
-        """
-        df_annotations = pd.read_parquet(annotations_path)
+        """Load annotations from a Parquet file on S3 and apply split filters."""
+        df_annotations = _read_annotations_cached(annotations_path)
+        df_annotations = self._apply_image_holdout(df_annotations)
         df_annotations = df_annotations.rename(
             columns={"benthic_attribute_name": "source_label_name"}
         )
+        if df_annotations.empty:
+            raise ValueError(
+                "MermaidDataset has zero annotations after applying split filters "
+                f"(holdout_fraction={self.holdout_fraction}, holdout_role={self.holdout_role})."
+            )
         df_images = self._derive_df_images_from_annotations(df_annotations)
         return df_annotations, df_images
 
-    def _derive_df_images_from_annotations(self, df_annotations: pd.DataFrame) -> pd.DataFrame:
-        return (
-            df_annotations[["image_id", "region_id", "region_name"]]
-            .drop_duplicates(subset=["image_id"])
-            .reset_index(drop=True)
+    def _apply_image_holdout(self, df_annotations: pd.DataFrame) -> pd.DataFrame:
+        if self.holdout_fraction is None or self.holdout_role is None:
+            return df_annotations
+        holdout_ids = select_stratified_holdout_image_ids(
+            df_annotations,
+            holdout_fraction=self.holdout_fraction,
+            holdout_seed=self.holdout_seed,
         )
+        image_ids = df_annotations["image_id"].astype(str)
+        if self.holdout_role == "val":
+            mask = image_ids.isin(holdout_ids)
+        else:
+            mask = ~image_ids.isin(holdout_ids)
+        return df_annotations.loc[mask].reset_index(drop=True)
+
+    def _derive_df_images_from_annotations(self, df_annotations: pd.DataFrame) -> pd.DataFrame:
+        cols = [c for c in ("image_id", "region_id", "region_name") if c in df_annotations.columns]
+        return df_annotations[cols].drop_duplicates(subset=["image_id"]).reset_index(drop=True)
 
     def read_image(self, image_id: str, **row_kwargs: Any) -> NDArray[Any]:
         key = f"mermaid/{image_id}.png"

--- a/mermaidseg/experiment.py
+++ b/mermaidseg/experiment.py
@@ -333,12 +333,8 @@ class Experiment:
             self._registry = registry
         return self._registry
 
-    def dataloaders(self) -> tuple[DataLoader, DataLoader]:
-        """Build the ``(train, val)`` loaders (ConcatDataset over the active splits)."""
+    def _base_loader_kwargs(self) -> dict[str, Any]:
         cfg = self.config
-        dataset_dict = self.datasets()
-        registry = self.registry  # ensure attach_registry ran before any __getitem__
-
         loader_kwargs: dict[str, Any] = {
             "batch_size": cfg.training.batch_size,
             "num_workers": self.overrides.num_workers,
@@ -351,9 +347,20 @@ class Experiment:
         if self.overrides.num_workers > 0:
             loader_kwargs["persistent_workers"] = True
             loader_kwargs["worker_init_fn"] = worker_init_fn
+        return loader_kwargs
+
+    def dataloaders(self) -> tuple[DataLoader, DataLoader]:
+        """Build the ``(train, val)`` loaders (ConcatDataset over the active splits)."""
+        dataset_dict = self.datasets()
+        registry = self.registry  # ensure attach_registry ran before any __getitem__
+        loader_kwargs = self._base_loader_kwargs()
 
         train_datasets = [ds for (_, split), ds in dataset_dict.items() if split == "train"]
         val_datasets = [ds for (_, split), ds in dataset_dict.items() if split == "val"]
+        if not train_datasets:
+            raise ValueError("No training datasets enabled in data config.")
+        if not val_datasets:
+            raise ValueError("No validation datasets enabled in data config.")
         self.train_dataset = ConcatDataset(train_datasets)
         self.val_dataset = ConcatDataset(val_datasets)
         train_loader = DataLoader(self.train_dataset, shuffle=True, **loader_kwargs)
@@ -363,6 +370,22 @@ class Experiment:
         if self._compute_concepts:
             assert registry.num_concepts == self._schema.num_channels
         return train_loader, val_loader
+
+    def dataset_val_loaders(self) -> dict[str, DataLoader]:
+        """Per-dataset validation loaders (e.g. ``{"mermaid": ..., "coralnet": ...}``),
+        for MLflow keys like ``validation/mermaid/miou``.
+
+        Checkpoint selection and early stopping still use the combined loader from
+        :meth:`dataloaders`.
+        """
+        dataset_dict = self.datasets()
+        _ = self.registry  # ensure attach_registry ran before any __getitem__
+        loader_kwargs = {**self._base_loader_kwargs(), "drop_last": False}
+        return {
+            name: DataLoader(ds, shuffle=False, **loader_kwargs)
+            for (name, split), ds in dataset_dict.items()
+            if split == "val"
+        }
 
     def meta_model(self) -> MetaModel:
         """Construct the :class:`MetaModel` from the registry's derived lookups."""

--- a/mermaidseg/model/train.py
+++ b/mermaidseg/model/train.py
@@ -94,6 +94,9 @@ def train_model(
     | None = None,
     test_loader: DataLoader[tuple[torch.Tensor, torch.Tensor] | dict[str, torch.Tensor]]
     | None = None,
+    dataset_val_loaders: (
+        dict[str, DataLoader[tuple[torch.Tensor, torch.Tensor] | dict[str, torch.Tensor]]] | None
+    ) = None,
     logger: Logger | None = None,
     start_epoch: int = -1,
     end_epoch: int = -1,
@@ -118,6 +121,9 @@ def train_model(
         test_loader (Optional[DataLoader], optional): DataLoader for the test dataset.
             Defaults to None. If provided, the model is evaluated periodically according
             to ``logger.log_epochs`` (or every epoch when logger is None), plus the final epoch.
+        dataset_val_loaders (dict[str, DataLoader] | None): Optional per-dataset validation
+            loaders (e.g. ``{"mermaid": ..., "coralnet": ...}``). Logged as
+            ``validation/{name}/*`` without affecting checkpoint selection.
         logger (Optional[Logger], optional): Logger object for logging metrics and saving
             model checkpoints. Defaults to None. When ``logger.log_checkpoint`` is set, a
             periodic (non-improvement) checkpoint is also saved every ``log_checkpoint``
@@ -210,6 +216,17 @@ def train_model(
             epoch_loss_dict["validation/loss"] = val_loss
             metrics_epoch[epoch]["validation_metrics"] = val_metric_results
             _log_metric_dict(logger, "validation", val_metric_results, epoch)
+
+            if dataset_val_loaders:
+                per_dataset_metrics: dict[str, object] = {}
+                for dataset_name, ds_loader in sorted(dataset_val_loaders.items()):
+                    ds_loss, ds_metrics = meta_model.validation_epoch(ds_loader, evaluator)
+                    prefix = f"validation/{dataset_name}"
+                    logging.info("VALID [%s] loss=%s metrics=%s", dataset_name, ds_loss, ds_metrics)
+                    epoch_loss_dict[f"{prefix}/loss"] = ds_loss
+                    _log_metric_dict(logger, prefix, ds_metrics, epoch)
+                    per_dataset_metrics[dataset_name] = {"loss": ds_loss, "metrics": ds_metrics}
+                metrics_epoch[epoch]["validation_per_dataset"] = per_dataset_metrics
 
             metric_value = extract_metric_value(metric_of_interest, val_loss, val_metric_results)
             if direction == "min":

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -344,6 +344,7 @@ def _run_training(args: argparse.Namespace) -> None:
     logging.info("Seed: %d", seed)
 
     train_loader, val_loader = experiment.dataloaders()
+    dataset_val_loaders = experiment.dataset_val_loaders()
     dataset_dict = experiment.datasets()
     registry = experiment.registry
     train_dataset_combined = experiment.train_dataset
@@ -378,6 +379,10 @@ def _run_training(args: argparse.Namespace) -> None:
         try:
             train_loader = [_take_first_non_empty_batch(train_loader, "train")]
             val_loader = [_take_first_non_empty_batch(val_loader, "val")]
+            dataset_val_loaders = {
+                name: [_take_first_non_empty_batch(loader, f"val/{name}")]
+                for name, loader in dataset_val_loaders.items()
+            }
         except RuntimeError:
             _write_failure_reports_once()
             raise
@@ -423,6 +428,7 @@ def _run_training(args: argparse.Namespace) -> None:
                 train_loader=train_loader,
                 val_loader=val_loader,
                 test_loader=None,
+                dataset_val_loaders=dataset_val_loaders,
                 logger=logger,
                 metric_of_interest=experiment.overrides.metric_of_interest,
                 early_stopping=experiment.overrides.early_stopping,

--- a/tests/datasets/test_mermaid_splits.py
+++ b/tests/datasets/test_mermaid_splits.py
@@ -1,0 +1,284 @@
+"""Tests for MERMAID train/val holdout."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from mermaidseg.datasets.mermaid.mermaid_dataset import (
+    DEFAULT_HOLDOUT_FRACTION,
+    DEFAULT_HOLDOUT_ROLE,
+    DEFAULT_HOLDOUT_SEED,
+    RARE_IMAGE_THRESHOLD,
+    MermaidDataset,
+    build_image_holdout_features,
+    compute_split_quality,
+    select_composite_holdout_image_ids,
+    select_stratified_holdout_image_ids,
+)
+
+
+def _ann_frame(
+    n_images: int = 20,
+    regions: list[str] | None = None,
+    *,
+    labels: list[str] | None = None,
+    benthic_ids: list[str] | None = None,
+    growth_forms: list[str] | None = None,
+) -> pd.DataFrame:
+    regions = regions or ["A", "B"]
+    labels = labels or ["Acropora"]
+    benthic_ids = benthic_ids or ["101"]
+    growth_forms = growth_forms or ["Branching"]
+    rows = []
+    for i in range(n_images):
+        rows.append(
+            {
+                "image_id": f"img-{i:03d}",
+                "region_id": i % len(regions),
+                "region_name": regions[i % len(regions)],
+                "benthic_attribute_name": labels[i % len(labels)],
+                "benthic_attribute_id": benthic_ids[i % len(benthic_ids)],
+                "growth_form_name": growth_forms[i % len(growth_forms)],
+                "row": 10,
+                "col": 10,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+class TestBuildImageHoldoutFeatures:
+    def test_modes_and_region(self):
+        df = _ann_frame(2, regions=["Alpha"], labels=["Acropora", "Porites"])
+        features = build_image_holdout_features(df)
+        assert list(features.columns) == [
+            "image_id",
+            "region_name",
+            "benthic_attribute_name",
+            "benthic_attribute_id",
+            "growth_form_name",
+        ]
+        assert set(features["region_name"]) == {"Alpha"}
+        assert set(features["benthic_attribute_name"]) == {"Acropora", "Porites"}
+
+
+class TestSelectStratifiedHoldoutImageIds:
+    def test_deterministic(self):
+        df = _ann_frame(100)
+        a = select_stratified_holdout_image_ids(df, holdout_fraction=0.1, holdout_seed=42)
+        b = select_stratified_holdout_image_ids(df, holdout_fraction=0.1, holdout_seed=42)
+        assert a == b
+        c = select_stratified_holdout_image_ids(df, holdout_fraction=0.1, holdout_seed=7)
+        assert a != c
+
+    def test_complement(self):
+        df = _ann_frame(40)
+        val_ids = select_stratified_holdout_image_ids(df, holdout_fraction=0.1, holdout_seed=42)
+        all_ids = set(df["image_id"].astype(str))
+        assert val_ids <= all_ids
+        assert val_ids.isdisjoint(all_ids - val_ids)
+        assert val_ids | (all_ids - val_ids) == all_ids
+
+    def test_per_region_val_presence(self):
+        df = _ann_frame(20, regions=["Alpha", "Beta"])
+        val_ids = select_stratified_holdout_image_ids(df, holdout_fraction=0.1, holdout_seed=42)
+        for region in df["region_name"].unique():
+            region_ids = set(df.loc[df["region_name"] == region, "image_id"].astype(str))
+            if len(region_ids) >= 2:
+                assert region_ids & val_ids
+
+    def test_rare_class_gets_val_coverage(self):
+        rows = []
+        for i in range(3):
+            rows.append(
+                {
+                    "image_id": f"rare-{i}",
+                    "region_name": "R1",
+                    "benthic_attribute_name": "RareTaxon",
+                    "benthic_attribute_id": "999",
+                    "growth_form_name": "None",
+                    "row": 0,
+                    "col": 0,
+                }
+            )
+            for j in range(24):
+                rows.append(
+                    {
+                        "image_id": f"rare-{i}",
+                        "region_name": "R1",
+                        "benthic_attribute_name": "Common",
+                        "benthic_attribute_id": "1",
+                        "growth_form_name": "None",
+                        "row": j // 5,
+                        "col": j % 5,
+                    }
+                )
+        for i in range(20):
+            rows.append(
+                {
+                    "image_id": f"common-{i:02d}",
+                    "region_name": "R1",
+                    "benthic_attribute_name": "Common",
+                    "benthic_attribute_id": "1",
+                    "growth_form_name": "None",
+                    "row": 0,
+                    "col": 0,
+                }
+            )
+        df = pd.DataFrame(rows)
+        composite = select_composite_holdout_image_ids(df, holdout_fraction=0.1, holdout_seed=42)
+        rare_aware = select_stratified_holdout_image_ids(df, holdout_fraction=0.1, holdout_seed=42)
+        assert not any(image_id in composite for image_id in ("rare-0", "rare-1", "rare-2"))
+        assert any(image_id in rare_aware for image_id in ("rare-0", "rare-1", "rare-2"))
+
+    def test_singleton_rare_pair_stays_train(self):
+        df = pd.DataFrame(
+            [
+                {
+                    "image_id": "solo",
+                    "region_name": "Only",
+                    "benthic_attribute_name": "Rare",
+                    "benthic_attribute_id": "1",
+                    "growth_form_name": "Branching",
+                }
+            ]
+        )
+        val_ids = select_stratified_holdout_image_ids(df, holdout_fraction=0.1, holdout_seed=42)
+        assert val_ids == set()
+
+    def test_rare_growth_form_gets_val_coverage(self):
+        rows = []
+        for i in range(3):
+            rows.append(
+                {
+                    "image_id": f"gf-{i}",
+                    "region_name": "R1",
+                    "benthic_attribute_name": "Acropora",
+                    "benthic_attribute_id": "1",
+                    "growth_form_name": "Columnar",
+                    "row": i,
+                    "col": i,
+                }
+            )
+        for i in range(20):
+            rows.append(
+                {
+                    "image_id": f"plain-{i:02d}",
+                    "region_name": "R1",
+                    "benthic_attribute_name": "Acropora",
+                    "benthic_attribute_id": "1",
+                    "growth_form_name": "None",
+                    "row": 0,
+                    "col": 0,
+                }
+            )
+        df = pd.DataFrame(rows)
+        val_ids = select_stratified_holdout_image_ids(df, holdout_fraction=0.1, holdout_seed=42)
+        assert any(image_id in val_ids for image_id in ("gf-0", "gf-1", "gf-2"))
+
+    def test_regional_quota_near_target(self):
+        df = _ann_frame(100, regions=["Alpha"])
+        val_ids = select_stratified_holdout_image_ids(df, holdout_fraction=0.1, holdout_seed=42)
+        target = max(1, int(round(100 * 0.1)))
+        assert abs(len(val_ids) - target) <= 2
+
+    def test_deterministic_regardless_of_input_row_order(self):
+        """Guards against a real regression: an earlier implementation's regional-quota
+        pass iterated regions/classes via ``groupby(..., sort=False)`` while consuming a
+        single shared RNG, so the same seed produced a different split depending on the
+        order annotation rows happened to arrive in from the parquet read."""
+        df = _ann_frame(100, regions=["Alpha", "Beta", "Gamma"])
+        shuffled = df.sample(frac=1, random_state=123).reset_index(drop=True)
+        a = select_stratified_holdout_image_ids(df, holdout_fraction=0.1, holdout_seed=42)
+        b = select_stratified_holdout_image_ids(shuffled, holdout_fraction=0.1, holdout_seed=42)
+        assert a == b
+
+    def test_rare_aware_beats_composite_on_coverage(self):
+        rows = []
+        for region in ("R1", "R2"):
+            for i in range(3):
+                rows.append(
+                    {
+                        "image_id": f"{region}-rare-{i}",
+                        "region_name": region,
+                        "benthic_attribute_name": f"Rare-{region}",
+                        "benthic_attribute_id": f"r{i}",
+                        "growth_form_name": "None",
+                        "row": i,
+                        "col": i,
+                    }
+                )
+            for i in range(30):
+                rows.append(
+                    {
+                        "image_id": f"{region}-common-{i:02d}",
+                        "region_name": region,
+                        "benthic_attribute_name": "Common",
+                        "benthic_attribute_id": "1",
+                        "growth_form_name": "None",
+                        "row": 0,
+                        "col": 0,
+                    }
+                )
+        df = pd.DataFrame(rows)
+        composite = compute_split_quality(
+            df,
+            select_composite_holdout_image_ids(df, holdout_fraction=0.1, holdout_seed=42),
+            holdout_fraction=0.1,
+            rare_image_threshold=RARE_IMAGE_THRESHOLD,
+        )
+        rare_aware = compute_split_quality(
+            df,
+            select_stratified_holdout_image_ids(df, holdout_fraction=0.1, holdout_seed=42),
+            holdout_fraction=0.1,
+            rare_image_threshold=RARE_IMAGE_THRESHOLD,
+        )
+        assert rare_aware["rare_class_val_coverage"] >= composite["rare_class_val_coverage"]
+
+
+class TestMermaidDatasetSplits:
+    def _build(self, df: pd.DataFrame, **kwargs) -> MermaidDataset:
+        with (
+            patch.object(MermaidDataset, "load_annotations", autospec=True),
+            patch(
+                "mermaidseg.datasets.mermaid.mermaid_dataset.boto3.client",
+                return_value=MagicMock(),
+            ),
+            patch.object(MermaidDataset, "read_image", return_value=MagicMock()),
+        ):
+            ds = object.__new__(MermaidDataset)
+            ds.annotations_path = "s3://bucket/x.parquet"
+            ds.source_bucket = "bucket"
+            ds.s3 = MagicMock()
+            ds.holdout_fraction = kwargs.get("holdout_fraction")
+            ds.holdout_seed = kwargs.get("holdout_seed", 42)
+            ds.holdout_role = kwargs.get("holdout_role")
+            ds.split = ds.holdout_role
+            filtered = ds._apply_image_holdout(df.copy())
+            ds.df_annotations = filtered
+            ds.df_images = ds._derive_df_images_from_annotations(filtered)
+            return ds
+
+    def test_holdout_train_val_are_complements(self):
+        df = _ann_frame(40)
+        train = self._build(df, holdout_fraction=0.1, holdout_seed=42, holdout_role="train")
+        val = self._build(df, holdout_fraction=0.1, holdout_seed=42, holdout_role="val")
+        train_ids = set(train.df_images["image_id"].astype(str))
+        val_ids = set(val.df_images["image_id"].astype(str))
+        assert train_ids.isdisjoint(val_ids)
+        assert train_ids | val_ids == set(df["image_id"].astype(str))
+        assert len(val_ids) >= 1
+
+    def test_default_holdout_settings(self):
+        import inspect
+
+        sig = inspect.signature(MermaidDataset.__init__)
+        assert sig.parameters["holdout_fraction"].default == DEFAULT_HOLDOUT_FRACTION
+        assert sig.parameters["holdout_seed"].default == DEFAULT_HOLDOUT_SEED
+        assert sig.parameters["holdout_role"].default == DEFAULT_HOLDOUT_ROLE
+
+    def test_holdout_role_sets_split(self):
+        df = _ann_frame(40)
+        ds = self._build(df, holdout_fraction=0.1, holdout_seed=42, holdout_role="val")
+        assert ds.split == "val"

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -71,7 +71,7 @@ def test_issue12_run_yaml_validates(monkeypatch):
     assert report.ok, report.errors
     assert report.summary["metric_of_interest"] == "miou"
     assert report.summary["datasets_enabled"].get("coralnet") == ["train", "val"]
-    assert report.summary["datasets_enabled"].get("mermaid") == ["train"]
+    assert report.summary["datasets_enabled"].get("mermaid") == ["train", "val"]
 
 
 def test_example_run_yaml_validates(monkeypatch):

--- a/tests/test_standard_pipeline_smoke.py
+++ b/tests/test_standard_pipeline_smoke.py
@@ -64,7 +64,8 @@ def test_standard_mode_training_pipeline_smoke(tmp_path, monkeypatch):
 
     from scripts.train import _run_training
 
-    synthetic_mermaid = SyntheticCoralDataset("mermaid", num_samples=20)
+    synthetic_mermaid_train = SyntheticCoralDataset("mermaid", num_samples=18)
+    synthetic_mermaid_val = SyntheticCoralDataset("mermaid", num_samples=2)
     synthetic_coralnet = SyntheticCoralDataset("coralnet", num_samples=20)
 
     concept_schema_calls = []
@@ -77,11 +78,18 @@ def test_standard_mode_training_pipeline_smoke(tmp_path, monkeypatch):
         concept_schema_calls.append((args, kwargs))
         return original_from_csv(*args, **kwargs)
 
+    def mermaid_factory(**kwargs):
+        # MERMAID now has a real (holdout-derived) val split — see configs/data_config_
+        # coralnet_mermaid.yaml — so DATASET_REGISTRY["mermaid"] is invoked once per role.
+        if kwargs.get("holdout_role") == "val":
+            return synthetic_mermaid_val
+        return synthetic_mermaid_train
+
     # Datasets are built via mermaidseg.experiment.DATASET_REGISTRY[name](...); override its
     # entries. The standard baseline uses only coralnet + mermaid — every other source has None
     # splits in the config and must never be instantiated (side_effect guards that).
     registry_override = {
-        "mermaid": MagicMock(return_value=synthetic_mermaid),
+        "mermaid": MagicMock(side_effect=mermaid_factory),
         "coralnet": MagicMock(return_value=synthetic_coralnet),
         **{
             name: MagicMock(side_effect=ValueError("Should not be called in standard baseline"))


### PR DESCRIPTION
## Summary

MERMAID currently has no validation split (`mermaid.val: None` in both data configs), which makes the rare-class IoU/recall slice required by #170 (Focal Loss) and #172 (LoRA) unmeasurable. This adds a two-pass stratified holdout and lands it first so both of those experiments branch from a comparable, rare-class-visible base.

- **Pass 1 (rare coverage)**: every (region, benthic_attribute) and (region, growth_form) pair with 2–9 images gets at least one image assigned to val.
- **Pass 2 (regional quota)**: fills the remaining ~10% per-region val quota, balanced across each region's dominant class.
- Legacy mode-based composite-strata split (`select_composite_holdout_image_ids`) kept for before/after comparison.

Also adds `Experiment.dataset_val_loaders()` — per-dataset validation loaders logged as `validation/{name}/*` in MLflow without affecting checkpoint selection (checkpointing still uses the combined val loader).

## Provenance

Ported from the closed `cursor/ab56a7a7` (#191), which bundled this together with Focal loss and LoRA. That PR was closed after review found two real bugs; this PR carries forward only the holdout piece, with the row-order bug fixed. Focal (#170) and LoRA (#172) will follow as separate branches off this PR's merged tip once it lands, per the DSLP-aligned restructuring plan.

## Bug fix

The original implementation's regional-quota pass iterated regions and classes via `groupby(..., sort=False)` while consuming a single shared `np.random.Generator` — so the same `holdout_seed` produced a *different* split depending on the order annotation rows happened to arrive in from the parquet read (not reproducible across re-reads or corpus appends). Fixed at the source: region/class iteration inside `_fill_regional_quota` now uses `sort=True`, so the RNG is consumed in a canonical order regardless of input row order. Added `test_deterministic_regardless_of_input_row_order`, which fails against the original code and passes against the fix (verified both directions manually before committing).

Also cached the annotations parquet read (`_read_annotations_cached`, keyed by path) so train- and val-role `MermaidDataset` instances share one DataFrame object instead of each independently re-reading and re-splitting.

## Config wiring

Both `configs/data_config.yaml` and `configs/data_config_coralnet_mermaid.yaml` previously set `mermaid: val: None`. Now both set `holdout_fraction: 0.1` / `holdout_seed: 42` / `holdout_role: train|val` for MERMAID's train/val blocks (recursively merged with the `default` transform block, so augmentations are unaffected).

## Testing

- `tests/datasets/test_mermaid_splits.py`: 13 tests (12 ported + 1 new row-order-independence test)
- `uv run pytest -m "not integration"`: 419 passed
- `uv run --extra all pytest -m integration`: 11 passed
- `python -m mermaidseg.experiment validate` on both committed run YAMLs: clean, now correctly showing `datasets_enabled: {'mermaid': ['train', 'val'], ...}`

Closes #193