### PR TITLE
feat(model): LoRA Q/V adapters on LinearDINOv3 (r=8, r=16)

### DIFF
--- a/configs/model_config_dinov3_lora_qv_r16.yaml
+++ b/configs/model_config_dinov3_lora_qv_r16.yaml
@@ -1,0 +1,11 @@
+# LinearDINOv3 + LoRA on Q/V projections, rank 16 (Ticket 3).
+model:
+  name: "LinearLoRADINOv3"
+  encoder_name: "facebook/dinov3-vitb16-pretrain-lvd1689m"
+  input_size: [512, 512]
+  use_lora: true
+  lora_r: 16
+  lora_alpha: 32
+  lora_dropout: 0.05
+  lora_target_modules: ["q_proj", "v_proj"]
+  lora_bias: "none"

--- a/configs/model_config_dinov3_lora_qv_r8.yaml
+++ b/configs/model_config_dinov3_lora_qv_r8.yaml
@@ -1,0 +1,11 @@
+# LinearDINOv3 + LoRA on Q/V projections, rank 8 (Ticket 3).
+model:
+  name: "LinearLoRADINOv3"
+  encoder_name: "facebook/dinov3-vitb16-pretrain-lvd1689m"
+  input_size: [512, 512]
+  use_lora: true
+  lora_r: 8
+  lora_alpha: 16
+  lora_dropout: 0.05
+  lora_target_modules: ["q_proj", "v_proj"]
+  lora_bias: "none"

--- a/configs/training_config_dinov3_lora.yaml
+++ b/configs/training_config_dinov3_lora.yaml
@@ -1,0 +1,42 @@
+# Training config for LinearLoRADINOv3 (Ticket 3 / #172). Param groups: head lr + lora_lr.
+# Pair with model_config_dinov3_lora_qv_r{8,16}.yaml. Same class_subset as issue #12 baseline.
+# Optionally set loss to DomainWeightedFocalLoss after Ticket 2a if Focal wins over CE.
+training:
+    training_mode: "standard"
+    freeze_encoder: true
+    loss:
+        type: CrossEntropyLoss
+        ignore_index: 0
+        damping_denominator: 100
+    epochs: 200
+    optimizer:
+        type: AdamW
+        lr: 0.001
+        lora_lr: 0.0001
+        weight_decay: 0.01
+    scheduler:
+        type: PolynomialLR
+        power: 1
+        total_iters: 200
+        # Short warmup for LoRA adapters (unlike frozen head-only probe).
+        warmup_iters: 200
+        warmup_start_factor: 0.01
+    iterations_per_train_epoch: 1000
+    iterations_per_val_epoch: 200
+    # Below issue-12 frozen batch 32: LoRA keeps encoder grads on (no torch.no_grad path),
+    # so VRAM is higher. Start at 16 on ml.g5.2xlarge; drop to 8 if OOM.
+    batch_size: 16
+    class_subset: ['Acanthastrea', 'Acropora', 'Agaricia agaricites', 'Algae covered substrate', 'Alveopora',
+                    'Astrea', 'Astreopora', 'Background', 'Bare substrate', 'Coscinaraea', 'Crustose coralline algae',
+                    'Cyanobacteria', 'Cyphastrea', 'Dark', 'Dictyota', 'Diploastrea', 'Dipsastraea', 'Echinophyllia',
+                    'Echinopora', 'Euphyllia', 'Favia', 'Favites', 'Fungia', 'Galaxea', 'Gardineroseris', 'Goniastrea',
+                    'Goniopora', 'Gorgonian', 'Halimeda', 'Hard coral', 'Heliopora', 'Human', 'Human-made structure', 'Hydnophora',
+                    'Isopora', 'Leptastrea', 'Leptoria', 'Leptoseris', 'Lobophora', 'Lobophyllia', 'Macroalgae', 'Madracis',
+                    'Merulina', 'Millepora', 'Montastraea', 'Montastraea cavernosa', 'Montipora', 'Mycedium',
+                    'Orbicella annularis', 'Orbicella faveolata', 'Pachyseris', 'Padina', 'Pavona', 'Pectinia', 'Platygyra',
+                    'Pocillopora', 'Porites', 'Porites astreoides', 'Psammocora', 'Rock', 'Rubble', 'Sand', 'Sargassum',
+                    'Sea urchin', 'Seagrass', 'Seriatopora', 'Siderastrea siderea', 'Soft coral', 'Sponge', 'Stylophora',
+                    'Symphyllia', 'Transect tools', 'Tridacna giant clam', 'Turbinaria-algae', 'Turbinaria-coral',
+                    'Turf algae', 'Zoanthid']
+    padding: 3
+    label_roll_up: True

--- a/mermaidseg/model/meta.py
+++ b/mermaidseg/model/meta.py
@@ -236,8 +236,27 @@ class MetaModel:
             self.loss = loss_cls(**loss_kwargs)
 
         optimizer_cls = getattr(torch.optim, training_kwargs.optimizer.pop("type", None))
+        optimizer_kwargs = dict(training_kwargs.optimizer)
+        lora_lr = optimizer_kwargs.pop("lora_lr", None)
         self._trainable_params = [p for p in self.model.parameters() if p.requires_grad]
-        self.optimizer = optimizer_cls(params=self._trainable_params, **training_kwargs.optimizer)
+        if lora_lr is not None and getattr(self.model, "use_lora", False):
+            head_params = [
+                p for n, p in self.model.named_parameters() if p.requires_grad and "lora_" not in n
+            ]
+            lora_params = [
+                p for n, p in self.model.named_parameters() if p.requires_grad and "lora_" in n
+            ]
+            base_lr = float(optimizer_kwargs.pop("lr"))
+            param_groups = []
+            if head_params:
+                param_groups.append({"params": head_params, "lr": base_lr})
+            if lora_params:
+                param_groups.append({"params": lora_params, "lr": float(lora_lr)})
+            if not param_groups:
+                param_groups = [{"params": self._trainable_params, "lr": base_lr}]
+            self.optimizer = optimizer_cls(param_groups, **optimizer_kwargs)
+        else:
+            self.optimizer = optimizer_cls(params=self._trainable_params, **optimizer_kwargs)
 
         if "scheduler" in training_kwargs:
             scheduler_cfg = dict(training_kwargs.scheduler)

--- a/mermaidseg/model/models.py
+++ b/mermaidseg/model/models.py
@@ -125,15 +125,11 @@ class ConceptHead(torch.nn.Module):
 class LinearDINOv3(torch.nn.Module):
     """DINOv3 encoder with a linear segmentation head.
 
-    Encodes input images with a frozen-or-trainable DINOv3 backbone and
-    classifies each spatial token with a 1×1 conv, then bilinearly upsamples
-    back to input resolution.
+    Encodes input images with a frozen-or-trainable DINOv3 backbone and classifies each
+    spatial token with a 1×1 conv, then bilinearly upsamples back to input resolution.
 
-    Attributes:
-        encoder: DINOv3 model loaded via `AutoModel.from_pretrained`.
-        head (LinearClassifier): Per-token classification head.
-        token_width (int): Width of the patch-token grid.
-        token_height (int): Height of the patch-token grid.
+    When ``use_lora=True``, PEFT LoRA adapters are injected into the encoder attention
+    projections; base weights stay frozen and only adapters + head train.
     """
 
     def __init__(
@@ -141,22 +137,41 @@ class LinearDINOv3(torch.nn.Module):
         encoder_name: str = "facebook/dinov3-vitb16-pretrain-lvd1689m",
         num_classes: int = 2,
         input_size: tuple[int, int] = (512, 512),
+        use_lora: bool = False,
+        lora_r: int = 16,
+        lora_alpha: int = 32,
+        lora_dropout: float = 0.05,
+        lora_target_modules: Sequence[str] = ("q_proj", "v_proj"),
+        lora_bias: str = "none",
         **kwargs: Any,
     ):
         """Initialize encoder and linear segmentation head.
 
         Args:
             encoder_name (str): HuggingFace model ID for the DINOv3 encoder.
-                Defaults to "facebook/dinov3-vitb16-pretrain-lvd1689m".
-            num_classes (int): Number of segmentation output classes. Defaults to 2.
+            num_classes (int): Number of segmentation output classes.
             input_size (tuple[int, int]): Expected (height, width) of input images.
-                Determines the token grid size. Defaults to (512, 512).
+            use_lora (bool): If True, wrap the encoder with PEFT LoRA adapters.
+            lora_r / lora_alpha / lora_dropout / lora_target_modules / lora_bias:
+                PEFT LoRA hyperparameters (ignored when ``use_lora`` is False).
             **kwargs: Forwarded to `AutoModel.from_pretrained` (e.g., `token`).
         """
         super().__init__()
 
         token = kwargs.pop("token", None) or os.environ.get("HF_TOKEN")
-        self.encoder = AutoModel.from_pretrained(encoder_name, token=token, **kwargs)
+        base_encoder = AutoModel.from_pretrained(encoder_name, token=token, **kwargs)
+        self.use_lora = use_lora
+        if use_lora:
+            self.encoder = _wrap_encoder_with_lora(
+                base_encoder,
+                lora_r=lora_r,
+                lora_alpha=lora_alpha,
+                lora_dropout=lora_dropout,
+                lora_target_modules=lora_target_modules,
+                lora_bias=lora_bias,
+            )
+        else:
+            self.encoder = base_encoder
         hidden_size = self.encoder.config.hidden_size
         patch_size = self.encoder.config.patch_size
         self.token_width = input_size[1] // patch_size
@@ -164,8 +179,11 @@ class LinearDINOv3(torch.nn.Module):
         self.head = LinearClassifier(hidden_size, self.token_width, self.token_height, num_classes)
         # Gates the encoder forward under no_grad when the backbone is frozen (set by
         # freeze_encoder). Mirrors _DPTDINOv3Base so a frozen probe doesn't build the autograd
-        # graph over the backbone or hold its activations.
+        # graph over the backbone or hold its activations. LoRA keeps this False so adapters
+        # still receive gradients through the encoder forward.
         self._encoder_frozen = False
+        if use_lora:
+            self.freeze_encoder()
 
     def forward(self, x: torch.Tensor, labels=None, **kwargs: Any) -> SemanticSegmenterOutput:
         """Run encoder + linear head and upsample to input resolution.
@@ -186,39 +204,42 @@ class LinearDINOv3(torch.nn.Module):
         # Skip the 5 DINOv3 prefix tokens (CLS + 4 register tokens)
         patch_embeddings = outputs.last_hidden_state[:, 5:, :]
 
-        # convert to logits and upsample to the size of the pixel values
         logits = self.head(patch_embeddings)
         logits = torch.nn.functional.interpolate(
             logits, size=x.shape[-2:], mode="bilinear", align_corners=False
         )
 
-        loss = None
-        # if labels is not None:
-        #     logits = torch.nn.functional.interpolate(
-        #         logits, size=labels.shape[-2:], mode="bilinear", align_corners=False
-        #     )
-        #     loss_fct = torch.nn.CrossEntropyLoss(ignore_index=0)
-        #     loss = loss_fct(logits.squeeze(), labels.squeeze())
-
-        return SemanticSegmenterOutput(loss=loss, logits=logits)
+        return SemanticSegmenterOutput(loss=None, logits=logits)
 
     def freeze_encoder(self) -> None:
-        """Freeze the backbone: set encoder ``requires_grad`` to ``False`` and run its
-        forward under ``torch.no_grad`` so a frozen probe never builds the autograd
-        graph over it.
+        """Freeze encoder base weights; keep LoRA adapters trainable when present.
 
-        Only the head keeps training.
+        Without LoRA, also run the encoder under ``torch.no_grad`` (frozen probe). With
+        LoRA, adapters stay trainable so the encoder forward must keep gradients.
         """
+        if self.use_lora:
+            for name, param in self.encoder.named_parameters():
+                param.requires_grad = "lora_" in name
+            self._encoder_frozen = False
+            return
         for param in self.encoder.parameters():
             param.requires_grad = False
         self._encoder_frozen = True
 
     def unfreeze_encoder(self) -> None:
-        """Unfreeze the backbone: restore encoder ``requires_grad`` to ``True`` and run
-        its forward with gradients again (full fine-tune)."""
+        """Unfreeze the full encoder (base weights + LoRA adapters, if any)."""
         for param in self.encoder.parameters():
             param.requires_grad = True
         self._encoder_frozen = False
+
+
+class LinearLoRADINOv3(LinearDINOv3):
+    """LinearDINOv3 with LoRA enabled by default (Q/V adapters unless overridden)."""
+
+    def __init__(self, **kwargs: Any):
+        kwargs.setdefault("use_lora", True)
+        kwargs.setdefault("lora_target_modules", ("q_proj", "v_proj"))
+        super().__init__(**kwargs)
 
 
 class ConceptBottleneckDINOv3(torch.nn.Module):

--- a/sagemaker/configs/lora_qv_r16/run.yaml
+++ b/sagemaker/configs/lora_qv_r16/run.yaml
@@ -1,0 +1,24 @@
+job:
+  name_prefix: mermaidseg-dinov3-lora-r16
+  image: mermaid-segmentation-jobs:training-latest
+  entrypoint: scripts/sagemaker_train_entrypoint.py
+  instance_type: ml.g5.2xlarge
+  volume_gb: 200
+  max_runtime_hours: 48
+  env:
+    MERMAID_CORALNET_ANNOTATIONS_PATH: etl-outputs/coralnet/20260623_nogit/coralnet_training_manifest_20260623_nogit.parquet
+
+config:
+  config_data: configs/data_config_coralnet_mermaid.yaml
+  config_model: configs/model_config_dinov3_lora_qv_r16.yaml
+  config_training: configs/training_config_dinov3_lora.yaml
+  config_logger: configs/logger_config.yaml
+  overrides:
+    run-name: dinov3-lora-qv-r16-coralnet-all-mermaid
+    experiment-name: post-baseline
+    epochs: 200
+    seed: 42
+    num-workers: 8
+    metric-of-interest: miou
+    early-stopping: true
+    early-stopping-patience: 20

--- a/sagemaker/configs/lora_qv_r8/run.yaml
+++ b/sagemaker/configs/lora_qv_r8/run.yaml
@@ -1,0 +1,24 @@
+job:
+  name_prefix: mermaidseg-dinov3-lora-r8
+  image: mermaid-segmentation-jobs:training-latest
+  entrypoint: scripts/sagemaker_train_entrypoint.py
+  instance_type: ml.g5.2xlarge
+  volume_gb: 200
+  max_runtime_hours: 48
+  env:
+    MERMAID_CORALNET_ANNOTATIONS_PATH: etl-outputs/coralnet/20260623_nogit/coralnet_training_manifest_20260623_nogit.parquet
+
+config:
+  config_data: configs/data_config_coralnet_mermaid.yaml
+  config_model: configs/model_config_dinov3_lora_qv_r8.yaml
+  config_training: configs/training_config_dinov3_lora.yaml
+  config_logger: configs/logger_config.yaml
+  overrides:
+    run-name: dinov3-lora-qv-r8-coralnet-all-mermaid
+    experiment-name: post-baseline
+    epochs: 200
+    seed: 42
+    num-workers: 8
+    metric-of-interest: miou
+    early-stopping: true
+    early-stopping-patience: 20

--- a/sagemaker/runs/dinov3_lora_qv_r16.yaml
+++ b/sagemaker/runs/dinov3_lora_qv_r16.yaml
@@ -1,0 +1,24 @@
+job:
+  name_prefix: mermaidseg-dinov3-lora-r16
+  image: mermaid-segmentation-jobs:training-latest
+  entrypoint: scripts/sagemaker_train_entrypoint.py
+  instance_type: ml.g5.2xlarge
+  volume_gb: 200
+  max_runtime_hours: 48
+  env:
+    MERMAID_CORALNET_ANNOTATIONS_PATH: etl-outputs/coralnet/20260623_nogit/coralnet_training_manifest_20260623_nogit.parquet
+
+config:
+  config_data: configs/data_config_coralnet_mermaid.yaml
+  config_model: configs/model_config_dinov3_lora_qv_r16.yaml
+  config_training: configs/training_config_dinov3_lora.yaml
+  config_logger: configs/logger_config.yaml
+  overrides:
+    run-name: dinov3-lora-qv-r16-coralnet-all-mermaid
+    experiment-name: post-baseline
+    epochs: 200
+    seed: 42
+    num-workers: 8
+    metric-of-interest: miou
+    early-stopping: true
+    early-stopping-patience: 20

--- a/sagemaker/runs/dinov3_lora_qv_r8.yaml
+++ b/sagemaker/runs/dinov3_lora_qv_r8.yaml
@@ -1,0 +1,24 @@
+job:
+  name_prefix: mermaidseg-dinov3-lora-r8
+  image: mermaid-segmentation-jobs:training-latest
+  entrypoint: scripts/sagemaker_train_entrypoint.py
+  instance_type: ml.g5.2xlarge
+  volume_gb: 200
+  max_runtime_hours: 48
+  env:
+    MERMAID_CORALNET_ANNOTATIONS_PATH: etl-outputs/coralnet/20260623_nogit/coralnet_training_manifest_20260623_nogit.parquet
+
+config:
+  config_data: configs/data_config_coralnet_mermaid.yaml
+  config_model: configs/model_config_dinov3_lora_qv_r8.yaml
+  config_training: configs/training_config_dinov3_lora.yaml
+  config_logger: configs/logger_config.yaml
+  overrides:
+    run-name: dinov3-lora-qv-r8-coralnet-all-mermaid
+    experiment-name: post-baseline
+    epochs: 200
+    seed: 42
+    num-workers: 8
+    metric-of-interest: miou
+    early-stopping: true
+    early-stopping-patience: 20

--- a/tests/model/test_linear_lora.py
+++ b/tests/model/test_linear_lora.py
@@ -1,0 +1,26 @@
+"""Smoke tests for LinearDINOv3 LoRA wiring."""
+
+from __future__ import annotations
+
+import torch
+
+import mermaidseg.model.models as models
+
+
+def test_linear_lora_only_adapters_and_head_trainable(mock_dinov3_encoder, monkeypatch):
+    mock_dinov3_encoder(models)
+
+    def fake_wrap(encoder, **kwargs):
+        encoder.register_parameter("lora_q", torch.nn.Parameter(torch.ones(2)))
+        return encoder
+
+    monkeypatch.setattr(models, "_wrap_encoder_with_lora", fake_wrap)
+    model = models.LinearLoRADINOv3(num_classes=3, input_size=(56, 56))
+    assert model.use_lora is True
+    trainable = {n for n, p in model.named_parameters() if p.requires_grad}
+    assert any(n.endswith("lora_q") or "lora_q" in n for n in trainable)
+    assert any(n.startswith("head") for n in trainable)
+    non_lora_encoder = [
+        n for n, p in model.encoder.named_parameters() if p.requires_grad and "lora_" not in n
+    ]
+    assert non_lora_encoder == []


### PR DESCRIPTION
## Summary

Injects PEFT LoRA into the Q/V attention projections of the frozen LinearDINOv3 baseline (issue #12), per #172's post-baseline PEFT path.

- `LinearLoRADINOv3(LinearDINOv3)`: `use_lora=True` by default, `lora_target_modules=("q_proj","v_proj")`. Reuses the existing `_wrap_encoder_with_lora`/`DEFAULT_LORA_TARGET_MODULES` helpers already used by the DPT-head LoRA model classes — no new PEFT wiring, just applying it to the plain linear-head variant that matches the baseline architecture.
- `freeze_encoder()` override: with LoRA, keeps `lora_*` params trainable while freezing the rest of the encoder (rather than the plain frozen-probe path, which also runs the encoder under `torch.no_grad`).
- `MetaModel`: optional `lora_lr` optimizer kwarg. When set and the model has `use_lora`, splits trainable params into two groups — head at the base `lr`, LoRA adapters at `lora_lr` — instead of one flat param group.

## Configs (per #172's locked assumptions)

- `configs/model_config_dinov3_lora_qv_r8.yaml` / `_r16.yaml`: `lora_alpha = 2*r` (16, 32), targets exactly `["q_proj","v_proj"]`.
- `configs/training_config_dinov3_lora.yaml`: head `lr=1e-3`, `lora_lr=1e-4`, CE loss only. Per the ticket ("at most two loss variants... no full factorial"), this PR does not pull in Focal — LoRA+Focal is a possible follow-up once #170's winner is known.
- SageMaker run configs for both ranks.

## Provenance

Ported from the closed `cursor/ab56a7a7` (#191), which bundled this with Focal loss and a MERMAID holdout fix (split out separately — see #194, merged, and the upcoming #170 branch). This piece had no known defects in review and is close to a straight cherry-pick: `mermaidseg/model/models.py` and `meta.py` are unchanged between the fork point and current trunk, so nothing needed adapting to the `Experiment` seam.

## Testing

- `tests/model/test_linear_lora.py` (ported, unchanged): asserts only `lora_*` + head params are trainable, base encoder params are not.
- `uv run pytest -m "not integration"`: 420 passed
- `uv run --extra all pytest -m integration`: 11 passed
- `python -m mermaidseg.experiment validate` on both new run YAMLs: clean

Closes #172