### PR TITLE
feat(model): class-weighted focal loss on frozen LinearDINOv3

### DIFF
--- a/artifacts/README.md
+++ b/artifacts/README.md
@@ -1,0 +1,16 @@
+# Class-weight artifacts
+
+Build from annotation parquet/manifests (no image decode):
+
+```bash
+uv run python scripts/build_class_weight_artifact.py \
+  --class-subset-from configs/training_config_dinov3_base.yaml \
+  --mapping configs/coralnet_to_mermaid_mapping_temporary.json \
+  --coralnet-parquet /path/to/coralnet_training_manifest.parquet \
+  --coralnet-label-column source_label_name \
+  --mermaid-parquet /path/to/mermaid_confirmed_annotations.parquet \
+  --mermaid-label-column benthic_attribute_name \
+  --output artifacts/class_weights_dinov3_base.json
+```
+
+Point `training.loss.weight_path` at the resulting JSON. Counts are point-label frequencies, not padded pixel masks.

--- a/configs/training_config_dinov3_focal.yaml
+++ b/configs/training_config_dinov3_focal.yaml
@@ -1,0 +1,45 @@
+# Training config: Class-Weighted Focal Loss on frozen LinearDINOv3 (Ticket 2a / #170).
+# Fork of training_config_dinov3_linear.yaml — same freeze/batch/class_subset as issue #12
+# baseline; only the loss block changes. Do not resume a CE checkpoint into this run.
+# Build weights first:
+#   uv run python scripts/build_class_weight_artifact.py ... --output artifacts/class_weights_dinov3_base.json
+training:
+    training_mode: "standard"
+    freeze_encoder: true
+    loss:
+        type: ClassWeightedFocalLoss
+        ignore_index: 0
+        gamma: 2.0
+        damping_denominator: 100
+        weight_path: artifacts/class_weights_dinov3_base.json
+    epochs: 200
+    optimizer:
+        type: AdamW
+        lr: 0.001
+        weight_decay: 0.01
+    scheduler:
+        type: PolynomialLR
+        power: 1
+        total_iters: 200
+        # Frozen probe: no LR warmup (matches issue-12 linear baseline).
+        warmup_iters: 0
+    iterations_per_train_epoch: 1000
+    iterations_per_val_epoch: 200
+    # Matches training_config_dinov3_linear.yaml (issue #12): batch 8 -> 32 after MLflow
+    # showed ~2.85 GB / 24 GB at batch 8. Frozen encoder runs under torch.no_grad.
+    batch_size: 32
+    # Same class_subset as training_config_dinov3_linear.yaml (issue #12).
+    class_subset: ['Acanthastrea', 'Acropora', 'Agaricia agaricites', 'Algae covered substrate', 'Alveopora',
+                    'Astrea', 'Astreopora', 'Background', 'Bare substrate', 'Coscinaraea', 'Crustose coralline algae',
+                    'Cyanobacteria', 'Cyphastrea', 'Dark', 'Dictyota', 'Diploastrea', 'Dipsastraea', 'Echinophyllia',
+                    'Echinopora', 'Euphyllia', 'Favia', 'Favites', 'Fungia', 'Galaxea', 'Gardineroseris', 'Goniastrea',
+                    'Goniopora', 'Gorgonian', 'Halimeda', 'Hard coral', 'Heliopora', 'Human', 'Human-made structure', 'Hydnophora',
+                    'Isopora', 'Leptastrea', 'Leptoria', 'Leptoseris', 'Lobophora', 'Lobophyllia', 'Macroalgae', 'Madracis',
+                    'Merulina', 'Millepora', 'Montastraea', 'Montastraea cavernosa', 'Montipora', 'Mycedium',
+                    'Orbicella annularis', 'Orbicella faveolata', 'Pachyseris', 'Padina', 'Pavona', 'Pectinia', 'Platygyra',
+                    'Pocillopora', 'Porites', 'Porites astreoides', 'Psammocora', 'Rock', 'Rubble', 'Sand', 'Sargassum',
+                    'Sea urchin', 'Seagrass', 'Seriatopora', 'Siderastrea siderea', 'Soft coral', 'Sponge', 'Stylophora',
+                    'Symphyllia', 'Transect tools', 'Tridacna giant clam', 'Turbinaria-algae', 'Turbinaria-coral',
+                    'Turf algae', 'Zoanthid']
+    padding: 3
+    label_roll_up: True

--- a/mermaidseg/model/class_weights.py
+++ b/mermaidseg/model/class_weights.py
@@ -1,0 +1,184 @@
+"""Class-frequency weights from annotation parquet counts (no image I/O).
+
+Ticket 2a (1A): count labels in CoralNet/MERMAID annotation tables, map to target ids,
+and write a versioned JSON artifact that training loads into the loss.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import torch
+
+logger = logging.getLogger(__name__)
+
+ARTIFACT_SCHEMA_VERSION = 2
+
+
+def inverse_frequency_weights(
+    counts: np.ndarray,
+    *,
+    ignore_index: int = 0,
+    max_ratio: float = 10.0,
+) -> np.ndarray:
+    """Inverse-frequency weights, mean-normalized over active classes and clipped to
+    ``max_ratio`` so the rarest class can't dominate the loss unboundedly."""
+    counts = np.asarray(counts, dtype=np.float64)
+    weights = 1.0 / np.maximum(counts, 1.0)
+    active = np.ones(len(weights), dtype=bool)
+    if 0 <= ignore_index < len(weights):
+        active[ignore_index] = False
+        weights[ignore_index] = 0.0
+    if active.any() and weights[active].mean() > 0:
+        weights[active] /= weights[active].mean()
+        weights[active] = np.clip(weights[active], None, max_ratio)
+    return weights.astype(np.float64)
+
+
+def counts_from_label_series(
+    labels: pd.Series,
+    name_to_target: dict[str, int],
+    num_classes: int,
+) -> np.ndarray:
+    """Map source label names to target ids and accumulate annotation counts."""
+    counts = np.zeros(num_classes, dtype=np.int64)
+    mapped = labels.map(name_to_target).fillna(0).astype(int)
+    for tid, count in mapped.value_counts().items():
+        tid_i = int(tid)
+        if 0 <= tid_i < num_classes:
+            counts[tid_i] += int(count)
+    return counts
+
+
+def build_target_name_map(class_subset: list[str]) -> dict[str, int]:
+    """Assign target ids 1..N alphabetically (case-sensitive names as in training
+    config)."""
+    return {name: idx for idx, name in enumerate(sorted(class_subset), start=1)}
+
+
+def load_source_to_target_name_map(
+    mapping_path: Path | str | None,
+) -> dict[str, str]:
+    """Load coralnet→mermaid (or identity) name map; keys/values lowercased for
+    lookup."""
+    if mapping_path is None:
+        return {}
+    path = Path(mapping_path)
+    raw = json.loads(path.read_text())
+    return {str(k).lower(): str(v) for k, v in raw.items()}
+
+
+def resolve_source_label_to_target_id(
+    source_label: str,
+    *,
+    source_to_mermaid: dict[str, str],
+    target_name_to_id: dict[str, int],
+) -> int:
+    """Map a source label string to a target id (0 = ignore)."""
+    key = str(source_label).lower()
+    mermaid_name = source_to_mermaid.get(key, key)
+    # Prefer exact case match against class_subset, then case-insensitive.
+    if mermaid_name in target_name_to_id:
+        return target_name_to_id[mermaid_name]
+    lower_map = {n.lower(): i for n, i in target_name_to_id.items()}
+    return lower_map.get(mermaid_name.lower(), 0)
+
+
+def count_parquet_labels(
+    parquet_paths: list[Path | str],
+    *,
+    label_column: str,
+    source_to_mermaid: dict[str, str],
+    target_name_to_id: dict[str, int],
+    num_classes: int,
+) -> np.ndarray:
+    """Accumulate target-id counts from one or more annotation parquet files."""
+    counts = np.zeros(num_classes, dtype=np.int64)
+    for path in parquet_paths:
+        path = Path(path)
+        df = pd.read_parquet(path, columns=[label_column])
+        series = df[label_column].astype(str)
+        name_to_target = {
+            name: resolve_source_label_to_target_id(
+                name,
+                source_to_mermaid=source_to_mermaid,
+                target_name_to_id=target_name_to_id,
+            )
+            for name in series.unique()
+        }
+        counts += counts_from_label_series(series, name_to_target, num_classes)
+        logger.info("Counted labels from %s (%d rows)", path, len(df))
+    return counts
+
+
+def build_weight_artifact(
+    *,
+    counts: np.ndarray,
+    target_id2label: dict[int, str],
+    class_subset: list[str],
+    max_ratio: float = 10.0,
+    ignore_index: int = 0,
+    mapping_path: str | None = None,
+    git_sha: str | None = None,
+    sources: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Assemble the versioned class-weight artifact dict."""
+    weights = inverse_frequency_weights(counts, ignore_index=ignore_index, max_ratio=max_ratio)
+    labels = ["ignore"] + [target_id2label[i] for i in sorted(target_id2label)]
+    payload = {
+        "schema_version": ARTIFACT_SCHEMA_VERSION,
+        "recipe": {
+            "type": "inverse_freq_clipped",
+            "max_ratio": max_ratio,
+            "ignore_index": ignore_index,
+            "note": (
+                "Counts from annotation parquet/manifests (point labels), not "
+                "padded pixel masks (padding: 3)."
+            ),
+        },
+        "class_subset": list(class_subset),
+        "target_id2label": {str(k): v for k, v in sorted(target_id2label.items())},
+        "counts": [int(c) for c in counts.tolist()],
+        "weights": [float(w) for w in weights.tolist()],
+        "labels": labels[: len(counts)],
+        "mapping_path": mapping_path,
+        "git_sha": git_sha,
+        "sources": sources or [],
+    }
+    payload["mapping_hash"] = hashlib.sha256(
+        json.dumps(
+            {
+                "class_subset": payload["class_subset"],
+                "mapping_path": mapping_path,
+                "target_id2label": payload["target_id2label"],
+            },
+            sort_keys=True,
+        ).encode()
+    ).hexdigest()[:16]
+    return payload
+
+
+def save_weight_artifact(artifact: dict[str, Any], path: Path | str) -> Path:
+    """Atomically write the weight artifact JSON."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n")
+    tmp.replace(path)
+    logger.info("Wrote class-weight artifact to %s", path)
+    return path
+
+
+def load_class_weight_tensor(path: Path | str) -> torch.Tensor:
+    """Load ``weights`` from a class-weight artifact JSON as a float tensor."""
+    path = Path(path)
+    artifact = json.loads(path.read_text())
+    if "weights" not in artifact:
+        raise ValueError(f"Class-weight artifact missing 'weights': {path}")
+    return torch.tensor(artifact["weights"], dtype=torch.float32)

--- a/mermaidseg/model/loss.py
+++ b/mermaidseg/model/loss.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn.functional as F
 
 from mermaidseg.dataset_reconciliation.concepts import TAXONOMIC_CONCEPTS
+from mermaidseg.model.class_weights import load_class_weight_tensor
 from mermaidseg.model.concept_metrics import (
     calculate_multi_hot_concept_loss,
     calculate_taxonomic_rank_loss,
@@ -16,7 +17,8 @@ def iter_concept_slices(
     concept_labels: torch.Tensor,
     concept_outputs: torch.Tensor,
 ) -> Iterator[tuple[str, torch.Tensor, torch.Tensor]]:
-    """Yield (name, labels_slice, outputs_slice) for each taxonomic rank and the binary tail."""
+    """Yield (name, labels_slice, outputs_slice) for each taxonomic rank and the binary
+    tail."""
     offset = 0
     for concept in TAXONOMIC_CONCEPTS:
         if concept not in concept_value2id:
@@ -62,8 +64,8 @@ def _masked_cross_entropy(
 
 
 class CrossEntropyLoss(torch.nn.CrossEntropyLoss):
-    """CrossEntropyLoss is a wrapper of `torch.nn.CrossEntropyLoss` that allows for additional
-    customization.
+    """CrossEntropyLoss is a wrapper of `torch.nn.CrossEntropyLoss` that allows for
+    additional customization.
 
     Attributes:
         ignore_index (int): Specifies a target value that is ignored and does not contribute to the input gradient.
@@ -74,6 +76,9 @@ class CrossEntropyLoss(torch.nn.CrossEntropyLoss):
     def __init__(
         self, ignore_index: int = 0, damping_denominator: float = 0.0, **kwargs: Any
     ) -> None:
+        weight_path = kwargs.pop("weight_path", None)
+        if weight_path is not None and "weight" not in kwargs:
+            kwargs["weight"] = load_class_weight_tensor(weight_path)
         super().__init__(ignore_index=ignore_index, **kwargs)
         self.damping_denominator = damping_denominator
 
@@ -96,8 +101,9 @@ class CrossEntropyLoss(torch.nn.CrossEntropyLoss):
 class BCEWithLogitsLoss(torch.nn.BCEWithLogitsLoss):
     """BCE loss for concept prediction that masks background pixels before averaging.
 
-    Wraps `torch.nn.BCEWithLogitsLoss` with `reduction="none"` and applies a foreground mask derived
-    from `labels` so background pixels (label == 0) do not contribute to the mean.
+    Wraps `torch.nn.BCEWithLogitsLoss` with `reduction="none"` and applies a foreground
+    mask derived from `labels` so background pixels (label == 0) do not contribute to
+    the mean.
     """
 
     def __init__(
@@ -180,7 +186,8 @@ class BCEWithLogitsLoss(torch.nn.BCEWithLogitsLoss):
 
 
 class ConceptBottleneckLoss(torch.nn.Module):
-    """ConceptBottleneckLoss combines a classification loss with a concept prediction loss.
+    """ConceptBottleneckLoss combines a classification loss with a concept prediction
+    loss.
 
     It computes the total loss as the sum of the classification loss and a weighted concept loss.
     The concept loss operates on the model's raw concept *logits* (pre-activation): taxonomic
@@ -220,8 +227,8 @@ class ConceptBottleneckLoss(torch.nn.Module):
         concept_logits: torch.Tensor,
         concept_labels: torch.Tensor,
     ) -> tuple[torch.Tensor, dict[str, float]]:
-        """Computes the total loss as the sum of the classification loss and a weighted concept
-        loss.
+        """Computes the total loss as the sum of the classification loss and a weighted
+        concept loss.
 
         Args:
             outputs (torch.Tensor): The model's output logits for classification.
@@ -275,3 +282,83 @@ class ConceptBottleneckLoss(torch.nn.Module):
         loss_components["concepts"] = concept_loss_value.item()
         total_loss = class_loss_value + self.lambda_weight * concept_loss_value
         return total_loss, loss_components
+
+
+def _resolve_class_weight(
+    weight: torch.Tensor | list[float] | None,
+    weight_path: str | None,
+) -> torch.Tensor | None:
+    if weight_path is not None:
+        return load_class_weight_tensor(weight_path)
+    if weight is None:
+        return None
+    if isinstance(weight, torch.Tensor):
+        return weight.float()
+    return torch.tensor(weight, dtype=torch.float32)
+
+
+class ClassWeightedFocalLoss(torch.nn.Module):
+    """Masked focal loss with optional per-class frequency weights.
+
+    Operates on logits ``[B, C, H, W]`` and target labels ``[B, H, W]``. Class weights
+    typically come from a parquet-derived artifact (``weight_path``, built via
+    ``scripts/build_class_weight_artifact.py`` — inverse-frequency, mean-normalized,
+    clipped to a max ratio). The ignore slot (default 0) does not contribute.
+    """
+
+    def __init__(
+        self,
+        ignore_index: int = 0,
+        gamma: float = 2.0,
+        damping_denominator: float = 100.0,
+        weight: torch.Tensor | list[float] | None = None,
+        weight_path: str | None = None,
+        label_smoothing: float = 0.0,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__()
+        if kwargs:
+            # Allow unused YAML keys (e.g. legacy CE kwargs) without failing MetaModel.
+            pass
+        self.ignore_index = ignore_index
+        self.gamma = gamma
+        self.damping_denominator = damping_denominator
+        self.label_smoothing = label_smoothing
+        resolved = _resolve_class_weight(weight, weight_path)
+        if resolved is not None:
+            self.register_buffer("weight", resolved)
+        else:
+            self.weight = None
+
+    def forward(
+        self,
+        outputs: torch.Tensor,
+        target_labels: torch.Tensor,
+    ) -> tuple[torch.Tensor, dict[str, float]]:
+        valid_mask = target_labels != self.ignore_index
+        if not valid_mask.any():
+            zero = outputs.sum() * 0.0
+            return zero, {"classification": 0.0, "focal": 0.0}
+
+        # Per-pixel CE without class weights so focal modulating factor uses true p_t.
+        per_pixel_ce = F.cross_entropy(
+            outputs,
+            target_labels,
+            weight=None,
+            ignore_index=self.ignore_index,
+            reduction="none",
+            label_smoothing=self.label_smoothing,
+        )
+        pt = torch.exp(-per_pixel_ce.detach())
+        focal = ((1.0 - pt) ** self.gamma) * per_pixel_ce
+
+        if self.weight is not None:
+            # Gather class weight per pixel; ignore pixels already masked out.
+            w = self.weight.to(device=outputs.device, dtype=outputs.dtype)
+            class_w = w[target_labels.clamp(min=0, max=w.numel() - 1)]
+            focal = focal * class_w
+
+        valid = focal[valid_mask]
+        loss = valid.sum() / (valid.numel() + self.damping_denominator)
+        value = float(loss.item())
+        return loss, {"classification": value, "focal": value}

--- a/sagemaker/configs/focal/run.yaml
+++ b/sagemaker/configs/focal/run.yaml
@@ -1,0 +1,25 @@
+job:
+  name_prefix: mermaidseg-dinov3-focal
+  image: mermaid-segmentation-jobs:training-latest
+  entrypoint: scripts/sagemaker_train_entrypoint.py
+  instance_type: ml.g5.2xlarge
+  volume_gb: 200
+  max_runtime_hours: 48
+  env:
+    MERMAID_CORALNET_ANNOTATIONS_PATH: etl-outputs/coralnet/20260623_nogit/coralnet_training_manifest_20260623_nogit.parquet
+
+# Same data/model stack as issue #12 baseline; only training config swaps CE → Focal.
+config:
+  config_data: configs/data_config_coralnet_mermaid.yaml
+  config_model: configs/model_config.yaml
+  config_training: configs/training_config_dinov3_focal.yaml
+  config_logger: configs/logger_config.yaml
+  overrides:
+    run-name: dinov3-focal-coralnet-all-mermaid
+    experiment-name: post-baseline
+    epochs: 200
+    seed: 42
+    num-workers: 8
+    metric-of-interest: miou
+    early-stopping: true
+    early-stopping-patience: 20

--- a/sagemaker/runs/dinov3_focal.yaml
+++ b/sagemaker/runs/dinov3_focal.yaml
@@ -1,0 +1,25 @@
+job:
+  name_prefix: mermaidseg-dinov3-focal
+  image: mermaid-segmentation-jobs:training-latest
+  entrypoint: scripts/sagemaker_train_entrypoint.py
+  instance_type: ml.g5.2xlarge
+  volume_gb: 200
+  max_runtime_hours: 48
+  env:
+    MERMAID_CORALNET_ANNOTATIONS_PATH: etl-outputs/coralnet/20260623_nogit/coralnet_training_manifest_20260623_nogit.parquet
+
+# Same data/model stack as issue #12 baseline; only training config swaps CE → Focal.
+config:
+  config_data: configs/data_config_coralnet_mermaid.yaml
+  config_model: configs/model_config.yaml
+  config_training: configs/training_config_dinov3_focal.yaml
+  config_logger: configs/logger_config.yaml
+  overrides:
+    run-name: dinov3-focal-coralnet-all-mermaid
+    experiment-name: post-baseline
+    epochs: 200
+    seed: 42
+    num-workers: 8
+    metric-of-interest: miou
+    early-stopping: true
+    early-stopping-patience: 20

--- a/scripts/build_class_weight_artifact.py
+++ b/scripts/build_class_weight_artifact.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Build a versioned class-weight artifact from annotation parquet/manifests.
+
+Counts labels without loading images (Ticket 2a / 1A). Example::
+
+    uv run python scripts/build_class_weight_artifact.py \\
+      --class-subset-from configs/training_config_dinov3_base.yaml \\
+      --mapping configs/coralnet_to_mermaid_mapping_temporary.json \\
+      --coralnet-parquet /path/to/coralnet_training_manifest.parquet \\
+      --coralnet-label-column source_label_name \\
+      --mermaid-parquet /path/to/mermaid_confirmed_annotations.parquet \\
+      --mermaid-label-column benthic_attribute_name \\
+      --output artifacts/class_weights_dinov3_base.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import yaml
+
+from mermaidseg.model.class_weights import (
+    build_target_name_map,
+    build_weight_artifact,
+    count_parquet_labels,
+    load_source_to_target_name_map,
+    save_weight_artifact,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    stream=sys.stdout,
+)
+logger = logging.getLogger(__name__)
+
+
+def _git_sha() -> str | None:
+    try:
+        return subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], text=True).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def _load_class_subset(path: Path) -> list[str]:
+    cfg = yaml.safe_load(path.read_text())
+    subset = cfg.get("training", cfg).get("class_subset")
+    if not subset:
+        raise ValueError(f"No training.class_subset in {path}")
+    return list(subset)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--class-subset-from",
+        type=Path,
+        required=True,
+        help="Training YAML containing training.class_subset",
+    )
+    parser.add_argument(
+        "--mapping",
+        type=Path,
+        default=None,
+        help="Optional coralnet→mermaid JSON map (name or id keys)",
+    )
+    parser.add_argument(
+        "--coralnet-parquet",
+        type=Path,
+        action="append",
+        default=[],
+        help="CoralNet annotation/manifest parquet (repeatable)",
+    )
+    parser.add_argument(
+        "--coralnet-label-column",
+        default="source_label_name",
+        help="Label column in CoralNet parquet (default: source_label_name)",
+    )
+    parser.add_argument(
+        "--mermaid-parquet",
+        type=Path,
+        action="append",
+        default=[],
+        help="MERMAID annotation parquet (repeatable)",
+    )
+    parser.add_argument(
+        "--mermaid-label-column",
+        default="benthic_attribute_name",
+        help="Label column in MERMAID parquet",
+    )
+    parser.add_argument(
+        "--max-ratio",
+        type=float,
+        default=10.0,
+        help="Clip inverse-frequency weights to this max ratio over the mean (default: 10.0)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Output JSON path",
+    )
+    args = parser.parse_args()
+
+    if not args.coralnet_parquet and not args.mermaid_parquet:
+        parser.error("Provide at least one --coralnet-parquet or --mermaid-parquet")
+
+    class_subset = _load_class_subset(args.class_subset_from)
+    target_name_to_id = build_target_name_map(class_subset)
+    target_id2label = {i: n for n, i in target_name_to_id.items()}
+    num_classes = len(class_subset) + 1  # + ignore slot
+    source_to_mermaid = load_source_to_target_name_map(args.mapping)
+
+    counts = np.zeros(num_classes, dtype=np.int64)
+    sources: list[dict] = []
+
+    if args.coralnet_parquet:
+        part = count_parquet_labels(
+            args.coralnet_parquet,
+            label_column=args.coralnet_label_column,
+            source_to_mermaid=source_to_mermaid,
+            target_name_to_id=target_name_to_id,
+            num_classes=num_classes,
+        )
+        counts = counts + part
+        sources.append(
+            {
+                "dataset": "coralnet",
+                "paths": [str(p) for p in args.coralnet_parquet],
+                "label_column": args.coralnet_label_column,
+            }
+        )
+
+    if args.mermaid_parquet:
+        # MERMAID labels are already benthic names; identity map via empty overlay.
+        part = count_parquet_labels(
+            args.mermaid_parquet,
+            label_column=args.mermaid_label_column,
+            source_to_mermaid={},
+            target_name_to_id=target_name_to_id,
+            num_classes=num_classes,
+        )
+        counts = counts + part
+        sources.append(
+            {
+                "dataset": "mermaid",
+                "paths": [str(p) for p in args.mermaid_parquet],
+                "label_column": args.mermaid_label_column,
+            }
+        )
+
+    artifact = build_weight_artifact(
+        counts=counts,
+        target_id2label=target_id2label,
+        class_subset=class_subset,
+        max_ratio=args.max_ratio,
+        mapping_path=str(args.mapping) if args.mapping else None,
+        git_sha=_git_sha(),
+        sources=sources,
+    )
+    save_weight_artifact(artifact, args.output)
+    logger.info(
+        "Active classes with counts>0: %d / %d",
+        int((counts[1:] > 0).sum()),
+        len(class_subset),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/model/test_loss_and_weights.py
+++ b/tests/model/test_loss_and_weights.py
@@ -1,0 +1,97 @@
+"""Tests for class-weight helpers and the class-weighted focal loss."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+
+from mermaidseg.model.class_weights import (
+    build_target_name_map,
+    build_weight_artifact,
+    counts_from_label_series,
+    inverse_frequency_weights,
+    load_class_weight_tensor,
+    save_weight_artifact,
+)
+from mermaidseg.model.loss import ClassWeightedFocalLoss
+
+
+class TestClassWeights:
+    def test_zeros_ignore_and_upweights_rare(self):
+        counts = np.array([1000, 1000, 10], dtype=np.float64)
+        weights = inverse_frequency_weights(counts, ignore_index=0)
+        assert weights[0] == 0.0
+        assert weights[2] > weights[1]
+
+    def test_clips_extreme_ratio(self):
+        # 20 common classes (count 1000) + 1 rare class (count 1). Uncapped
+        # inverse-frequency, mean-normalized, would put the rare class's weight at
+        # ~20.6 (>> max_ratio); the clip must bring it down to exactly max_ratio.
+        counts = np.array([1000, *([1000] * 20), 1], dtype=np.float64)
+        weights = inverse_frequency_weights(counts, ignore_index=0, max_ratio=10.0)
+        active = weights[1:]
+        assert active.max() == 10.0
+        assert active.min() > 0
+
+    def test_counts_from_label_series(self):
+        series = pd.Series(["Acropora", "Porites", "Acropora", "unknown"])
+        name_to_target = {"Acropora": 1, "Porites": 2}
+        counts = counts_from_label_series(series, name_to_target, num_classes=3)
+        assert counts.tolist() == [1, 2, 1]
+
+    def test_artifact_roundtrip(self, tmp_path: Path):
+        class_subset = ["Acropora", "Porites"]
+        target_name_to_id = build_target_name_map(class_subset)
+        target_id2label = {i: n for n, i in target_name_to_id.items()}
+        counts = np.array([5, 100, 10], dtype=np.int64)
+        artifact = build_weight_artifact(
+            counts=counts,
+            target_id2label=target_id2label,
+            class_subset=class_subset,
+            max_ratio=10.0,
+        )
+        path = save_weight_artifact(artifact, tmp_path / "weights.json")
+        loaded = load_class_weight_tensor(path)
+        assert loaded.shape == (3,)
+        assert loaded[0].item() == 0.0
+        assert "mapping_hash" in json.loads(path.read_text())
+
+
+class TestClassWeightedFocalLoss:
+    def test_shapes_ignore_and_finite_grads(self):
+        loss_fn = ClassWeightedFocalLoss(
+            ignore_index=0,
+            gamma=2.0,
+            damping_denominator=1.0,
+            weight=[0.0, 1.0, 2.0],
+        )
+        outputs = torch.randn(2, 3, 8, 8, requires_grad=True)
+        labels = torch.randint(0, 3, (2, 8, 8))
+        loss, comps = loss_fn(outputs, labels)
+        assert torch.isfinite(loss)
+        assert "classification" in comps
+        loss.backward()
+        assert outputs.grad is not None
+
+    def test_all_ignore_returns_zero(self):
+        loss_fn = ClassWeightedFocalLoss(ignore_index=0, gamma=2.0)
+        outputs = torch.randn(1, 3, 4, 4, requires_grad=True)
+        labels = torch.zeros(1, 4, 4, dtype=torch.long)
+        loss, comps = loss_fn(outputs, labels)
+        assert loss.item() == 0.0
+        assert comps["classification"] == 0.0
+
+    def test_weight_path_loads(self, tmp_path: Path):
+        artifact = {
+            "weights": [0.0, 1.0, 3.0],
+            "schema_version": 2,
+        }
+        path = tmp_path / "w.json"
+        path.write_text(json.dumps(artifact))
+        loss_fn = ClassWeightedFocalLoss(weight_path=str(path), gamma=2.0)
+        assert loss_fn.weight is not None
+        assert loss_fn.weight[2].item() == 3.0


### PR DESCRIPTION
## Summary

Replaces CrossEntropyLoss with `ClassWeightedFocalLoss` on the frozen LinearDINOv3 baseline (issue #12), per #170's post-baseline tuning path — testing whether per-class weighting improves rare coral classes under severe imbalance.

- `ClassWeightedFocalLoss`: masked focal loss (`(1-p_t)^gamma * CE`) with an optional per-class weight tensor gathered by pixel label id.
- `mermaidseg/model/class_weights.py`: counts labels from annotation parquet/manifests (point-label counts, not padded pixel masks — `padding: 3`), maps source labels → target ids, and writes a versioned weight-artifact JSON (`schema_version`, `mapping_hash`, `git_sha`) that the loss loads via `weight_path`.
- `scripts/build_class_weight_artifact.py`: CLI to build that artifact ahead of a run — see `artifacts/README.md`.

## Provenance and bug fix

Ported from the closed `cursor/ab56a7a7` (#191), which bundled this with LoRA (split out separately — see #195) and a MERMAID holdout fix (#194, merged). Review of #191 found the weight formula was a near no-op: `inverse_sqrt_weights` computed `1/sqrt(counts + 2_000_000)`, and that additive constant swamps the sqrt at any realistic per-class count — a count-of-10 class and a count-of-2,000,000 class differed by only ~√2× after normalization. The existing weight test only passed because it explicitly overrode the constant to `0.0`, sidestepping the bug rather than catching the shipped default.

Fixed: `inverse_frequency_weights` now computes true `1/count`, mean-normalized over active (non-ignore) classes, clipped to a **max 10× ratio** so the rarest class can't dominate the loss unboundedly. Added `test_clips_extreme_ratio`, which constructs a 20-common/1-rare synthetic count distribution where the uncapped weight would land at ~20.6× and asserts the clip brings it down to exactly 10.0.

Also renamed `DomainWeightedFocalLoss` → `ClassWeightedFocalLoss` and `inverse_sqrt_weights` → `inverse_frequency_weights` — the mechanism is per-class weighting gathered by pixel label, not per-domain/source weighting; the old names were a leftover from an earlier design the code no longer matched.

## Scope

Deliberately excludes `EdgeAwareSegmentationLoss` and `label_edge_mask` (#171's code) and `training_config_dinov3_focal_edge.yaml` — #171 explicitly says wait for this PR to show signal before building the edge-aware variant.

## Testing

- `tests/model/test_loss_and_weights.py`: 7 tests (ported + rewritten for the new formula/signature, plus the new clip test; dropped the bundled-in `TestEvaluatorMiou`, already covered by `tests/model/test_eval.py`)
- `uv run pytest -m "not integration"`: 426 passed
- `uv run --extra all pytest -m integration`: 11 passed
- `python -m mermaidseg.experiment validate sagemaker/runs/dinov3_focal.yaml`: clean

Closes #170