### PR TITLE
Port issue-129 baseline configs and Dockerfile fix from PR branch

### DIFF
--- a/SUBMIT_BASELINE.sh
+++ b/SUBMIT_BASELINE.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# =============================================================================
+# BASELINE SUBMISSION - READY-TO-RUN COMMAND SHEET
+# =============================================================================
+# This script is a reference for submitting the LinearDINOv3 baseline.
+# DO NOT run this directly - commands are here for copy-paste.
+# See .docs/BASELINE_QUICK_START.md for the full walkthrough.
+# =============================================================================
+
+# ============================================================================
+# STEP 1: PREFLIGHT SETUP (one-time)
+# ============================================================================
+# Load environment and validate setup
+
+direnv reload
+
+# Check AWS credentials & SageMaker setup
+make sm-check
+
+# Expected output:
+#   ✓ AWS region: us-east-1
+#   ✓ Credentials valid
+#   ✓ SageMaker execution role trusted
+#   ✓ MLflow tracking URI reachable
+
+
+# ============================================================================
+# STEP 1B: BUILD & PUSH DOCKER IMAGE
+# ============================================================================
+# Build the training container image and push to ECR
+
+export AWS_PROFILE=wcs-launcher
+ACCT=554812291621
+IMG=$ACCT.dkr.ecr.us-east-1.amazonaws.com/mermaid-segmentation-jobs
+
+# Login to ECR
+aws ecr get-login-password --region us-east-1 \
+    | docker login --username AWS --password-stdin \
+        $ACCT.dkr.ecr.us-east-1.amazonaws.com
+
+# Build image (amd64 for SageMaker)
+docker buildx build --platform linux/amd64 \
+    -t $IMG:training-latest \
+    -f docker/jobs/Dockerfile .
+
+# Push to ECR
+docker push $IMG:training-latest
+
+# Verify locally (smoke test)
+bash docker/jobs/local_smoke.sh training
+
+# Expected output:
+#   ✓ Image built successfully
+#   ✓ Pushed to ECR
+#   ✓ Local smoke test passed
+
+
+# ============================================================================
+# STEP 2: VALIDATE LOCALLY
+# ============================================================================
+# Test the training pipeline locally before SageMaker submission
+
+# Option A: Synthetic smoke test (fast, ~5 seconds)
+make smoke-standard
+
+# Option B: Real data dry-run (slower, ~40 seconds, requires AWS access)
+uv run python scripts/train_baseline.py --dry-run
+
+# Expected output from both:
+#   ✓ Dataset loaded (mermaid 15.8k + coralnet 75.7k samples)
+#   ✓ Model initialized (LinearDINOv3)
+#   ✓ Training completed (epoch 0 metrics)
+#   ✓ "Training complete" message
+
+
+# ============================================================================
+# STEP 3: SAGEMAKER DRY-RUN (validation without queuing)
+# ============================================================================
+# Validate the SageMaker job spec without actually queuing the job
+
+make sm-baseline-dry-run
+
+# Expected output:
+#   [launcher] Validating run config: sagemaker/runs/issue_129_dinov3_baseline.yaml
+#   [launcher] Image: 554812291621.dkr.ecr.us-east-1.amazonaws.com/mermaid-segmentation-jobs:training-latest
+#   [launcher] InstanceType: ml.g5.2xlarge
+#   ...
+#   [launcher] Dry-run OK. Run 'make sm-baseline-launch' to submit.
+
+
+# ============================================================================
+# STEP 4: SUBMIT THE JOB (LIVE)
+# ============================================================================
+# Actually queue the job to SageMaker
+
+make sm-baseline-launch
+
+# Expected output:
+#   [launcher] Submitting TrainingJob: mermaidseg-issue-129-baseline-20260616T123456Z
+#   [launcher] Job status: InProgress
+#   [launcher] CloudWatch: https://console.aws.amazon.com/cloudwatch/...
+#   [launcher] MLflow: https://mlflow.sagemaker.us-east-1.app.aws/#/experiments/2/runs/...
+#
+#   Job submitted! 🚀
+
+
+# ============================================================================
+# STEP 5: MONITOR THE JOB
+# ============================================================================
+# Watch the job run
+
+# Option A: Tail CloudWatch logs (real-time)
+make sm-baseline-logs
+
+# Option B: Check job status
+make sm-baseline-status
+
+# Option C: View in MLflow
+# Open the link from Step 4 and look for:
+#   Run name: "issue-129-dinov3-baseline-mermaid-coralnet"
+#   Experiment: "mermaid"
+# Metrics will be logged per epoch
+
+# Expected duration:
+#   - Dataset loading & model download: ~5 min
+#   - Training (200 epochs): ~3-4 hours
+#   - Total: ~3.5-4.5 hours
+
+
+# ============================================================================
+# ESTIMATED COST
+# ============================================================================
+# Instance:  ml.g5.2xlarge (A10G GPU) @ $1.52/hr
+# Duration:  ~4 hours
+# Cost:      ~$6 compute + <$1 storage = ~$7-10 per run
+
+
+# ============================================================================
+# SUCCESS CRITERIA
+# ============================================================================
+# Job is complete when:
+#   ✓ CloudWatch logs show "Training complete"
+#   ✓ Job status: "Completed"
+#   ✓ MLflow run has 200 epochs of metrics
+#   ✓ Model artifact in S3: s3://dev-datamermaid-sm-data/runs/<job-id>/output/
+
+
+# ============================================================================
+# TROUBLESHOOTING
+# ============================================================================
+
+# Job stuck in "Downloading" (5-10 min wait is normal)
+#   → Check CloudWatch logs: make sm-baseline-logs
+#   → Look for "Downloading image" messages
+
+# "Unable to pull image" error
+#   → Verify image exists: aws ecr list-images --repository-name mermaid-segmentation-jobs
+#   → Rebuild & push: docker push $IMG:training-latest
+
+# NaN loss or training errors
+#   → Reproduce locally: uv run python scripts/train_baseline.py ...
+#   → Check CloudWatch logs for specific error
+#   → See .docs/BASELINE_SUBMISSION.md section 8 for full troubleshooting
+
+# =============================================================================
+# REFERENCE
+# =============================================================================
+# Quick start guide:       .docs/BASELINE_QUICK_START.md (1 page)
+# Full guide:              .docs/BASELINE_SUBMISSION.md (11 sections)
+# Configuration:           sagemaker/configs/baseline/
+# Training script:         scripts/train_baseline.py
+# Main training script:    scripts/train.py
+
+# =============================================================================

--- a/configs/data_config_dinov3_base.yaml
+++ b/configs/data_config_dinov3_base.yaml
@@ -1,0 +1,65 @@
+data:
+  default:
+    train:
+      transform:
+        SmallestMaxSize:
+          max_size: 1024
+        RandomResizedCrop:
+          size: [512, 512]
+          scale: [0.2, 1]
+          ratio: [0.75, 1.33]
+        HorizontalFlip:
+          p: 0.5
+        VerticalFlip:
+          p: 0.5
+        Normalize:
+          mean: [0.485, 0.456, 0.406]
+          std: [0.229, 0.224, 0.225]
+    val:
+      transform:
+          Resize:
+            width: 512
+            height: 512
+          Normalize:
+            mean: [0.485, 0.456, 0.406]
+            std: [0.229, 0.224, 0.225]
+
+  coralnet:
+    train:
+      whitelist_sources: [1645, 1783, 1968, 2055, 3058, 3064, 3363, 3401, 3411,
+                          3425, 3460, 3478, 3681, 4342, 4559, 4721, 4882, 5155,
+                          5181, 5847, 6053, 6537, 6687, 6698, 6716, 6721, 6722,
+                          6733, 6839, 6855, 6868, 6920, 6924, 6929, 6931, 6932]
+
+    val:
+      whitelist_sources: [1776, 2297, 2759, 2978, 3573, 4353, 4596, 4710, 5086,
+                          5444, 6521, 6699, 6700, 6717, 6834, 6838, 6923, 6930,
+                          6968, 7116]
+
+  mermaid:
+    train: {}
+    val: None
+
+  coralscapes:
+    train: None
+    val: None
+
+  coralscapes_v2:
+    train: None
+    val: None
+
+  benthos_yuval:
+    train: None
+    val: None
+
+  catlin_seaview:
+    train: None
+    val: None
+
+  moorea_labeled_corals:
+    train: None
+    val: None
+
+  pacific_labeled_corals:
+    train: None
+    val: None

--- a/configs/model_config_dinov3_base.yaml
+++ b/configs/model_config_dinov3_base.yaml
@@ -1,0 +1,5 @@
+# LinearDINOv3 baseline model for issue #129 evaluation
+model:
+  name: "LinearDINOv3"
+  encoder_name: "facebook/dinov3-vitb16-pretrain-lvd1689m"
+  input_size: [512, 512]

--- a/configs/training_config_dinov3_base.yaml
+++ b/configs/training_config_dinov3_base.yaml
@@ -1,0 +1,46 @@
+# Training config for LinearDINOv3 baseline: mermaid+coralnet datasets (issue #129).
+# Linear probe: the DINOv3 backbone is frozen and only the 1x1-conv head trains, so this
+# measures the quality of frozen DINOv3 features. A frozen probe takes a higher LR than
+# full fine-tuning (head-only). Flip freeze_encoder to false (and drop lr to ~5e-5) for a
+# full fine-tune comparison.
+training:
+    training_mode: "standard"
+    freeze_encoder: true
+    loss:
+        type: CrossEntropyLoss
+        ignore_index: 0
+    epochs: 200
+    optimizer:
+        type: AdamW
+        lr: 0.001
+        weight_decay: 0.01
+    scheduler:
+        type: PolynomialLR
+        power: 1
+        total_iters: 200
+        # Frozen probe: no LR warmup (only the head trains on fixed features). Without this,
+        # meta.py defaults warmup_iters to 2000 (~2 epochs) — a fine-tune-oriented default.
+        warmup_iters: 0
+    iterations_per_train_epoch: 1000
+    iterations_per_val_epoch: 200
+    batch_size: 8
+    # Target-class whitelist (SourceLabelRegistry target_label_subset). Ids 1..N are assigned
+    # alphabetically; id 0 is the unmapped/ignore slot (ignore_index: 0). 'Background' is a real
+    # trained class here: the coralnet->mermaid map (configs/coralnet_to_mermaid_mapping_temporary.json)
+    # sends water/unclear/etc. to the benthic target 'Background' (capitalized — match is
+    # case-sensitive). Names must match the produced targets (coralnet map values + MERMAID
+    # benthic-attribute hierarchy) exactly.
+    class_subset: ['Acanthastrea', 'Acropora', 'Agaricia agaricites', 'Algae covered substrate', 'Alveopora',
+                    'Astrea', 'Astreopora', 'Background', 'Bare substrate', 'Coscinaraea', 'Crustose coralline algae',
+                    'Cyanobacteria', 'Cyphastrea', 'Dark', 'Dictyota', 'Diploastrea', 'Dipsastraea', 'Echinophyllia',
+                    'Echinopora', 'Euphyllia', 'Favia', 'Favites', 'Fungia', 'Galaxea', 'Gardineroseris', 'Goniastrea',
+                    'Goniopora', 'Gorgonian', 'Halimeda', 'Hard coral', 'Heliopora', 'Human-made structure', 'Hydnophora',
+                    'Isopora', 'Leptastrea', 'Leptoria', 'Leptoseris', 'Lobophora', 'Lobophyllia', 'Macroalgae', 'Madracis',
+                    'Merulina', 'Millepora', 'Montastraea', 'Montastraea cavernosa', 'Montipora', 'Mycedium',
+                    'Orbicella annularis', 'Orbicella faveolata', 'Pachyseris', 'Padina', 'Pavona', 'Pectinia', 'Platygyra',
+                    'Pocillopora', 'Porites', 'Porites astreoides', 'Psammocora', 'Rock', 'Rubble', 'Sand', 'Sargassum',
+                    'Sea urchin', 'Seagrass', 'Seriatopora', 'Siderastrea siderea', 'Soft coral', 'Sponge', 'Stylophora',
+                    'Symphyllia', 'Transect tools', 'Tridacna giant clam', 'Turbinaria-algae', 'Turbinaria-coral',
+                    'Turf algae', 'Zoanthid']
+    padding: 3
+    label_roll_up: True

--- a/docker/jobs/Dockerfile
+++ b/docker/jobs/Dockerfile
@@ -13,8 +13,10 @@
 
 ARG BASE_IMAGE=pytorch/pytorch:2.4.1-cuda12.4-cudnn9-runtime
 FROM ${BASE_IMAGE}
-ARG HF_TOKEN
-ENV HF_TOKEN=$HF_TOKEN
+
+# HF_TOKEN is injected at runtime by the launcher (scripts/launch_training.py sets it in the
+# SageMaker Estimator environment). Do NOT bake it via ARG/ENV — that persists the secret in
+# image layers (docker history/inspect). Gated-model downloads happen at run time, not build.
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/mermaidseg/datasets/coralnet/coralnet_dataset.py
+++ b/mermaidseg/datasets/coralnet/coralnet_dataset.py
@@ -171,5 +171,7 @@ class CoralNetDataset(BaseCoralDataset):
         image_s3_key: str | None = None,
         **row_kwargs: Any,
     ) -> NDArray[Any]:
+        if not isinstance(image_s3_key, str) or not image_s3_key:
+            image_s3_key = None
         key = image_s3_key or f"{self.source_s3_prefix}/s{source_id}/images/{image_id}.jpg"
         return np.array(get_image_s3(s3=self.s3, bucket=self.source_bucket, key=key).convert("RGB"))

--- a/sagemaker/configs/baseline/run.yaml
+++ b/sagemaker/configs/baseline/run.yaml
@@ -1,0 +1,28 @@
+job:
+  name_prefix: mermaidseg-issue-129-baseline
+  image: mermaid-segmentation-jobs:training-latest
+  entrypoint: scripts/sagemaker_train_entrypoint.py
+  instance_type: ml.g5.2xlarge
+  volume_gb: 200
+  max_runtime_hours: 48
+
+# Consumed by scripts/sagemaker_train_entrypoint.py (NOT the launcher).
+# Uses mermaid + coralnet sources only (no cbm).
+config:
+  config_model: configs/model_config_dinov3_base.yaml
+  config_training: configs/training_config_dinov3_base.yaml
+  config_data: configs/data_config_dinov3_base.yaml
+  config_logger: configs/logger_config.yaml
+  overrides:
+    run-name: issue-129-dinov3-baseline-mermaid-coralnet-tiela
+    experiment-name: baselines
+    epochs: 200
+    seed: 42
+    num-workers: 8
+    # Select the best checkpoint / early-stop on mIoU, not accuracy — benthic classes are
+    # heavily imbalanced, so accuracy rewards the majority classes. Generous patience because
+    # val is randomly sampled (noisy epoch-to-epoch). 200 epochs is the ceiling; a frozen probe
+    # usually plateaus well before that.
+    metric-of-interest: miou
+    early-stopping: true
+    early-stopping-patience: 20

--- a/sagemaker/runs/issue_129_dinov3_baseline.yaml
+++ b/sagemaker/runs/issue_129_dinov3_baseline.yaml
@@ -1,0 +1,33 @@
+job:
+  name_prefix: mermaidseg-issue-129-baseline
+  image: mermaid-segmentation-jobs:training-latest
+  entrypoint: scripts/sagemaker_train_entrypoint.py
+  instance_type: ml.g5.2xlarge
+  volume_gb: 200
+  max_runtime_hours: 48
+  env:
+    # Point the CoralNet dataset at the rebuilt corpus's TRAINING MANIFEST, not the legacy
+    # 30112025 fallback. The manifest carries a per-row `image_s3_key` (resized copy when
+    # >threshold, original otherwise), which CoralNetDataset reads instead of templating the
+    # original path — ~40% less I/O per image. Full key (ANNOTATIONS_PATH, resolved as
+    # s3://{source_bucket}/{path}) because the ETL publishes under etl-outputs/coralnet/<version>/.
+    MERMAID_CORALNET_ANNOTATIONS_PATH: etl-outputs/coralnet/20260623_nogit/coralnet_training_manifest_20260623_nogit.parquet
+
+# Consumed by scripts/sagemaker_train_entrypoint.py (NOT the launcher).
+# Uses mermaid + coralnet sources only (no cbm). Frozen linear probe (see training config).
+config:
+  config_model: configs/model_config_dinov3_base.yaml
+  config_training: configs/training_config_dinov3_base.yaml
+  config_data: configs/data_config_dinov3_base.yaml
+  config_logger: configs/logger_config.yaml
+  overrides:
+    run-name: issue-129-dinov3-baseline-mermaid-coralnet-tiela
+    experiment-name: baselines
+    epochs: 200
+    seed: 42
+    num-workers: 8
+    # Select best checkpoint / early-stop on mIoU (benthic classes are imbalanced; accuracy
+    # favors majority classes). Patience is generous because val is randomly sampled (noisy).
+    metric-of-interest: miou
+    early-stopping: true
+    early-stopping-patience: 20

--- a/scripts/train_baseline.py
+++ b/scripts/train_baseline.py
@@ -1,0 +1,431 @@
+"""Simplified training entry point for LinearDINOv3 baseline (mermaid + coralnet, no
+CBM).
+
+This is a streamlined version of scripts/train.py that:
+- Only imports MermaidDataset and CoralNetDataset (faster startup)
+- Disables all other datasets
+- Uses standard (non-CBM) training defaults
+- Ideal for issue #129 baseline and SageMaker launcher
+
+Usage::
+
+    # Local dry-run (smoke test)
+    uv run python scripts/train_baseline.py --dry-run
+
+    # Full training with custom config
+    uv run python scripts/train_baseline.py \\
+        --config-data configs/data_config_dinov3_base.yaml \\
+        --config-model configs/model_config_dinov3_base.yaml \\
+        --config-training configs/training_config_dinov3_base.yaml
+
+    # Background (safe to close browser)
+    nohup uv run python scripts/train_baseline.py \\
+        --auto-shutdown \\
+        > logs/train_baseline_$(date +%Y%m%d_%H%M%S).log 2>&1 &
+"""
+
+import argparse
+import copy
+import json
+import logging
+import os
+import signal
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+import torch
+from torch.utils.data import ConcatDataset, DataLoader
+
+from mermaidseg.dataset_reconciliation import (
+    SourceLabelRegistry,
+    attach_registry,
+    prepare_splits_for_registry,
+)
+from mermaidseg.datasets import CoralNetDataset, MermaidDataset, worker_init_fn
+from mermaidseg.io import get_parser, setup_config, update_config_with_args
+from mermaidseg.logger import Logger
+from mermaidseg.model.eval import Evaluator
+from mermaidseg.model.meta import MetaModel
+from mermaidseg.model.metric_policy import SUPPORTED_METRIC_NAMES
+from mermaidseg.model.train import train_model
+
+_METADATA = Path("/opt/ml/metadata/resource-metadata.json")
+
+
+def _configure_third_party_loggers() -> None:
+    """Reduce verbosity from chatty third-party libraries."""
+    logging.getLogger("botocore.tokens").setLevel(logging.WARNING)
+
+
+def _setup_logging(log_dir: Path) -> None:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_file = log_dir / f"train_{timestamp}.log"
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        handlers=[
+            logging.StreamHandler(sys.stderr),
+            logging.FileHandler(log_file),
+        ],
+    )
+    _configure_third_party_loggers()
+    logging.info("Logging to %s", log_file)
+
+
+def _cleanup_pid(pid_file: Path) -> None:
+    pid_file.unlink(missing_ok=True)
+
+
+def _write_pid(pid_file: Path) -> None:
+    pid_file.parent.mkdir(parents=True, exist_ok=True)
+    pid_file.write_text(str(os.getpid()))
+
+
+def _stop_current_space() -> None:
+    """Stop the SageMaker JupyterLab app via delete_app."""
+    if not _METADATA.exists():
+        logging.info("Not running on SageMaker — skipping auto-shutdown")
+        return
+    import boto3
+    import botocore.exceptions
+
+    info = json.loads(_METADATA.read_text())
+    try:
+        boto3.client("sagemaker").delete_app(
+            DomainId=info["DomainId"],
+            SpaceName=info["SpaceName"],
+            AppType="JupyterLab",
+            AppName=info.get("AppName", "default"),
+        )
+        logging.info(
+            "Space shutdown initiated (DomainId=%s, SpaceName=%s)",
+            info["DomainId"],
+            info["SpaceName"],
+        )
+    except botocore.exceptions.ClientError as e:
+        logging.warning("Auto-shutdown failed (check sagemaker:DeleteApp permission): %s", e)
+
+
+def _batch_is_non_empty(batch: object) -> bool:
+    if not isinstance(batch, tuple | list) or len(batch) < 2:
+        return True
+    images, labels = batch[0], batch[1]
+    if isinstance(images, torch.Tensor) and images.numel() == 0:
+        return False
+    return not (isinstance(labels, torch.Tensor) and labels.numel() == 0)
+
+
+def _take_first_non_empty_batch(loader: object, split: str) -> tuple[torch.Tensor, torch.Tensor]:
+    for batch in loader:
+        if _batch_is_non_empty(batch):
+            return batch
+    raise RuntimeError(
+        f"Dry run could not find a non-empty batch for split '{split}'. Check data access credentials and dataset availability."
+    )
+
+
+def _save_failure_report_if_available(
+    dataset: object,
+    log_dir: Path,
+    explicit_output_path: str | None = None,
+) -> Path | None:
+    num_failures = getattr(dataset, "num_load_failures", None)
+    save_failures = getattr(dataset, "save_load_failures", None)
+    if not callable(num_failures) or not callable(save_failures):
+        return None
+    n_failures = int(num_failures())
+    if n_failures == 0:
+        return None
+
+    report_path = (
+        Path(explicit_output_path)
+        if explicit_output_path
+        else (log_dir / f"data_load_failures_{datetime.now().strftime('%Y%m%d_%H%M%S')}.parquet")
+    )
+    saved_path = Path(save_failures(report_path))
+    logging.warning("Saved %d data-load failure records to %s", n_failures, saved_path)
+    return saved_path
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    base = get_parser()
+    base.add_argument(
+        "--config-data",
+        type=str,
+        default="configs/data_config_dinov3_base.yaml",
+        help="path to data config file (baseline: dinov3_base)",
+    )
+    base.add_argument(
+        "--config-model",
+        type=str,
+        default="configs/model_config_dinov3_base.yaml",
+        help="path to model config file (baseline: dinov3_base)",
+    )
+    base.add_argument(
+        "--config-training",
+        type=str,
+        default="configs/training_config_dinov3_base.yaml",
+        help="path to training config file (baseline: dinov3_base)",
+    )
+    base.add_argument(
+        "--config-logger",
+        type=str,
+        default="configs/logger_config.yaml",
+        help="path to logger config file",
+    )
+    base.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="run one batch only (smoke test)",
+    )
+    base.add_argument(
+        "--auto-shutdown",
+        action="store_true",
+        help="stop the SageMaker space after a clean training finish",
+    )
+    base.add_argument(
+        "--log-dir",
+        type=str,
+        default="logs",
+        help="directory for log files and PID file",
+    )
+    base.add_argument(
+        "--failure-report-path",
+        type=str,
+        default=None,
+        help="optional parquet path for data-load failure report",
+    )
+    base.add_argument(
+        "--early-stopping",
+        action="store_true",
+        help="enable early stopping on validation metric_of_interest",
+    )
+    base.add_argument(
+        "--early-stopping-patience",
+        type=int,
+        default=10,
+        help="epochs without improvement before early stopping",
+    )
+    base.add_argument(
+        "--early-stopping-min-delta",
+        type=float,
+        default=0.0,
+        help="minimum improvement required to reset early stopping patience",
+    )
+    base.add_argument(
+        "--metric-of-interest",
+        type=str,
+        default="accuracy",
+        choices=sorted(SUPPORTED_METRIC_NAMES),
+        help="metric used for checkpointing and early stopping",
+    )
+    base.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="random seed for reproducibility",
+    )
+    base.add_argument(
+        "--num-workers",
+        type=int,
+        default=0,
+        help="DataLoader num_workers (default: 0)",
+    )
+    return base
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    log_dir = Path(args.log_dir)
+    _setup_logging(log_dir)
+    pid_file = log_dir / "train.pid"
+    _write_pid(pid_file)
+
+    def _handle_sigterm(_sig: int, _frame: object) -> None:
+        logging.warning("SIGTERM received — exiting")
+        _cleanup_pid(pid_file)
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, _handle_sigterm)
+
+    try:
+        _run_training(args)
+    except Exception:
+        logging.exception("Training failed")
+        sys.exit(1)
+    finally:
+        _cleanup_pid(pid_file)
+
+    if args.auto_shutdown:
+        _SHUTDOWN_GRACE_SEC = 5
+        logging.info("Waiting %ds for MLflow flush before shutdown...", _SHUTDOWN_GRACE_SEC)
+        time.sleep(_SHUTDOWN_GRACE_SEC)
+        _stop_current_space()
+
+
+def _run_training(args: argparse.Namespace) -> None:
+    os.environ.setdefault("TF_ENABLE_ONEDNN_OPTS", "0")
+    os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
+
+    if not os.getenv("MLFLOW_TRACKING_URI"):
+        logging.warning(
+            "MLFLOW_TRACKING_URI is not set — MLflow will log to a local filesystem store. "
+            "Set MLFLOW_TRACKING_URI to the SageMaker MLflow App ARN for remote tracking:\n"
+            '    export MLFLOW_TRACKING_URI="arn:aws:sagemaker:us-east-1:ACCOUNT:mlflow-app/APP-ID"'
+        )
+
+    cfg = setup_config(
+        {
+            "data": args.config_data,
+            "training": args.config_training,
+            "model": args.config_model,
+            "logger": args.config_logger,
+        }
+    )
+
+    cfg = update_config_with_args(cfg, args)
+
+    if not hasattr(cfg, "run_name") or cfg.run_name is None:
+        cfg.run_name = f"baseline-{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+
+    cfg_logger = copy.deepcopy(cfg)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    logging.info("Device: %s", device)
+
+    seed = args.seed
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+    logging.info("Seed: %d", seed)
+
+    loader_kwargs = {
+        "batch_size": cfg.training.batch_size,
+        "num_workers": args.num_workers,
+        "pin_memory": torch.cuda.is_available(),
+        "drop_last": True,
+    }
+    if args.num_workers > 0:
+        loader_kwargs["persistent_workers"] = True
+        loader_kwargs["worker_init_fn"] = worker_init_fn
+
+    dataset_dict: dict[tuple[str, str], object] = {}
+    for name in ["mermaid", "coralnet"]:
+        for split, split_cfg in cfg.data[name].items():
+            if split_cfg is None or split_cfg == "None":
+                continue
+            if name == "mermaid":
+                ds = MermaidDataset(**split_cfg, padding=cfg.training.padding)
+            else:  # coralnet
+                ds = CoralNetDataset(**split_cfg, padding=cfg.training.padding)
+            dataset_dict[(name, split)] = ds
+            print(f"{name:>24s} - {split:<5s}: {len(ds):>7d} samples")
+
+    _, registry_datasets = prepare_splits_for_registry(dataset_dict)
+
+    registry = SourceLabelRegistry(
+        registry_datasets,
+        target_label_subset=cfg.training.class_subset,
+        compute_concepts=False,
+        concept_mapping_path=None,
+        concept_schema=None,
+        label_roll_up=cfg.training.get("label_roll_up", False),
+    ).to(device)
+
+    attach_registry(registry, dataset_dict.values())
+
+    train_datasets = [ds for (_, split), ds in dataset_dict.items() if split == "train"]
+    val_datasets = [ds for (_, split), ds in dataset_dict.items() if split == "val"]
+
+    train_loader = DataLoader(ConcatDataset(train_datasets), shuffle=True, **loader_kwargs)
+    val_loader = DataLoader(ConcatDataset(val_datasets), shuffle=True, **loader_kwargs)
+
+    print(f"train batches: {len(train_loader)}   val batches: {len(val_loader)}")
+
+    logging.info(
+        "Dataset: %s (%d samples)",
+        "mermaid+coralnet",
+        (len(train_loader) + len(val_loader)) * cfg.training.batch_size,
+    )
+
+    if args.dry_run:
+        max_dry_epochs = 1
+        actual_epochs = cfg.training.epochs
+        if actual_epochs > max_dry_epochs:
+            cfg.training.epochs = max_dry_epochs
+            logging.info("Dry run: capping epochs %d → %d", actual_epochs, max_dry_epochs)
+        logging.info("Dry run: limiting to 1 batch per epoch")
+        cfg.training.iterations_per_train_epoch = 1
+        cfg.training.iterations_per_val_epoch = 1
+        try:
+            train_loader = [_take_first_non_empty_batch(train_loader, "train")]
+            val_loader = [_take_first_non_empty_batch(val_loader, "val")]
+        except RuntimeError:
+            raise
+
+    meta_model = MetaModel(
+        run_name=cfg.run_name,
+        num_classes=registry.num_target_classes,
+        num_concepts=None,
+        device=device,
+        model_kwargs=cfg.model.copy(),
+        training_kwargs=cfg.training.copy(),
+        source_to_target_lookup=registry.source_to_target,
+        source_to_concepts_lookup=None,
+        concept_matrix=None,
+        conceptid2labelid=None,
+        concept_value2id=None,
+    )
+
+    evaluator = Evaluator(
+        num_classes=registry.num_target_classes,
+        device=device,
+        calculate_concept_metrics=False,
+        concept_value2id=None,
+    )
+
+    # Baseline runs log to the dedicated "baselines" MLflow experiment.
+    cfg.logger.experiment_name = "baselines"
+    cfg_logger.logger.experiment_name = "baselines"
+
+    with Logger(
+        config=cfg_logger,
+        meta_model=meta_model,
+        log_epochs=cfg.logger.get("log_epochs", 1),
+        log_checkpoint=cfg_logger.logger.get("log_checkpoint", 50),
+        checkpoint_dir=".",
+        enable_mlflow=True,
+        id2label={0: "background", **registry.target_id2label},
+    ) as logger:
+        if logger.mlflow_run_id is not None:
+            logging.info("MLflow run_id: %s", logger.mlflow_run_id)
+
+        logger.log_dataloader_params(train_loader, prefix="train_loader")
+        logger.log_dataloader_params(val_loader, prefix="val_loader")
+        logger.log_reconciliation(registry)
+
+        try:
+            train_model(
+                meta_model=meta_model,
+                evaluator=evaluator,
+                train_loader=train_loader,
+                val_loader=val_loader,
+                test_loader=None,
+                logger=logger,
+                metric_of_interest=args.metric_of_interest,
+                early_stopping=args.early_stopping,
+                early_stopping_patience=args.early_stopping_patience,
+                early_stopping_min_delta=args.early_stopping_min_delta,
+            )
+        finally:
+            pass
+        logging.info("Training complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/datasets/coralnet/test_coralnet_read_image.py
+++ b/tests/datasets/coralnet/test_coralnet_read_image.py
@@ -1,0 +1,47 @@
+"""read_image key resolution: parquet-provided key vs templated original path."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from mermaidseg.datasets.coralnet import coralnet_dataset as cd
+
+
+def _make_ds():
+    """A CoralNetDataset instance without the S3-reading __init__ (just read_image
+    deps)."""
+    ds = object.__new__(cd.CoralNetDataset)
+    ds.source_bucket = "test-bucket"
+    ds.source_s3_prefix = "coralnet-public-images"
+    ds.s3 = MagicMock()
+    return ds
+
+
+def _captured_key(**read_image_kwargs):
+    ds = _make_ds()
+    fake_img = MagicMock()
+    fake_img.convert.return_value = [[[0, 0, 0]]]  # np.array-able (1x1x3)
+    with patch.object(cd, "get_image_s3", return_value=fake_img) as get_img:
+        ds.read_image(**read_image_kwargs)
+    return get_img.call_args.kwargs
+
+
+def test_templates_original_key_when_no_parquet_key():
+    kwargs = _captured_key(image_id="1472493", source_id="1645")
+    assert kwargs["key"] == "coralnet-public-images/s1645/images/1472493.jpg"
+    assert kwargs["bucket"] == "test-bucket"
+
+
+def test_uses_parquet_key_when_present():
+    kwargs = _captured_key(
+        image_id="1472493",
+        source_id="1645",
+        image_s3_key="dev/images/resized/s1645/images/1472493.jpg",
+    )
+    assert kwargs["key"] == "dev/images/resized/s1645/images/1472493.jpg"
+
+
+def test_falls_back_to_template_on_null_key():
+    # A parquet column present but null (pandas NaN → float) must not become the S3 key.
+    kwargs = _captured_key(image_id="1472493", source_id="1645", image_s3_key=float("nan"))
+    assert kwargs["key"] == "coralnet-public-images/s1645/images/1472493.jpg"


### PR DESCRIPTION
## Summary

- Copies the final state of baseline-specific files from `claude/pr-merge-branch-diff-9b5371` (the issue-129 PR branch) onto `integration/stable`
- Fixes a NaN bug in `CoralNetDataset.read_image` caught by the ported test
- Fixes the Dockerfile to stop baking `HF_TOKEN` into image layers

The shared-code changes from that PR branch (collate_fn, tqdm throttle, mIoU/early stopping, num_workers, ConceptSchema guard, experiment-name CLI, sagemaker entrypoint bool flags) already landed on `integration/stable` via its own refactoring PRs — only the new files and two fixes were missing.

## New files

| File | Purpose |
|---|---|
| `scripts/train_baseline.py` | Simplified LinearDINOv3 entry point (no CBM, mermaid+coralnet only) |
| `SUBMIT_BASELINE.sh` | Baseline submission reference/command sheet |
| `configs/data_config_dinov3_base.yaml` | Data config with CoralNet source whitelists |
| `configs/model_config_dinov3_base.yaml` | Model config (LinearDINOv3) |
| `configs/training_config_dinov3_base.yaml` | Training config for frozen linear probe baseline |
| `sagemaker/configs/baseline/run.yaml` | SageMaker launch config |
| `sagemaker/runs/issue_129_dinov3_baseline.yaml` | Issue 129 experiment spec |
| `tests/datasets/coralnet/test_coralnet_read_image.py` | Tests for `read_image` key resolution |

## Fixes

- **Dockerfile HF_TOKEN** — removed `ARG HF_TOKEN` / `ENV HF_TOKEN=$HF_TOKEN` that baked the secret into image layers; token is injected at runtime by the launcher
- **NaN image_s3_key** — `read_image` now guards against parquet null values (pandas `float("nan")`) that passed through the `key or fallback` check because NaN is truthy

## Test plan

- [x] All 403 tests pass (`pytest -m "not live and not slow and not integration"`)
- [x] New `test_coralnet_read_image.py` passes (3/3 including the NaN edge case)
- [x] Pre-commit hooks pass